### PR TITLE
[codex] Fix qzone install reload regression

### DIFF
--- a/qzone_bridge/controller.py
+++ b/qzone_bridge/controller.py
@@ -16,7 +16,8 @@ from typing import Any
 import httpx
 
 from .errors import DaemonUnavailableError, QzoneAuthError, QzoneBridgeError, QzoneNeedsRebind, QzoneParseError, QzoneRequestError
-from .models import BridgeState
+from .models import SessionState
+from .parser import normalize_uin, parse_cookie_text
 from .protocol import SECRET_HEADER
 from .storage import StateStore, ensure_state_secret
 from .utils import now_iso
@@ -141,6 +142,7 @@ class QzoneDaemonController:
         start_timeout: float = 20.0,
         keepalive_interval: int = 120,
         user_agent: str = "",
+        auto_start_daemon: bool = True,
     ) -> None:
         self.plugin_root = plugin_root
         self.data_dir = data_dir
@@ -150,6 +152,7 @@ class QzoneDaemonController:
         self.start_timeout = start_timeout
         self.keepalive_interval = keepalive_interval
         self.user_agent = user_agent
+        self.auto_start_daemon = auto_start_daemon
         self._client = httpx.AsyncClient(timeout=httpx.Timeout(request_timeout), trust_env=False)
         self._lock = asyncio.Lock()
         self._process: subprocess.Popen | None = None
@@ -203,12 +206,12 @@ class QzoneDaemonController:
         kwargs["env"] = env
         return subprocess.Popen(cmd, cwd=str(self.plugin_root), **kwargs)
 
-    async def _probe_health(self, port: int | None = None) -> bool:
+    async def _probe_health(self, port: int | None = None, *, secret: str | None = None) -> bool:
         runtime = self._runtime()
         try:
             response = await self._client.get(
                 f"{self._base_url(port)}/health",
-                headers={SECRET_HEADER: runtime.secret},
+                headers={SECRET_HEADER: secret or runtime.secret},
             )
         except httpx.HTTPError:
             return False
@@ -220,12 +223,12 @@ class QzoneDaemonController:
             return False
         return bool(payload.get("ok"))
 
-    async def ensure_running(self) -> None:
+    async def ensure_running(self) -> dict[str, Any]:
         async with self._lock:
             runtime = self._runtime()
             port = runtime.daemon_port or self.default_port
             if await self._probe_health(port):
-                return
+                return await self.get_status()
 
             if not _port_is_free(port):
                 candidate = port
@@ -253,7 +256,7 @@ class QzoneDaemonController:
                     state = self.store.read()
                     state.runtime = runtime
                     self.store.write(state)
-                    return
+                    return await self.get_status()
                 if self._process and self._process.poll() is not None:
                     break
                 await asyncio.sleep(0.5)
@@ -268,8 +271,12 @@ class QzoneDaemonController:
         params: dict[str, Any] | None = None,
         json_body: dict[str, Any] | None = None,
     ) -> Any:
-        await self.ensure_running()
         runtime = self._runtime()
+        if self.auto_start_daemon:
+            await self.ensure_running()
+            runtime = self._runtime()
+        elif not await self._probe_health(runtime.daemon_port):
+            raise DaemonUnavailableError("daemon 未运行")
         response = await self._client.request(
             method,
             f"{self._base_url()}{path}",
@@ -332,8 +339,61 @@ class QzoneDaemonController:
     async def bind_cookie(self, cookie_text: str, *, uin: int = 0, source: str = "manual") -> dict[str, Any]:
         return await self._request("POST", "/bind", json_body={"cookie_text": cookie_text, "uin": uin, "source": source})
 
+    async def bind_cookie_local(self, cookie_text: str, *, uin: int = 0, source: str = "manual") -> dict[str, Any]:
+        """Bind cookies directly into the persistent store when the daemon is unavailable."""
+
+        try:
+            return await self.bind_cookie(cookie_text, uin=uin, source=source)
+        except DaemonUnavailableError:
+            cookies = parse_cookie_text(cookie_text)
+            if not cookies:
+                raise QzoneParseError("Cookie 为空，无法绑定")
+            resolved_uin = normalize_uin(cookies, override=uin)
+            if not resolved_uin:
+                raise QzoneParseError("Cookie 中未找到 uin / p_uin，请补齐后重试")
+
+            state = self.store.read()
+            runtime = self._runtime()
+            state.runtime = runtime
+            state.session = SessionState(
+                uin=resolved_uin,
+                cookies=cookies,
+                qzonetokens={},
+                source=source,
+                updated_at=now_iso(),
+                last_ok_at="",
+                last_error=None,
+                revision=state.session.revision + 1,
+                needs_rebind=False,
+            )
+            self.store.write(state)
+            return await self.get_status()
+
     async def unbind(self) -> dict[str, Any]:
         return await self._request("POST", "/unbind", json_body={})
+
+    async def unbind_local(self) -> dict[str, Any]:
+        """Clear cookies even when the daemon is unavailable."""
+
+        try:
+            return await self.unbind()
+        except DaemonUnavailableError:
+            state = self.store.read()
+            runtime = self._runtime()
+            state.runtime = runtime
+            state.session = SessionState(
+                uin=0,
+                cookies={},
+                qzonetokens={},
+                source="manual",
+                updated_at=now_iso(),
+                last_ok_at="",
+                last_error=None,
+                revision=state.session.revision + 1,
+                needs_rebind=True,
+            )
+            self.store.write(state)
+            return await self.get_status()
 
     async def list_feeds(self, *, hostuin: int = 0, limit: int = 5, cursor: str = "", scope: str = "") -> dict[str, Any]:
         return await self._request(

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from aiohttp import web
 
 from .client import FeedPageResult, QzoneClient
-from .errors import QzoneAuthError, QzoneBridgeError, QzoneNeedsRebind, QzoneParseError
+from .errors import QzoneAuthError, QzoneBridgeError, QzoneNeedsRebind, QzoneParseError, QzoneRequestError
 from .models import BridgeState, FeedEntry, SessionState
 from .parser import extract_feed_entry, extract_feed_page, normalize_uin, parse_cookie_text, unwrap_payload
 from .protocol import SECRET_HEADER, fail, ok
@@ -57,6 +57,10 @@ class QzoneDaemonService:
     def touch(self) -> None:
         self.state.runtime.last_seen_at = now_iso()
 
+    def _ensure_session_ready(self) -> None:
+        if self.state.session.needs_rebind or not self.state.session.cookies or not self.state.session.uin:
+            raise QzoneNeedsRebind()
+
     def _set_success(self) -> None:
         self.health_state = "ready" if self.state.session.cookies else "needs_rebind"
         self.state.session.last_ok_at = now_iso()
@@ -69,6 +73,13 @@ class QzoneDaemonService:
         if isinstance(exc, (QzoneNeedsRebind, QzoneAuthError)):
             self.health_state = "needs_rebind"
             self.state.session.needs_rebind = True
+            self.state.session.qzonetokens.clear()
+            self.client.feed_cache.clear()
+        elif isinstance(exc, QzoneRequestError) and exc.status_code is not None and 400 <= exc.status_code < 500:
+            if self.state.session.cookies and not self.state.session.needs_rebind:
+                self.health_state = "ready"
+            else:
+                self.health_state = "needs_rebind"
         else:
             self.health_state = "degraded"
         self.state.session.last_error = {
@@ -94,6 +105,7 @@ class QzoneDaemonService:
             "last_seen_at": runtime.last_seen_at,
             "uptime_seconds": uptime,
             "login_uin": session.uin,
+            "session_source": session.source,
             "cookie_summary": self.client.cookie_summary(),
             "cookie_count": self.client.cookie_count,
             "needs_rebind": session.needs_rebind or not bool(session.cookies),
@@ -106,7 +118,7 @@ class QzoneDaemonService:
 
     async def bootstrap(self) -> None:
         self.save()
-        if self.state.session.cookies and self.state.session.uin:
+        if self.state.session.cookies and self.state.session.uin and not self.state.session.needs_rebind:
             try:
                 await self.warmup()
             except Exception as exc:
@@ -122,18 +134,21 @@ class QzoneDaemonService:
             self._keepalive_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await self._keepalive_task
+        self.health_state = "offline"
+        self.state.runtime.daemon_pid = 0
+        self.state.runtime.started_at = ""
+        self.touch()
+        self.save()
+        self.client.feed_cache.clear()
         await self.client.close()
 
     async def warmup(self) -> None:
-        if not self.state.session.cookies or not self.state.session.uin:
-            raise QzoneNeedsRebind()
-        if not self.state.session.qzonetokens.get(str(self.state.session.uin)):
-            await self.client.index()
-        else:
-            await self.client.mfeeds_get_count()
+        self._ensure_session_ready()
+        await self.client.mfeeds_get_count()
         self._set_success()
 
     async def ensure_token(self, hostuin: int | None = None) -> None:
+        self._ensure_session_ready()
         hostuin = int(hostuin or self.state.session.uin or 0)
         if not hostuin:
             raise QzoneNeedsRebind()
@@ -164,6 +179,7 @@ class QzoneDaemonService:
             needs_rebind=False,
         )
         self.client.update_session(self.state.session)
+        self.client.feed_cache.clear()
         self.save()
         try:
             await self.warmup()
@@ -185,11 +201,13 @@ class QzoneDaemonService:
             needs_rebind=True,
         )
         self.client.update_session(self.state.session)
+        self.client.feed_cache.clear()
         self.save()
         self.health_state = "needs_rebind"
         return self.snapshot()
 
     async def list_feeds(self, *, hostuin: int = 0, limit: int = 5, cursor: str = "", scope: str = "") -> dict[str, Any]:
+        self._ensure_session_ready()
         if limit <= 0:
             limit = 5
         hostuin = int(hostuin or self.state.session.uin or 0)
@@ -203,7 +221,12 @@ class QzoneDaemonService:
         while len(items) < limit and page_round < 6:
             if scope == "self":
                 if page_round == 0 and not next_cursor:
-                    payload = unwrap_payload(await self.client.index())
+                    try:
+                        payload = unwrap_payload(await self.client.index())
+                    except QzoneRequestError as exc:
+                        if exc.status_code not in {301, 302, 303, 307, 308}:
+                            raise
+                        payload = await self.client.legacy_recent_feeds()
                 else:
                     payload = unwrap_payload(await self.client.get_active_feeds(next_cursor))
                 feedpage = payload.get("data") if isinstance(payload, dict) and isinstance(payload.get("data"), dict) else payload
@@ -219,7 +242,11 @@ class QzoneDaemonService:
 
             if not isinstance(feedpage, dict):
                 break
-            raw_items = feedpage.get("vFeeds") or feedpage.get("vfeeds") or []
+            raw_items = feedpage.get("vFeeds") or feedpage.get("vfeeds") or feedpage.get("msglist") or feedpage.get("data") or []
+            if isinstance(raw_items, dict):
+                raw_items = raw_items.get("vFeeds") or raw_items.get("vfeeds") or raw_items.get("msglist") or raw_items.get("data") or []
+            if not isinstance(raw_items, list):
+                raw_items = []
             page_items = [
                 self.client.feed_entry_from_payload(item, default_hostuin=hostuin)
                 for item in raw_items
@@ -337,9 +364,10 @@ class QzoneDaemonService:
         }
 
     async def health(self) -> dict[str, Any]:
-        if not self.state.session.cookies or not self.state.session.uin:
-            self.health_state = "needs_rebind"
-            self.save()
+        if self.state.session.needs_rebind or not self.state.session.cookies or not self.state.session.uin:
+            if self.health_state != "needs_rebind":
+                self.health_state = "needs_rebind"
+                self.save()
             return self.snapshot()
         try:
             await self.client.mfeeds_get_count()
@@ -354,16 +382,20 @@ class QzoneDaemonService:
             await asyncio.sleep(self.keepalive_interval)
             if self._closing:
                 break
+            if self.state.session.needs_rebind:
+                if self.health_state != "needs_rebind":
+                    self.health_state = "needs_rebind"
+                    self.save()
+                continue
             if not self.state.session.cookies or not self.state.session.uin:
-                self.health_state = "needs_rebind"
-                self.save()
+                if self.health_state != "needs_rebind":
+                    self.health_state = "needs_rebind"
+                    self.save()
                 continue
             try:
-                await self.client.mfeeds_get_count()
+                await self.health()
             except Exception as exc:
-                self._set_error(exc)
-            else:
-                self._set_success()
+                log.debug("qzone keepalive failed: %s", exc)
 
 
 async def _json_body(request: web.Request) -> dict[str, Any]:


### PR DESCRIPTION
## What changed
- Restored `auto_start_daemon` support in `QzoneDaemonController` so `main.py` can instantiate the plugin without a `TypeError`.
- Restored controller local bind/unbind fallbacks and daemon status/lifecycle behavior that were regressed by the latest merge.
- Reinstated daemon session-health safeguards, token/cache cleanup on auth failures, JSON warmup health checks, and legacy feed fallback when H5 redirects.

## Why
Plugin installation/loading failed because `main.py` passed `auto_start_daemon` while the merged controller constructor no longer accepted it. The same merge also left tests and runtime code expecting methods/behavior that were missing from the controller/daemon implementation.

## Validation
- `python -m unittest discover -s tests` passed: 39 tests.