### PR TITLE
[codex] Fix Qzone autobind 302 fallback

### DIFF
--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -17,7 +17,6 @@ from .parser import (
     cookie_gtk,
     compute_unikey,
     extract_feed_entry,
-    extract_feed_page,
     normalize_uin,
     normalize_cookie_fields,
     parse_index_html,
@@ -31,6 +30,7 @@ log = logging.getLogger(__name__)
 
 AUTH_ERROR_CODES = {-3000}
 AUTH_ERROR_KEYWORDS = ("登录", "失效", "请先登录", "skey", "g_tk", "cookie", "expired", "login")
+LOGIN_REDIRECT_HOSTS = ("ptlogin", "ui.ptlogin", "xui.ptlogin", "ssl.ptlogin", "login")
 
 
 @dataclass(slots=True)
@@ -106,6 +106,22 @@ class QzoneClient:
         normalized = message.lower()
         return any(keyword in message or keyword in normalized for keyword in AUTH_ERROR_KEYWORDS)
 
+    def _raise_payload_error(self, payload: Any, response: httpx.Response) -> None:
+        if not isinstance(payload, dict):
+            return
+        for key in ("ret", "code", "err", "error"):
+            if key in payload and payload.get(key) not in (0, "0", None):
+                raw_code = payload.get(key)
+                try:
+                    code = int(raw_code or 0)
+                except (TypeError, ValueError):
+                    code = 0
+                message = str(payload.get("msg") or payload.get("message") or payload.get("text") or "")
+                if self._payload_needs_rebind(code, message):
+                    raise QzoneNeedsRebind(message or "QQ空间登录态已失效", detail=payload)
+                code_text = raw_code if raw_code not in (None, "") else code
+                raise QzoneRequestError(message or f"QQ空间返回错误码 {code_text}", status_code=response.status_code, detail=payload)
+
     @staticmethod
     def _response_detail(response: httpx.Response) -> dict[str, Any]:
         detail: dict[str, Any] = {
@@ -116,6 +132,23 @@ class QzoneClient:
         if location:
             detail["location"] = location
         return detail
+
+    @staticmethod
+    def _is_login_redirect(location: str) -> bool:
+        if not location:
+            return False
+        lowered = location.lower()
+        return any(host in lowered for host in LOGIN_REDIRECT_HOSTS)
+
+    def _is_qzone_home_redirect(self, response: httpx.Response) -> bool:
+        location = response.headers.get("location") or response.headers.get("Location") or ""
+        if not location:
+            return False
+        lowered = location.lower()
+        if "user.qzone.qq.com" not in lowered:
+            return False
+        uin = str(self.login_uin)
+        return lowered.rstrip("/").endswith(f"/{uin}") or lowered.rstrip("/").endswith("user.qzone.qq.com")
 
     def _persist_cookie_response(self, response: httpx.Response) -> None:
         for key, value in response.cookies.items():
@@ -187,9 +220,24 @@ class QzoneClient:
                     headers=self._headers(referer=referer, origin=origin),
                 )
                 self._persist_cookie_response(response)
-                if response.status_code in (301, 302, 303, 307, 308, 401):
+                location = response.headers.get("location") or response.headers.get("Location") or ""
+                if response.status_code in (301, 302, 303, 307, 308) and self._is_qzone_home_redirect(response):
+                    raise QzoneRequestError(
+                        "QQ空间 H5 入口跳转到个人主页，已切换备用接口",
+                        status_code=response.status_code,
+                        detail=self._response_detail(response),
+                    )
+                if response.status_code == 401 or (
+                    response.status_code in (301, 302, 303, 307, 308) and self._is_login_redirect(location)
+                ):
                     raise QzoneNeedsRebind(
                         "QQ空间登录失效，请重新绑定 Cookie",
+                        detail=self._response_detail(response),
+                    )
+                if response.status_code in (301, 302, 303, 307, 308):
+                    raise QzoneRequestError(
+                        f"QQ空间返回跳转状态码 {response.status_code}",
+                        status_code=response.status_code,
                         detail=self._response_detail(response),
                     )
                 if response.status_code == 403:
@@ -274,20 +322,9 @@ class QzoneClient:
                         "QQ 空间接口返回了非 JSON 响应",
                         detail={"text": text[:500], "url": str(response.request.url)},
                     )
+        self._raise_payload_error(payload, response)
         payload = unwrap_payload(payload)
-        if isinstance(payload, dict):
-            for key in ("ret", "code", "err", "error"):
-                if key in payload and payload.get(key) not in (0, "0", None):
-                    raw_code = payload.get(key)
-                    try:
-                        code = int(raw_code or 0)
-                    except (TypeError, ValueError):
-                        code = 0
-                    message = str(payload.get("msg") or payload.get("message") or payload.get("text") or "")
-                    if self._payload_needs_rebind(code, message):
-                        raise QzoneNeedsRebind(message or "QQ空间登录态已失效", detail=payload)
-                    code_text = raw_code if raw_code not in (None, "") else code
-                    raise QzoneRequestError(message or f"QQ空间返回错误码 {code_text}", status_code=response.status_code, detail=payload)
+        self._raise_payload_error(payload, response)
         return payload if isinstance(payload, dict) else {"data": payload}
 
     def _extract_index_or_profile(self, response_text: str, *, profile: bool = False) -> dict[str, Any]:
@@ -362,6 +399,56 @@ class QzoneClient:
         )
         return payload
 
+    async def legacy_feeds(self, hostuin: int, *, page: int = 1, num: int = 10) -> dict[str, Any]:
+        payload = await self._request_json(
+            "GET",
+            "https://user.qzone.qq.com/proxy/domain/taotao.qq.com/cgi-bin/emotion_cgi_msglist_v6",
+            params={
+                "uin": hostuin,
+                "hostUin": hostuin,
+                "pos": max(0, (max(1, int(page)) - 1) * max(1, int(num))),
+                "num": max(1, int(num)),
+                "replynum": 100,
+                "callback": "_preloadCallback",
+                "code_version": 1,
+                "format": "json",
+                "need_comment": 1,
+                "need_private_comment": 1,
+            },
+            referer=f"https://user.qzone.qq.com/{hostuin}",
+            origin="https://user.qzone.qq.com",
+            hostuin=hostuin,
+            attach_token=False,
+        )
+        return payload
+
+    async def legacy_recent_feeds(self, page: int = 1) -> dict[str, Any]:
+        payload = await self._request_json(
+            "GET",
+            "https://user.qzone.qq.com/proxy/domain/ic2.qzone.qq.com/cgi-bin/feeds/feeds3_html_more",
+            params={
+                "uin": self.login_uin,
+                "scope": 0,
+                "view": 1,
+                "filter": "all",
+                "flag": 1,
+                "applist": "all",
+                "pagenum": max(1, int(page)),
+                "aisortEndTime": 0,
+                "aisortOffset": 0,
+                "aisortBeginTime": 0,
+                "begintime": 0,
+                "format": "json",
+                "useutf8": 1,
+                "outputhtmlfeed": 1,
+            },
+            referer=f"https://user.qzone.qq.com/{self.login_uin}" if self.login_uin else "https://qzone.qq.com/",
+            origin="https://user.qzone.qq.com",
+            hostuin=self.login_uin,
+            attach_token=False,
+        )
+        return payload
+
     async def shuoshuo(self, fid: str, uin: int, appid: int = 311, busi_param: str = "") -> dict[str, Any]:
         payload = await self._request_json(
             "GET",
@@ -398,20 +485,27 @@ class QzoneClient:
         richval = " ".join(photo.get("richval", "") for photo in photos if isinstance(photo, dict))
         payload = await self._request_json(
             "POST",
-            "https://mobile.qzone.qq.com/mood/publish_mood",
+            "https://user.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_publish_v6",
             data={
-                "content": content,
+                "syn_tweet_verson": "1",
+                "paramstr": "1",
+                "who": "1",
+                "con": content,
+                "feedversion": "1",
+                "ver": "1",
+                "ugc_right": 1,
+                "to_sign": 0,
+                "hostuin": self.login_uin,
+                "code_version": "1",
                 "richval": richval,
                 "issyncweibo": int(bool(sync_weibo)),
-                "ugc_right": 1,
-                "opr_type": "publish_shuoshuo",
                 "format": "json",
-                "res_uin": self.login_uin,
+                "qzreferrer": f"https://user.qzone.qq.com/{self.login_uin}",
             },
             referer=f"https://user.qzone.qq.com/{self.login_uin}",
             origin="https://user.qzone.qq.com",
             hostuin=self.login_uin,
-            attach_token=True,
+            attach_token=False,
         )
         return payload
 
@@ -427,21 +521,28 @@ class QzoneClient:
     ) -> dict[str, Any]:
         payload = await self._request_json(
             "POST",
-            "https://h5.qzone.qq.com/webapp/json/qzoneOperation/addComment",
+            "https://user.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_re_feeds",
             json_body=None,
             data={
-                "ownuin": hostuin,
-                "srcId": fid,
-                "isPrivateComment": int(bool(private)),
+                "topicId": f"{hostuin}_{fid}__1",
+                "uin": self.login_uin,
+                "hostUin": hostuin,
+                "feedsType": 100,
+                "inCharset": "utf-8",
+                "outCharset": "utf-8",
+                "plat": "qzone",
+                "source": "ic",
+                "platformid": 52,
+                "format": "fs",
+                "ref": "feeds",
                 "content": content,
-                "appid": appid,
-                "bypass_param": json.dumps({}),
+                "private": int(bool(private)),
                 "busi_param": json.dumps(busi_param or {}, ensure_ascii=False),
             },
             referer=f"https://user.qzone.qq.com/{hostuin}/mood/{fid}",
             origin="https://user.qzone.qq.com",
             hostuin=hostuin,
-            attach_token=True,
+            attach_token=False,
         )
         return payload
 
@@ -459,13 +560,7 @@ class QzoneClient:
             if cached and cached.curkey:
                 curkey = cached.curkey
         if not curkey:
-            detail = await self.shuoshuo(fid=fid, uin=hostuin, appid=appid)
-            detail_payload = unwrap_payload(detail)
-            _, items = extract_feed_page(detail_payload if isinstance(detail_payload, dict) else {}, default_hostuin=hostuin)
-            if items:
-                curkey = items[0].curkey
-        if not curkey:
-            raise QzoneParseError("无法解析 curkey，无法点赞", detail={"hostuin": hostuin, "fid": fid})
+            curkey = compute_unikey(appid, hostuin, fid)
 
         unikey = compute_unikey(appid, hostuin, fid)
         path = (
@@ -487,7 +582,7 @@ class QzoneClient:
             referer=f"https://user.qzone.qq.com/{hostuin}/mood/{fid}",
             origin="https://user.qzone.qq.com",
             hostuin=hostuin,
-            attach_token=True,
+            attach_token=False,
         )
         return payload
 

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -16,7 +16,7 @@ from aiohttp import web
 from .client import QzoneClient
 from .errors import QzoneAuthError, QzoneBridgeError, QzoneNeedsRebind, QzoneParseError, QzoneRequestError
 from .models import FeedEntry, SessionState
-from .parser import normalize_uin, parse_cookie_text, unwrap_payload
+from .parser import extract_feed_page, normalize_uin, parse_cookie_text, unwrap_payload
 from .protocol import SECRET_HEADER, fail, ok
 from .storage import StateStore, ensure_state_secret
 from .utils import now_iso, from_iso
@@ -144,10 +144,7 @@ class QzoneDaemonService:
 
     async def warmup(self) -> None:
         self._ensure_session_ready()
-        if not self.state.session.qzonetokens.get(str(self.state.session.uin)):
-            await self.client.index()
-        else:
-            await self.client.mfeeds_get_count()
+        await self.client.mfeeds_get_count()
         self._set_success()
 
     async def ensure_token(self, hostuin: int | None = None) -> None:
@@ -155,12 +152,6 @@ class QzoneDaemonService:
         hostuin = int(hostuin or self.state.session.uin or 0)
         if not hostuin:
             raise QzoneNeedsRebind()
-        if hostuin == self.state.session.uin:
-            if not self.state.session.qzonetokens.get(str(hostuin)):
-                await self.client.index()
-        else:
-            if not self.state.session.qzonetokens.get(str(hostuin)):
-                await self.client.profile(hostuin)
         self.save()
 
     async def bind_cookie(self, cookie_text: str, *, uin: int = 0, source: str = "manual") -> dict[str, Any]:
@@ -223,16 +214,22 @@ class QzoneDaemonService:
         page_round = 0
         while len(items) < limit and page_round < 6:
             if scope == "self":
-                if page_round == 0 and not next_cursor:
-                    payload = unwrap_payload(await self.client.index())
-                else:
-                    payload = unwrap_payload(await self.client.get_active_feeds(next_cursor))
+                try:
+                    if page_round == 0 and not next_cursor:
+                        payload = unwrap_payload(await self.client.index())
+                    else:
+                        payload = unwrap_payload(await self.client.get_active_feeds(next_cursor))
+                except QzoneRequestError:
+                    payload = await self.client.legacy_recent_feeds(page=page_round + 1)
                 feedpage = payload.get("data") if isinstance(payload, dict) and isinstance(payload.get("data"), dict) else payload
             else:
-                if page_round == 0 and not next_cursor:
-                    payload = await self.client.profile(hostuin)
-                else:
-                    payload = unwrap_payload(await self.client.get_feeds(hostuin, next_cursor))
+                try:
+                    if page_round == 0 and not next_cursor:
+                        payload = await self.client.profile(hostuin)
+                    else:
+                        payload = unwrap_payload(await self.client.get_feeds(hostuin, next_cursor))
+                except QzoneRequestError:
+                    payload = await self.client.legacy_feeds(hostuin, page=page_round + 1, num=limit)
                 if isinstance(payload, dict) and isinstance(payload.get("feedpage"), dict):
                     feedpage = payload["feedpage"]
                 else:
@@ -240,12 +237,7 @@ class QzoneDaemonService:
 
             if not isinstance(feedpage, dict):
                 break
-            raw_items = feedpage.get("vFeeds") or feedpage.get("vfeeds") or []
-            page_items = [
-                self.client.feed_entry_from_payload(item, default_hostuin=hostuin)
-                for item in raw_items
-                if isinstance(item, dict)
-            ]
+            feedpage, page_items = extract_feed_page(feedpage, default_hostuin=hostuin)
             self.client.cache_feed_page(hostuin, page_items)
             items.extend(page_items)
             has_more = bool(feedpage.get("hasmore") or feedpage.get("hasMore") or False)
@@ -301,7 +293,6 @@ class QzoneDaemonService:
     async def publish_post(self, *, content: str, sync_weibo: bool = False) -> dict[str, Any]:
         if not content.strip():
             raise QzoneParseError("发布内容不能为空")
-        await self.ensure_token(self.state.session.uin)
         payload = unwrap_payload(await self.client.publish_mood(content, sync_weibo=sync_weibo))
         if not isinstance(payload, dict):
             raise QzoneParseError("发布说说返回结构异常")
@@ -323,7 +314,6 @@ class QzoneDaemonService:
     ) -> dict[str, Any]:
         if not content.strip():
             raise QzoneParseError("评论内容不能为空")
-        await self.ensure_token(hostuin)
         payload = unwrap_payload(await self.client.add_comment(hostuin, fid, content, appid=appid, private=private))
         if not isinstance(payload, dict):
             raise QzoneParseError("评论返回结构异常")

--- a/qzone_bridge/errors.py
+++ b/qzone_bridge/errors.py
@@ -39,11 +39,6 @@ class QzoneParseError(QzoneBridgeError):
         super().__init__(message, code="QZONE_PARSE", detail=detail)
 
 
-class QzoneCookieAcquireError(QzoneBridgeError):
-    def __init__(self, message: str, *, detail=None):
-        super().__init__(message, code="QZONE_COOKIE", detail=detail)
-
-
 class DaemonUnavailableError(QzoneBridgeError):
     def __init__(self, message: str = "Qzone daemon is unavailable", *, detail=None):
         super().__init__(message, code="DAEMON_UNAVAILABLE", detail=detail)

--- a/qzone_bridge/onebot_cookie.py
+++ b/qzone_bridge/onebot_cookie.py
@@ -7,11 +7,11 @@ import json
 import re
 from typing import Any
 
-from .parser import cookie_gtk, cookie_header, normalize_uin, parse_cookie_text
+from .parser import cookie_header, normalize_cookie_fields, normalize_uin, parse_cookie_text
 
 COOKIE_ACTIONS = ("get_cookies", "get_credentials")
 LOGIN_INFO_ACTIONS = ("get_login_info",)
-COOKIE_DOMAIN_FALLBACKS = ("user.qzone.qq.com", "qzone.qq.com")
+COOKIE_DOMAIN_FALLBACKS = ("user.qzone.qq.com", "qzone.qq.com", "h5.qzone.qq.com", "mobile.qzone.qq.com")
 COOKIE_VALUE_KEYS = (
     "cookies",
     "cookie",
@@ -211,6 +211,19 @@ def _merge_cookie_texts(parts: list[str]) -> str:
     return cookie_header(merged) if merged else ""
 
 
+def _merge_cookie_dicts(base: dict[str, str], incoming: dict[str, str]) -> dict[str, str]:
+    merged = dict(base)
+    for key, value in normalize_cookie_fields(incoming).items():
+        if value and key not in merged:
+            merged[key] = value
+    return merged
+
+
+def _has_auth_cookie(cookies: dict[str, str]) -> bool:
+    normalized = normalize_cookie_fields(cookies)
+    return any(normalized.get(key) for key in ("p_skey", "skey", "skey2"))
+
+
 def extract_cookie_text(payload: Any, *, _depth: int = 0, _seen: set[int] | None = None) -> str:
     """Extract a Cookie header string from OneBot action payloads."""
 
@@ -333,6 +346,7 @@ async def fetch_cookie_text(bot: Any, *, domain: str) -> str:
     """Try several OneBot actions and domains until a Cookie header is found."""
 
     login_uin: int | None = None
+    best_cookies: dict[str, str] = {}
     for action in COOKIE_ACTIONS:
         for candidate_domain in iter_cookie_domains(domain):
             for call_kwargs in ({"domain": candidate_domain}, {}):
@@ -356,6 +370,9 @@ async def fetch_cookie_text(bot: Any, *, domain: str) -> str:
                             cookies = parse_cookie_text(cookie_text)
                         except Exception:
                             cookies = {}
-                if normalize_uin(cookies) and cookie_gtk(cookies):
-                    return cookie_header(cookies)
+                candidate_cookies = _merge_cookie_dicts(best_cookies, cookies)
+                if normalize_uin(candidate_cookies) and _has_auth_cookie(candidate_cookies):
+                    best_cookies = candidate_cookies
+    if normalize_uin(best_cookies) and _has_auth_cookie(best_cookies):
+        return cookie_header(best_cookies)
     return ""

--- a/qzone_bridge/parser.py
+++ b/qzone_bridge/parser.py
@@ -52,6 +52,13 @@ def _text(value: Any) -> str:
     return str(value)
 
 
+def _int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value or 0)
+    except Exception:
+        return default
+
+
 def parse_cookie_text(cookie_text: str) -> dict[str, str]:
     cookie_text = cookie_text.strip()
     if not cookie_text:
@@ -216,22 +223,31 @@ def unwrap_payload(payload: Any) -> Any:
 
 
 def extract_hostuin(feed_item: dict[str, Any], default: int = 0) -> int:
-    candidate = _dig(feed_item, "userinfo", "uin")
-    if candidate is None:
-        candidate = _dig(feed_item, "user", "uin")
-    if candidate is None:
-        candidate = _dig(feed_item, "userinfo", "user", "uin")
-    if candidate is None:
-        candidate = default
-    try:
-        return int(candidate or 0)
-    except Exception:
-        return default
+    candidates = [
+        feed_item.get("uin"),
+        feed_item.get("hostuin"),
+        feed_item.get("hostUin"),
+        _dig(feed_item, "userinfo", "uin"),
+        _dig(feed_item, "user", "uin"),
+        _dig(feed_item, "userinfo", "user", "uin"),
+        default,
+    ]
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        try:
+            value = int(candidate or 0)
+        except Exception:
+            continue
+        if value:
+            return value
+    return default
 
 
 def extract_fid(feed_item: dict[str, Any]) -> str:
     candidates = [
         feed_item.get("fid"),
+        feed_item.get("tid"),
         feed_item.get("cellid"),
         _dig(feed_item, "id", "cellid"),
         _dig(feed_item, "common", "ugcrightkey"),
@@ -245,10 +261,11 @@ def extract_fid(feed_item: dict[str, Any]) -> str:
 
 def extract_summary_text(feed_item: dict[str, Any]) -> str:
     candidates = [
+        _text(feed_item.get("content")),
+        _text(feed_item.get("con")),
         _dig(feed_item, "summary", "summary"),
         _text(feed_item.get("summary")),
         _dig(feed_item, "original", "summary", "summary"),
-        _text(feed_item.get("content")),
         _text(feed_item.get("text")),
     ]
     for candidate in candidates:
@@ -278,26 +295,40 @@ def extract_feed_entry(feed_item: dict[str, Any], *, default_hostuin: int = 0) -
         original = {}
 
     hostuin = extract_hostuin(feed_item, default_hostuin)
-    appid = int(common.get("appid") or feed_item.get("appid") or 311)
+    appid = _int(common.get("appid") or feed_item.get("appid") or 311, 311)
     fid = extract_fid(feed_item)
-    created_at = int(common.get("time") or feed_item.get("abstime") or 0)
+    created_at = _int(common.get("time") or feed_item.get("abstime") or feed_item.get("created_time") or 0)
     summary = extract_summary_text(feed_item)
     if not summary:
         summary = extract_summary_text(original)
 
     curkey = str(
-        common.get("curkey")
-        or common.get("curlikekey")
-        or feed_item.get("curkey")
+        feed_item.get("curkey")
         or feed_item.get("curlikekey")
+        or common.get("curkey")
+        or common.get("curlikekey")
+        or compute_unikey(appid, hostuin, fid)
         or ""
     )
     unikey = compute_unikey(appid, hostuin, fid)
     topic = topic_id(appid, hostuin, fid, created_at)
-    nickname = str(userinfo.get("nickname") or userinfo.get("name") or "")
-    like_count = int(like.get("num") or like.get("likeNum") or like.get("count") or 0)
-    comment_count = int(comment.get("num") or comment.get("commentcount") or 0)
-    liked = bool(like.get("isliked") or like.get("ismylike") or False)
+    nickname = str(feed_item.get("name") or userinfo.get("nickname") or userinfo.get("name") or "")
+    like_count = _int(
+        like.get("num")
+        or like.get("likeNum")
+        or like.get("count")
+        or feed_item.get("likeNum")
+        or feed_item.get("likenum")
+        or feed_item.get("like_num")
+        or 0
+    )
+    raw_comments = feed_item.get("commentlist")
+    comment_count = _int(
+        comment.get("num") or comment.get("commentcount") or feed_item.get("cmtnum") or feed_item.get("commentnum") or 0
+    )
+    if not comment_count and isinstance(raw_comments, list):
+        comment_count = len(raw_comments)
+    liked = bool(like.get("isliked") or like.get("ismylike") or feed_item.get("isliked") or False)
     busi_param = operation.get("busi_param") or {}
     if not isinstance(busi_param, dict):
         busi_param = {}
@@ -324,7 +355,9 @@ def extract_feed_page(payload: dict[str, Any], *, default_hostuin: int = 0) -> t
     feedpage = payload.get("feedpage") if isinstance(payload.get("feedpage"), dict) else payload
     if not isinstance(feedpage, dict):
         return {}, []
-    raw_feeds = feedpage.get("vFeeds") or feedpage.get("vfeeds") or []
+    raw_feeds = feedpage.get("vFeeds") or feedpage.get("vfeeds") or feedpage.get("msglist") or feedpage.get("data") or []
+    if isinstance(raw_feeds, dict):
+        raw_feeds = raw_feeds.get("vFeeds") or raw_feeds.get("vfeeds") or raw_feeds.get("msglist") or raw_feeds.get("data") or []
     if not isinstance(raw_feeds, list):
         raw_feeds = []
     items = [extract_feed_entry(item, default_hostuin=default_hostuin) for item in raw_feeds if isinstance(item, dict)]

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -49,6 +49,19 @@ class ClientErrorMappingTests(unittest.IsolatedAsyncioTestCase):
             str(caught.exception.detail["url"]).startswith("https://h5.qzone.qq.com/mqzone/index")
         )
 
+    async def test_qzone_home_302_is_not_login_expired(self):
+        await self._use_response(
+            lambda request: httpx.Response(
+                302,
+                headers={"location": "https://user.qzone.qq.com/123456"},
+                request=request,
+            )
+        )
+        with self.assertRaises(QzoneRequestError) as caught:
+            await self.client._request_text("GET", "https://h5.qzone.qq.com/mqzone/index")
+        self.assertNotIsInstance(caught.exception, QzoneNeedsRebind)
+        self.assertEqual(caught.exception.status_code, 302)
+
     async def test_403_is_permission_error(self):
         await self._use_response(lambda request: httpx.Response(403, text="forbidden", request=request))
         with self.assertRaises(QzoneRequestError) as caught:
@@ -59,6 +72,13 @@ class ClientErrorMappingTests(unittest.IsolatedAsyncioTestCase):
     async def test_payload_login_code_requires_rebind(self):
         await self._use_response(
             lambda request: httpx.Response(200, json={"code": -3000, "message": "登录态失效"}, request=request)
+        )
+        with self.assertRaises(QzoneNeedsRebind):
+            await self.client._request_json("GET", "https://mobile.qzone.qq.com/feeds/mfeeds_get_count")
+
+    async def test_payload_login_code_inside_data_requires_rebind(self):
+        await self._use_response(
+            lambda request: httpx.Response(200, json={"data": {"code": -3000, "message": "登录态失效"}}, request=request)
         )
         with self.assertRaises(QzoneNeedsRebind):
             await self.client._request_json("GET", "https://mobile.qzone.qq.com/feeds/mfeeds_get_count")

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -3,6 +3,7 @@ import socket
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import AsyncMock, patch
 
 from qzone_bridge.controller import QzoneDaemonController, _port_is_free
 from qzone_bridge.daemon import QzoneDaemonService
@@ -18,6 +19,27 @@ def free_port() -> int:
 
 
 class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
+    async def test_warmup_uses_json_health_check_instead_of_h5_index(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            try:
+                with patch.object(service.client, "index", new=AsyncMock()) as index, patch.object(
+                    service.client,
+                    "mfeeds_get_count",
+                    new=AsyncMock(return_value={"code": 0}),
+                ) as count:
+                    await service.warmup()
+                    index.assert_not_awaited()
+                    count.assert_awaited_once()
+                self.assertFalse(service.state.session.needs_rebind)
+            finally:
+                await service.close()
+
     async def test_4xx_request_error_does_not_degrade_session_health(self):
         with TemporaryDirectory() as tmp:
             service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
@@ -54,6 +76,31 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(service.state.session.qzonetokens, {})
             self.assertEqual(service.client.feed_cache, {})
             await service.close()
+
+    async def test_list_feeds_falls_back_when_h5_home_redirects(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            try:
+                with patch.object(
+                    service.client,
+                    "index",
+                    new=AsyncMock(side_effect=QzoneRequestError("h5 redirect", status_code=302)),
+                ) as index, patch.object(
+                    service.client,
+                    "legacy_recent_feeds",
+                    new=AsyncMock(return_value={"msglist": [{"tid": "fid-1", "uin": 123456, "content": "hello"}]}),
+                ) as legacy:
+                    payload = await service.list_feeds(limit=1)
+                index.assert_awaited_once()
+                legacy.assert_awaited_once()
+                self.assertEqual(payload["items"][0]["fid"], "fid-1")
+            finally:
+                await service.close()
 
 
 class ControllerLifecycleTests(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_onebot_cookie.py
+++ b/tests/test_onebot_cookie.py
@@ -50,6 +50,19 @@ class DomainAwareCookieClient:
         return {"cookies": "uin=o123456; p_uin=o123456; pskey=domain-secret"}
 
 
+class MultiDomainCookieClient:
+    def __init__(self):
+        self.calls = []
+
+    async def get_cookies(self, domain=None):
+        self.calls.append(("get_cookies", domain))
+        if domain == "user.qzone.qq.com":
+            return {"cookies": "uin=o123456; p_uin=o123456; skey=user-skey"}
+        if domain == "h5.qzone.qq.com":
+            return {"cookies": "p_skey=h5-pskey"}
+        return {"cookies": ""}
+
+
 class OneBotCookieTests(unittest.IsolatedAsyncioTestCase):
     def test_extract_cookie_text_from_string(self):
         text = extract_cookie_text("uin=o123; p_uin=o123; skey=abc; p_skey=def")
@@ -122,6 +135,14 @@ class OneBotCookieTests(unittest.IsolatedAsyncioTestCase):
         cookies = parse_cookie_text(text)
         self.assertEqual(cookies["p_skey"], "domain-secret")
         self.assertGreater(len(client.calls), 1)
+
+    async def test_fetch_cookie_text_merges_qzone_domains(self):
+        client = MultiDomainCookieClient()
+        text = await fetch_cookie_text(client, domain="user.qzone.qq.com")
+        cookies = parse_cookie_text(text)
+        self.assertEqual(cookies["skey"], "user-skey")
+        self.assertEqual(cookies["p_skey"], "h5-pskey")
+        self.assertIn(("get_cookies", "h5.qzone.qq.com"), client.calls)
 
 
 if __name__ == "__main__":

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,9 +2,11 @@ import unittest
 
 from qzone_bridge.parser import (
     extract_feed_entry,
+    extract_feed_page,
     parse_cookie_text,
     parse_index_html,
     parse_profile_html,
+    unwrap_payload,
 )
 from qzone_bridge.utils import gtk
 
@@ -66,6 +68,32 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(entry.curkey, "cur-key")
         self.assertEqual(entry.summary, "hello qzone")
         self.assertEqual(entry.unikey, "https://user.qzone.qq.com/123456/mood/fid-1")
+
+    def test_extract_legacy_feed_entry(self):
+        raw = {
+            "tid": "legacy-fid",
+            "uin": 123456,
+            "name": "Alice",
+            "content": "legacy hello",
+            "created_time": 1715330001,
+            "commentlist": [{"content": "x"}],
+        }
+        entry = extract_feed_entry(raw)
+        self.assertEqual(entry.hostuin, 123456)
+        self.assertEqual(entry.fid, "legacy-fid")
+        self.assertEqual(entry.summary, "legacy hello")
+        self.assertEqual(entry.curkey, "https://user.qzone.qq.com/123456/mood/legacy-fid")
+
+    def test_extract_feed_page_accepts_msglist(self):
+        feedpage, items = extract_feed_page({"msglist": [{"tid": "fid-1", "uin": 123456, "content": "hello"}]})
+        self.assertEqual(feedpage["msglist"][0]["tid"], "fid-1")
+        self.assertEqual(items[0].fid, "fid-1")
+
+    def test_unwrap_payload_keeps_legacy_data_behavior(self):
+        payload = {"data": {"code": -3000, "message": "登录态失效"}}
+        self.assertEqual(unwrap_payload(payload), payload["data"])
+        payload = {"code": -3000, "data": {"x": 1}, "message": "登录态失效"}
+        self.assertEqual(unwrap_payload(payload), {"x": 1})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
﻿## Summary
- stop treating Qzone H5 home redirects as expired login state and fall back to legacy Qzone APIs
- make autobind aggregate OneBot cookies across Qzone domains and require real skey/p_skey credentials
- move daemon warmup to a JSON health check so autobind no longer fails on h5.qzone.qq.com/mqzone/index 302
- expand legacy feed parsing and fix duplicate cookie acquire error class

## Validation
- python -m unittest discover -s tests -v
- source compile check for main.py, qzone_bridge/*.py, tests/*.py
