### PR TITLE
[codex] Avoid H5 token probe for Qzone writes

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 name: astrbot_plugin_qzone_stable
-version: 0.1.1
+version: 0.1.2
 author: OpenAI
 description: Stable QQ空间 bridge with a local daemon and LLM tools.
 desc: Stable QQ空间 bridge with a local daemon and LLM tools.

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -307,7 +307,7 @@ class QzoneDaemonService:
     async def publish_post(self, *, content: str, sync_weibo: bool = False) -> dict[str, Any]:
         if not content.strip():
             raise QzoneParseError("发布内容不能为空")
-        await self.ensure_token(self.state.session.uin)
+        self._ensure_session_ready()
         payload = unwrap_payload(await self.client.publish_mood(content, sync_weibo=sync_weibo))
         if not isinstance(payload, dict):
             raise QzoneParseError("发布说说返回结构异常")
@@ -329,7 +329,7 @@ class QzoneDaemonService:
     ) -> dict[str, Any]:
         if not content.strip():
             raise QzoneParseError("评论内容不能为空")
-        await self.ensure_token(hostuin)
+        self._ensure_session_ready()
         payload = unwrap_payload(await self.client.add_comment(hostuin, fid, content, appid=appid, private=private))
         if not isinstance(payload, dict):
             raise QzoneParseError("评论返回结构异常")
@@ -350,7 +350,7 @@ class QzoneDaemonService:
         curkey: str = "",
         unlike: bool = False,
     ) -> dict[str, Any]:
-        await self.ensure_token(hostuin)
+        self._ensure_session_ready()
         payload = unwrap_payload(
             await self.client.like_post(hostuin, fid, appid=appid, curkey=curkey, like=not unlike)
         )

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -102,6 +102,63 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             finally:
                 await service.close()
 
+    async def test_publish_post_does_not_probe_h5_index_for_token(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            try:
+                with patch.object(
+                    service.client,
+                    "index",
+                    new=AsyncMock(side_effect=QzoneRequestError("h5 redirect", status_code=302)),
+                ) as index, patch.object(
+                    service.client,
+                    "publish_mood",
+                    new=AsyncMock(return_value={"fid": "fid-1", "message": "ok"}),
+                ) as publish:
+                    payload = await service.publish_post(content="hello")
+                index.assert_not_awaited()
+                publish.assert_awaited_once()
+                self.assertEqual(payload["fid"], "fid-1")
+            finally:
+                await service.close()
+
+    async def test_comment_and_like_do_not_probe_h5_index_for_token(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            try:
+                with patch.object(
+                    service.client,
+                    "index",
+                    new=AsyncMock(side_effect=QzoneRequestError("h5 redirect", status_code=302)),
+                ) as index, patch.object(
+                    service.client,
+                    "add_comment",
+                    new=AsyncMock(return_value={"commentid": 7, "message": "ok"}),
+                ) as comment, patch.object(
+                    service.client,
+                    "like_post",
+                    new=AsyncMock(return_value={"message": "ok"}),
+                ) as like:
+                    comment_payload = await service.comment_post(hostuin=123456, fid="fid-1", content="hello")
+                    like_payload = await service.like_post(hostuin=123456, fid="fid-1")
+                index.assert_not_awaited()
+                comment.assert_awaited_once()
+                like.assert_awaited_once()
+                self.assertEqual(comment_payload["commentid"], 7)
+                self.assertEqual(like_payload["action"], "like")
+            finally:
+                await service.close()
+
 
 class ControllerLifecycleTests(unittest.IsolatedAsyncioTestCase):
     async def test_close_shuts_down_daemon_and_releases_port(self):


### PR DESCRIPTION
## What changed
- Stop calling `ensure_token()` before write actions (`post`, `comment`, `like`).
- Keep the session/cookie readiness check for write actions without touching the H5 index page.
- Bump plugin metadata to `0.1.2`.
- Add regression tests proving write actions do not call `client.index()` when the H5 index redirects to the profile page.

## Why
The write APIs currently used by the daemon have `attach_token=False` and do not require qzonetoken. Calling `ensure_token()` first forced a visit to `https://h5.qzone.qq.com/mqzone/index`; for accounts where that H5 entry redirects to `user.qzone.qq.com`, `/qzone post` failed before reaching the publish endpoint and surfaced the feed fallback message.

## Validation
- `python -m unittest tests.test_daemon_lifecycle` passed: 7 tests.
- `python -m unittest discover -s tests` passed: 42 tests.
