### PR TITLE
[codex] support AstrBot 4.24 aiohttp runtime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 httpx>=0.27,<1
-aiohttp>=3.9,<3.11
+# AstrBot 4.24.x ships aiohttp 3.13.5; keep this aligned with the core runtime.
+aiohttp>=3.13.5,<4


### PR DESCRIPTION
## What changed
- Relaxed the plugin's `aiohttp` dependency range to match AstrBot 4.24.x.

## Why
- AstrBot 4.24.2 reports `aiohttp 3.13.5`, while the previous `<3.11` pin caused dependency conflicts during plugin installation.

## Impact
- The plugin installs cleanly against the current AstrBot runtime without downgrading the core dependency.

## Validation
- `python -m unittest discover -s tests -v`
- `python -m compileall . -q`
