### PR TITLE
[codex] Support Qzone media posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - AstrBot 负责命令、LLM tools 和展示
 - Cookie 持久化，断线后可自动恢复
 - 支持从 OneBot v11 平台自动获取 Cookie
+- 发布说说支持文字、图片、图片文件以及文件+文字组合
 
 ## 使用
 
@@ -19,7 +20,7 @@
    - `/qzone autobind`
    - `/qzone feed`
    - `/qzone detail <hostuin> <fid>`
-   - `/qzone post <content>`
+   - `/qzone post <content>`（可同消息携带图片/图片文件，普通文件会写入可读引用）
    - `/qzone comment <hostuin> <fid> <content>`
    - `/qzone like <hostuin> <fid>`
 

--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ _prepare_local_qzone_bridge_imports()
 
 from qzone_bridge.controller import QzoneDaemonController
 from qzone_bridge.errors import DaemonUnavailableError, QzoneBridgeError, QzoneCookieAcquireError, QzoneNeedsRebind
+from qzone_bridge.media import collect_post_payload
 from qzone_bridge.models import FeedEntry
 from qzone_bridge.onebot_cookie import fetch_cookie_text
 from qzone_bridge.parser import normalize_uin, parse_cookie_text
@@ -264,7 +265,7 @@ class QzoneStablePlugin(Star):
                 "/qzone unbind",
                 "/qzone feed [hostuin] [limit] [cursor]",
                 "/qzone detail <hostuin> <fid> [appid]",
-                "/qzone post <content>",
+                "/qzone post <content> [图片/图片文件]",
                 "/qzone comment <hostuin> <fid> <content>",
                 "/qzone like <hostuin> <fid> [appid] [unlike]",
                 "",
@@ -358,14 +359,23 @@ class QzoneStablePlugin(Star):
         yield event.plain_result(self._render_detail(payload))
 
     @qzone.command("post")
-    async def qzone_post(self, event: AstrMessageEvent, content: str):
+    async def qzone_post(self, event: AstrMessageEvent, content: str = ""):
         if not self._is_admin(event):
             yield event.plain_result("仅管理员可发说说。")
             return
+        post = collect_post_payload(
+            event,
+            fallback_content=content,
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
-            payload = await self.controller.publish_post(content=content)
+            payload = await self.controller.publish_post(
+                content=post.content,
+                media=[item.to_dict() for item in post.media],
+            )
         except QzoneBridgeError as exc:
             yield event.plain_result(self._error_text(exc))
             return
@@ -460,7 +470,14 @@ class QzoneStablePlugin(Star):
         yield event.plain_result(self._render_detail(payload))
 
     @filter.llm_tool(name="qzone_publish_post")
-    async def tool_publish_post(self, event: AstrMessageEvent, content: str, confirm: bool = False, sync_weibo: bool = False):
+    async def tool_publish_post(
+        self,
+        event: AstrMessageEvent,
+        content: str,
+        confirm: bool = False,
+        sync_weibo: bool = False,
+        media: list[str] | None = None,
+    ):
         """发布一条 QQ 空间说说。
 
         Args:
@@ -471,13 +488,25 @@ class QzoneStablePlugin(Star):
         if not self._is_admin(event):
             yield event.plain_result("仅管理员可发布说说。")
             return
+        post = collect_post_payload(
+            event,
+            fallback_content=content,
+            include_event_text=False,
+            extra_media=media,
+        )
         if self.settings.preview_writes and not confirm:
-            yield event.plain_result(f"待发布草稿: {truncate(content, 120)}。确认后将执行。")
+            draft = truncate(post.content or "（仅附件）", 120)
+            suffix = f"；附件 {len(post.media)} 个" if post.media else ""
+            yield event.plain_result(f"待发布草稿: {draft}{suffix}。确认后将执行。")
             return
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
-            payload = await self.controller.publish_post(content=content, sync_weibo=sync_weibo)
+            payload = await self.controller.publish_post(
+                content=post.content,
+                sync_weibo=sync_weibo,
+                media=[item.to_dict() for item in post.media],
+            )
         except QzoneBridgeError as exc:
             yield event.plain_result(self._error_text(exc))
             return

--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
+from urllib.parse import unquote, urlparse
 
 import httpx
 
 from .errors import QzoneNeedsRebind, QzoneParseError, QzoneRequestError
+from .media import QZONE_MAX_IMAGES, is_supported_image, normalize_media_item, source_name
 from .models import FeedEntry, SessionState
 from .parser import (
     cookie_header,
@@ -31,6 +35,7 @@ log = logging.getLogger(__name__)
 AUTH_ERROR_CODES = {-3000}
 AUTH_ERROR_KEYWORDS = ("登录", "失效", "请先登录", "skey", "g_tk", "cookie", "expired", "login")
 LOGIN_REDIRECT_HOSTS = ("ptlogin", "ui.ptlogin", "xui.ptlogin", "ssl.ptlogin", "login")
+QZONE_IMAGE_UPLOAD_URL = "https://up.qzone.qq.com/cgi-bin/upload/cgi_upload_image"
 
 
 @dataclass(slots=True)
@@ -480,28 +485,202 @@ class QzoneClient:
         )
         return payload
 
+    @staticmethod
+    def _photo_type(filename: str, mime_type: str = "") -> int:
+        lowered = f"{filename} {mime_type}".lower()
+        if ".gif" in lowered or "image/gif" in lowered:
+            return 2
+        if ".png" in lowered or "image/png" in lowered:
+            return 3
+        if ".bmp" in lowered or "image/bmp" in lowered:
+            return 4
+        return 1
+
+    @staticmethod
+    def _extract_pic_bo(value: str) -> str:
+        if not value or "bo=" not in value:
+            return ""
+        result = value.split("bo=", 1)[1]
+        for token in ("!!", "&", "#"):
+            result = result.split(token, 1)[0]
+        return unquote(result)
+
+    async def _load_image_source(self, media: dict[str, Any]) -> tuple[bytes, str, str]:
+        item = normalize_media_item(media, default_kind="image")
+        if item is None or not item.source:
+            raise QzoneParseError("图片来源为空，无法上传")
+
+        source = item.source.strip()
+        filename = item.name or source_name(source) or "image.jpg"
+        mime_type = item.mime_type
+        if source.startswith("base64://"):
+            try:
+                return base64.b64decode(source[len("base64://") :], validate=False), filename, mime_type
+            except Exception as exc:
+                raise QzoneParseError("无法解析 base64 图片数据") from exc
+        if source.startswith("data:"):
+            try:
+                header, encoded = source.split(",", 1)
+            except ValueError as exc:
+                raise QzoneParseError("无法解析 data URI 图片数据") from exc
+            header_mime = header[5:].split(";", 1)[0]
+            if ";base64" not in header:
+                raise QzoneParseError("data URI 图片必须使用 base64 编码")
+            try:
+                data = base64.b64decode(encoded, validate=False)
+            except Exception as exc:
+                raise QzoneParseError("无法解析 data URI 图片数据") from exc
+            return data, filename, mime_type or header_mime
+
+        parsed = urlparse(source)
+        if parsed.scheme.lower() in {"http", "https"}:
+            try:
+                response = await self._client.get(
+                    source,
+                    headers=self._headers(referer=f"https://user.qzone.qq.com/{self.login_uin}"),
+                    follow_redirects=True,
+                )
+            except httpx.HTTPError as exc:
+                raise QzoneRequestError("下载图片失败", detail={"url": source}) from exc
+            self._persist_cookie_response(response)
+            if response.status_code >= 400:
+                raise QzoneRequestError(
+                    f"下载图片返回 HTTP {response.status_code}",
+                    status_code=response.status_code,
+                    detail={"url": source, "text": response.text[:500]},
+                )
+            content_type = response.headers.get("content-type", "").split(";", 1)[0]
+            return response.content, filename, mime_type or content_type
+
+        path = Path(source)
+        if not path.exists() or not path.is_file():
+            raise QzoneParseError("图片文件不存在", detail={"path": source})
+        return path.read_bytes(), filename or path.name, mime_type
+
+    @staticmethod
+    def _photo_payload_from_upload(payload: dict[str, Any], *, filename: str = "", mime_type: str = "") -> dict[str, Any]:
+        data = unwrap_payload(payload)
+        if not isinstance(data, dict):
+            raise QzoneParseError("图片上传返回结构异常", detail=payload)
+        albumid = str(data.get("albumid") or data.get("albumId") or "")
+        lloc = str(data.get("lloc") or data.get("LLoc") or "")
+        sloc = str(data.get("sloc") or data.get("SLoc") or "")
+        photo_type = str(data.get("type") or QzoneClient._photo_type(filename, mime_type))
+        height = str(data.get("height") or data.get("h") or 0)
+        width = str(data.get("width") or data.get("w") or 0)
+        if not albumid or not lloc or not sloc:
+            raise QzoneParseError("图片上传返回缺少 richval 字段", detail=data)
+        url = str(data.get("url") or data.get("origin_url") or data.get("originUrl") or data.get("pre") or "")
+        pic_bo = str(data.get("pic_bo") or data.get("picBo") or QzoneClient._extract_pic_bo(url) or "")
+        richval = f",{albumid},{lloc},{sloc},{photo_type},{height},{width},,{height},{width}"
+        return {
+            "albumid": albumid,
+            "lloc": lloc,
+            "sloc": sloc,
+            "type": photo_type,
+            "height": height,
+            "width": width,
+            "url": url,
+            "pic_bo": pic_bo,
+            "richval": richval,
+        }
+
+    async def upload_photo(self, media: dict[str, Any]) -> dict[str, Any]:
+        item = normalize_media_item(media, default_kind="image")
+        if item is None or not is_supported_image(item):
+            raise QzoneParseError("QQ空间说说仅支持上传图片附件", detail=media)
+        data, filename, mime_type = await self._load_image_source(item.to_dict())
+        if not data:
+            raise QzoneParseError("图片内容为空，无法上传", detail={"name": filename})
+
+        encoded = base64.b64encode(data).decode("ascii")
+        skey = self.session.cookies.get("skey") or self.session.cookies.get("p_skey") or ""
+        p_skey = self.session.cookies.get("p_skey") or self.session.cookies.get("skey") or ""
+        upload_payload = await self._request_json(
+            "POST",
+            QZONE_IMAGE_UPLOAD_URL,
+            params={"g_tk": self.gtk},
+            data={
+                "filename": filename,
+                "uin": self.login_uin,
+                "skey": skey,
+                "zzpaneluin": self.login_uin,
+                "p_uin": self.login_uin,
+                "p_skey": p_skey,
+                "qzonetoken": self.session.qzonetokens.get(str(self.login_uin), ""),
+                "uploadtype": "1",
+                "albumtype": "7",
+                "exttype": "0",
+                "refer": "shuoshuo",
+                "output_type": "json",
+                "charset": "utf-8",
+                "output_charset": "utf-8",
+                "upload_hd": "1",
+                "hd_width": "2048",
+                "hd_height": "10000",
+                "hd_quality": "96",
+                "backUrls": (
+                    "http://upbak.photo.qzone.qq.com/cgi-bin/upload/cgi_upload_image,"
+                    "http://119.147.64.75/cgi-bin/upload/cgi_upload_image"
+                ),
+                "url": f"{QZONE_IMAGE_UPLOAD_URL}?g_tk={self.gtk}",
+                "base64": "1",
+                "picfile": encoded,
+                "qzreferrer": f"https://user.qzone.qq.com/{self.login_uin}",
+            },
+            referer=f"https://user.qzone.qq.com/{self.login_uin}",
+            origin="https://user.qzone.qq.com",
+            hostuin=self.login_uin,
+            attach_token=False,
+        )
+        return self._photo_payload_from_upload(upload_payload, filename=filename, mime_type=mime_type)
+
+    async def _prepare_publish_photos(self, photos: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+        if photos and len(photos) > QZONE_MAX_IMAGES:
+            raise QzoneParseError(f"QQ空间说说最多支持 {QZONE_MAX_IMAGES} 张图片")
+        prepared: list[dict[str, Any]] = []
+        for photo in photos or []:
+            if isinstance(photo, dict) and photo.get("richval"):
+                prepared.append(photo)
+                continue
+            prepared.append(await self.upload_photo(photo))
+        if len(prepared) > QZONE_MAX_IMAGES:
+            raise QzoneParseError(f"QQ空间说说最多支持 {QZONE_MAX_IMAGES} 张图片")
+        return prepared
+
     async def publish_mood(self, content: str, *, sync_weibo: bool = False, photos: list[dict[str, Any]] | None = None) -> dict[str, Any]:
-        photos = photos or []
-        richval = " ".join(photo.get("richval", "") for photo in photos if isinstance(photo, dict))
+        photos = await self._prepare_publish_photos(photos)
+        richval = "\t".join(photo.get("richval", "") for photo in photos if isinstance(photo, dict))
+        pic_bo = ",".join(photo.get("pic_bo", "") for photo in photos if isinstance(photo, dict) and photo.get("pic_bo"))
+        data = {
+            "syn_tweet_verson": "1",
+            "paramstr": "1",
+            "who": "1",
+            "con": content,
+            "feedversion": "1",
+            "ver": "1",
+            "ugc_right": 1,
+            "to_sign": 0,
+            "hostuin": self.login_uin,
+            "code_version": "1",
+            "richval": richval,
+            "issyncweibo": int(bool(sync_weibo)),
+            "format": "json",
+            "qzreferrer": f"https://user.qzone.qq.com/{self.login_uin}",
+        }
+        if photos:
+            data.update(
+                {
+                    "richtype": "1",
+                    "subrichtype": "1",
+                    "pic_bo": pic_bo,
+                    "pic_template": "",
+                }
+            )
         payload = await self._request_json(
             "POST",
             "https://user.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_publish_v6",
-            data={
-                "syn_tweet_verson": "1",
-                "paramstr": "1",
-                "who": "1",
-                "con": content,
-                "feedversion": "1",
-                "ver": "1",
-                "ugc_right": 1,
-                "to_sign": 0,
-                "hostuin": self.login_uin,
-                "code_version": "1",
-                "richval": richval,
-                "issyncweibo": int(bool(sync_weibo)),
-                "format": "json",
-                "qzreferrer": f"https://user.qzone.qq.com/{self.login_uin}",
-            },
+            data=data,
             referer=f"https://user.qzone.qq.com/{self.login_uin}",
             origin="https://user.qzone.qq.com",
             hostuin=self.login_uin,

--- a/qzone_bridge/controller.py
+++ b/qzone_bridge/controller.py
@@ -409,8 +409,18 @@ class QzoneDaemonController:
             params={"hostuin": hostuin, "fid": fid, "appid": appid, "busi_param": busi_param},
         )
 
-    async def publish_post(self, *, content: str, sync_weibo: bool = False) -> dict[str, Any]:
-        return await self._request("POST", "/post", json_body={"content": content, "sync_weibo": sync_weibo})
+    async def publish_post(
+        self,
+        *,
+        content: str,
+        sync_weibo: bool = False,
+        media: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        return await self._request(
+            "POST",
+            "/post",
+            json_body={"content": content, "sync_weibo": sync_weibo, "media": media or []},
+        )
 
     async def comment_post(
         self,

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -15,6 +15,7 @@ from aiohttp import web
 
 from .client import FeedPageResult, QzoneClient
 from .errors import QzoneAuthError, QzoneBridgeError, QzoneNeedsRebind, QzoneParseError, QzoneRequestError
+from .media import QZONE_MAX_IMAGES, media_reference_text, normalize_media_list, split_publishable_images
 from .models import BridgeState, FeedEntry, SessionState
 from .parser import extract_feed_entry, extract_feed_page, normalize_uin, parse_cookie_text, unwrap_payload
 from .protocol import SECRET_HEADER, fail, ok
@@ -304,17 +305,38 @@ class QzoneDaemonService:
                     )
         return {"entry": asdict(entry), "comments": comments, "raw": payload}
 
-    async def publish_post(self, *, content: str, sync_weibo: bool = False) -> dict[str, Any]:
-        if not content.strip():
+    async def publish_post(
+        self,
+        *,
+        content: str,
+        sync_weibo: bool = False,
+        media: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        normalized_media = normalize_media_list(media)
+        photos, fallback_media = split_publishable_images(normalized_media)
+        if len(photos) > QZONE_MAX_IMAGES:
+            raise QzoneParseError(f"QQ空间说说最多支持 {QZONE_MAX_IMAGES} 张图片")
+        if fallback_media:
+            refs = "\n".join(media_reference_text(item) for item in fallback_media)
+            content = "\n".join(part for part in (content.strip(), refs) if part)
+        if not content.strip() and not photos:
             raise QzoneParseError("发布内容不能为空")
         self._ensure_session_ready()
-        payload = unwrap_payload(await self.client.publish_mood(content, sync_weibo=sync_weibo))
+        payload = unwrap_payload(
+            await self.client.publish_mood(
+                content,
+                sync_weibo=sync_weibo,
+                photos=[item.to_dict() for item in photos],
+            )
+        )
         if not isinstance(payload, dict):
             raise QzoneParseError("发布说说返回结构异常")
         self._set_success()
         return {
             "fid": payload.get("fid") or payload.get("tid") or "",
             "message": payload.get("msg") or payload.get("message") or "",
+            "media_count": len(normalized_media),
+            "photo_count": len(photos),
             "raw": payload,
         }
 
@@ -409,7 +431,7 @@ async def _json_body(request: web.Request) -> dict[str, Any]:
 
 
 def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None = None) -> web.Application:
-    app = web.Application(client_max_size=8 * 1024 * 1024)
+    app = web.Application(client_max_size=32 * 1024 * 1024)
     app["service"] = service
     if shutdown_event is not None:
         app["shutdown_event"] = shutdown_event
@@ -477,8 +499,9 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
         body = await _json_body(request)
         content = str(body.get("content") or "")
         sync_weibo = bool(body.get("sync_weibo") or False)
+        media = body.get("media") or body.get("attachments") or body.get("photos") or []
         try:
-            payload = await service.publish_post(content=content, sync_weibo=sync_weibo)
+            payload = await service.publish_post(content=content, sync_weibo=sync_weibo, media=media)
         except QzoneBridgeError as exc:
             service._set_error(exc)
             return fail(exc.code, exc.message, detail=exc.detail)

--- a/qzone_bridge/media.py
+++ b/qzone_bridge/media.py
@@ -1,0 +1,378 @@
+"""Media helpers for building QQ Space posts from AstrBot messages."""
+
+from __future__ import annotations
+
+import mimetypes
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import unquote, urlparse
+
+
+QZONE_MAX_IMAGES = 9
+QZONE_IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"}
+TEXT_KINDS = {"plain", "text"}
+MEDIA_KINDS = {"image", "file", "video", "record", "audio", "voice"}
+COMPONENT_STRING_RE = re.compile(r"\b(?:Image|Video|File|Record|Plain)\s*\(|\[CQ:(?:image|video|file|record)\b", re.I)
+
+
+@dataclass(slots=True)
+class PostMedia:
+    kind: str
+    source: str
+    name: str = ""
+    mime_type: str = ""
+    size: int = 0
+    raw_type: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class PostPayload:
+    content: str
+    media: list[PostMedia]
+
+    def to_request_body(self) -> dict[str, Any]:
+        return {
+            "content": self.content,
+            "media": [item.to_dict() for item in self.media],
+        }
+
+
+def _is_url(value: str) -> bool:
+    parsed = urlparse(value)
+    return parsed.scheme.lower() in {"http", "https"}
+
+
+def _is_base64_source(value: str) -> bool:
+    return value.startswith("base64://") or value.startswith("data:")
+
+
+def _looks_like_path(value: str) -> bool:
+    if not value:
+        return False
+    if value.startswith("file://"):
+        return True
+    if Path(value).exists():
+        return True
+    return bool(re.match(r"^[a-zA-Z]:[\\/]", value) or value.startswith(("/", "\\")))
+
+
+def normalize_source(value: Any) -> str:
+    if value is None:
+        return ""
+    source = str(value).strip()
+    if source.startswith("file://"):
+        parsed = urlparse(source)
+        if parsed.netloc and parsed.path:
+            return unquote(f"//{parsed.netloc}{parsed.path}")
+        return unquote(parsed.path)
+    return source
+
+
+def source_name(source: str) -> str:
+    if not source:
+        return ""
+    if _is_url(source) or source.startswith("file://"):
+        parsed = urlparse(source)
+        name = Path(unquote(parsed.path)).name
+    elif _is_base64_source(source):
+        name = ""
+    else:
+        name = Path(source).name
+    return name or ""
+
+
+def guess_mime_type(name_or_source: str) -> str:
+    if not name_or_source or _is_base64_source(name_or_source):
+        return ""
+    guessed, _ = mimetypes.guess_type(name_or_source)
+    return guessed or ""
+
+
+def is_supported_image(media: PostMedia | dict[str, Any]) -> bool:
+    if isinstance(media, dict):
+        kind = str(media.get("kind") or media.get("type") or "").lower()
+        source = str(media.get("source") or media.get("file") or media.get("url") or media.get("path") or "")
+        name = str(media.get("name") or source_name(source) or "")
+        mime_type = str(media.get("mime_type") or media.get("mime") or guess_mime_type(name or source) or "")
+    else:
+        kind = media.kind
+        source = media.source
+        name = media.name
+        mime_type = media.mime_type or guess_mime_type(name or source)
+
+    if kind == "image":
+        return True
+    if mime_type.lower().startswith("image/"):
+        return True
+    suffix = Path(name or source).suffix.lower()
+    return suffix in QZONE_IMAGE_SUFFIXES
+
+
+def normalize_media_item(item: Any, *, default_kind: str = "file") -> PostMedia | None:
+    if item is None:
+        return None
+    if isinstance(item, PostMedia):
+        return item
+    if isinstance(item, str):
+        source = normalize_source(item)
+        if not source:
+            return None
+        name = source_name(source)
+        media = PostMedia(
+            kind=default_kind,
+            source=source,
+            name=name,
+            mime_type=guess_mime_type(name or source),
+        )
+        if is_supported_image(media):
+            media.kind = "image"
+        return media
+    if isinstance(item, dict):
+        source = normalize_source(item.get("source") or item.get("file") or item.get("url") or item.get("path") or "")
+        if not source:
+            return None
+        kind = str(item.get("kind") or item.get("type") or default_kind).lower()
+        if kind == "voice":
+            kind = "audio"
+        name = str(item.get("name") or item.get("filename") or source_name(source) or "")
+        mime_type = str(item.get("mime_type") or item.get("mime") or guess_mime_type(name or source) or "")
+        size_value = item.get("size") or 0
+        try:
+            size = int(size_value or 0)
+        except (TypeError, ValueError):
+            size = 0
+        media = PostMedia(kind=kind, source=source, name=name, mime_type=mime_type, size=size, raw_type=kind)
+        if is_supported_image(media):
+            media.kind = "image"
+        return media
+    return None
+
+
+def normalize_media_list(items: Iterable[Any] | None) -> list[PostMedia]:
+    if isinstance(items, (str, dict, PostMedia)):
+        items = [items]
+    media: list[PostMedia] = []
+    for item in items or []:
+        normalized = normalize_media_item(item)
+        if normalized:
+            media.append(normalized)
+    return media
+
+
+def split_publishable_images(media: Iterable[PostMedia]) -> tuple[list[PostMedia], list[PostMedia]]:
+    images: list[PostMedia] = []
+    fallback: list[PostMedia] = []
+    for item in media:
+        if is_supported_image(item):
+            normalized = PostMedia(
+                kind="image",
+                source=item.source,
+                name=item.name or source_name(item.source),
+                mime_type=item.mime_type or guess_mime_type(item.name or item.source),
+                size=item.size,
+                raw_type=item.raw_type or item.kind,
+            )
+            images.append(normalized)
+        else:
+            fallback.append(item)
+    return images, fallback
+
+
+def media_reference_text(media: PostMedia) -> str:
+    labels = {
+        "file": "文件",
+        "video": "视频",
+        "audio": "音频",
+        "record": "语音",
+        "voice": "语音",
+        "image": "图片",
+    }
+    label = labels.get(media.kind, "附件")
+    name = media.name or source_name(media.source) or label
+    if media.source and media.source != name:
+        return f"[{label}: {name}] {media.source}"
+    return f"[{label}: {name}]"
+
+
+def _component_kind(component: Any) -> str:
+    if isinstance(component, dict):
+        raw = component.get("type") or component.get("kind") or component.get("message_type") or ""
+    else:
+        raw = getattr(component, "type", None) or getattr(component, "kind", None) or component.__class__.__name__
+    kind = str(raw or "").split(".")[-1].lower()
+    aliases = {
+        "plain": "plain",
+        "text": "plain",
+        "image": "image",
+        "picture": "image",
+        "file": "file",
+        "video": "video",
+        "record": "record",
+        "voice": "audio",
+        "audio": "audio",
+    }
+    return aliases.get(kind, kind)
+
+
+def _component_mapping(component: Any) -> dict[str, Any]:
+    if isinstance(component, dict):
+        data = component.get("data")
+        merged = dict(component)
+        if isinstance(data, dict):
+            merged.update(data)
+        return merged
+    data: dict[str, Any] = {}
+    for attr in (
+        "text",
+        "content",
+        "message",
+        "file",
+        "url",
+        "path",
+        "name",
+        "filename",
+        "mime",
+        "mime_type",
+        "size",
+    ):
+        if hasattr(component, attr):
+            data[attr] = getattr(component, attr)
+    return data
+
+
+def _component_text(component: Any) -> str:
+    data = _component_mapping(component)
+    for key in ("text", "content", "message"):
+        value = data.get(key)
+        if value not in (None, ""):
+            return str(value)
+    if isinstance(component, str):
+        return component
+    return ""
+
+
+def _choose_media_source(data: dict[str, Any]) -> str:
+    candidates = [
+        data.get("url"),
+        data.get("path"),
+        data.get("file"),
+        data.get("source"),
+        data.get("attachment_id"),
+    ]
+    normalized = [normalize_source(value) for value in candidates if value not in (None, "")]
+    for value in normalized:
+        if _is_url(value) or _is_base64_source(value) or _looks_like_path(value):
+            return value
+    return normalized[0] if normalized else ""
+
+
+def _component_media(component: Any, kind: str) -> PostMedia | None:
+    data = _component_mapping(component)
+    source = _choose_media_source(data)
+    if not source:
+        return None
+    name = str(data.get("name") or data.get("filename") or source_name(source) or "")
+    mime_type = str(data.get("mime_type") or data.get("mime") or guess_mime_type(name or source) or "")
+    try:
+        size = int(data.get("size") or 0)
+    except (TypeError, ValueError):
+        size = 0
+    media = PostMedia(kind=kind, source=source, name=name, mime_type=mime_type, size=size, raw_type=kind)
+    if is_supported_image(media):
+        media.kind = "image"
+    return media
+
+
+def iter_event_components(event: Any) -> list[Any]:
+    message_obj = getattr(event, "message_obj", None)
+    candidates = [
+        getattr(message_obj, "message", None),
+        getattr(message_obj, "messages", None),
+        getattr(message_obj, "chain", None),
+        getattr(message_obj, "message_chain", None),
+        getattr(event, "message", None),
+        getattr(event, "messages", None),
+        getattr(event, "chain", None),
+        getattr(event, "message_chain", None),
+    ]
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        if isinstance(candidate, (list, tuple)):
+            return list(candidate)
+        inner = getattr(candidate, "chain", None) or getattr(candidate, "messages", None)
+        if isinstance(inner, (list, tuple)):
+            return list(inner)
+    raw = getattr(message_obj, "raw_message", None) or getattr(event, "raw_message", None)
+    if isinstance(raw, list):
+        return list(raw)
+    if isinstance(raw, dict) and isinstance(raw.get("message"), list):
+        return list(raw["message"])
+    return []
+
+
+def strip_command_prefix(text: str, prefixes: Iterable[str]) -> str:
+    stripped = text.lstrip()
+    for prefix in prefixes:
+        prefix = prefix.strip()
+        if not prefix:
+            continue
+        for candidate in (prefix, f"/{prefix}" if not prefix.startswith("/") else prefix[1:]):
+            if stripped.lower().startswith(candidate.lower()):
+                return stripped[len(candidate) :].lstrip()
+    return text
+
+
+def looks_like_component_string(text: str) -> bool:
+    return bool(text and COMPONENT_STRING_RE.search(text))
+
+
+def collect_post_payload(
+    event: Any,
+    *,
+    fallback_content: str = "",
+    include_event_text: bool = True,
+    command_prefixes: Iterable[str] = (),
+    extra_media: Iterable[Any] | None = None,
+) -> PostPayload:
+    content_parts: list[str] = []
+    reference_parts: list[str] = []
+    media: list[PostMedia] = []
+    first_text = True
+
+    for component in iter_event_components(event):
+        kind = _component_kind(component)
+        if kind in TEXT_KINDS:
+            text = _component_text(component)
+            if first_text and command_prefixes:
+                text = strip_command_prefix(text, command_prefixes)
+            first_text = False
+            if include_event_text and text:
+                content_parts.append(text)
+            continue
+        if kind in MEDIA_KINDS:
+            item = _component_media(component, kind)
+            if not item:
+                continue
+            if item.kind == "image":
+                media.append(item)
+            else:
+                reference_parts.append(media_reference_text(item))
+
+    media.extend(normalize_media_list(extra_media))
+    content = "".join(content_parts).strip() if include_event_text else ""
+    fallback = str(fallback_content or "").strip()
+    use_fallback = bool(fallback and not (media and looks_like_component_string(fallback)))
+    if not content and use_fallback:
+        content = fallback
+    if not include_event_text and use_fallback:
+        content = fallback
+    if reference_parts:
+        refs = "\n".join(reference_parts)
+        content = "\n".join(part for part in (content, refs) if part)
+    return PostPayload(content=content, media=media)

--- a/qzone_bridge/utils.py
+++ b/qzone_bridge/utils.py
@@ -12,7 +12,7 @@ from textwrap import dedent
 from typing import Any, Iterable, TypeVar
 
 MATCH_PAIR = {"{": "}", "[": "]"}
-CALLBACK_RE = re.compile(r"callback\(\s*([\{\[].*[\}\]])\s*\)", re.S | re.I)
+CALLBACK_RE = re.compile(r"(?:[A-Za-z_$][\w$]*\.)*[A-Za-z_$][\w$]*\(\s*([\{\[].*[\}\]])\s*\)", re.S)
 SCRIPT_RE = re.compile(
     r"<script[^>]+type=[\"']application/javascript[\"'][^>]*>(.*?)</script>",
     re.S | re.I,

--- a/tests/test_client_media.py
+++ b/tests/test_client_media.py
@@ -1,0 +1,103 @@
+import unittest
+from urllib.parse import parse_qs
+
+import httpx
+
+from qzone_bridge.client import QzoneClient
+from qzone_bridge.models import SessionState
+
+
+class ClientMediaTests(unittest.IsolatedAsyncioTestCase):
+    async def test_publish_mood_uploads_image_and_sends_rich_fields(self):
+        seen_upload = False
+        seen_publish = False
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal seen_upload, seen_publish
+            form = parse_qs(request.content.decode())
+            if request.url.path.endswith("/cgi_upload_image"):
+                seen_upload = True
+                self.assertEqual(form["base64"][0], "1")
+                self.assertEqual(form["filename"][0], "photo.jpg")
+                self.assertEqual(form["uin"][0], "123456")
+                self.assertTrue(form["picfile"][0])
+                return httpx.Response(
+                    200,
+                    text=(
+                        '_Callback({"ret":0,"data":{"albumid":"album-1","lloc":"lloc-1",'
+                        '"sloc":"sloc-1","type":1,"height":10,"width":20,'
+                        '"url":"https://qzone.qq.com/photo?bo=bo-token!!x"}})'
+                    ),
+                    request=request,
+                )
+
+            seen_publish = True
+            self.assertEqual(form["con"][0], "hello")
+            self.assertEqual(form["richtype"][0], "1")
+            self.assertEqual(form["subrichtype"][0], "1")
+            self.assertEqual(form["pic_bo"][0], "bo-token")
+            self.assertEqual(form["richval"][0], ",album-1,lloc-1,sloc-1,1,10,20,,10,20")
+            return httpx.Response(200, json={"code": 0, "tid": "fid-1"}, request=request)
+
+        client = QzoneClient(
+            SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+        )
+        await client._client.aclose()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            trust_env=False,
+            headers={"User-Agent": client.user_agent},
+        )
+        try:
+            payload = await client.publish_mood(
+                "hello",
+                photos=[{"kind": "image", "source": "base64://aGVsbG8=", "name": "photo.jpg"}],
+            )
+        finally:
+            await client.close()
+
+        self.assertTrue(seen_upload)
+        self.assertTrue(seen_publish)
+        self.assertEqual(payload["tid"], "fid-1")
+
+    async def test_publish_mood_reuses_prepared_photo_payload(self):
+        upload_called = False
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal upload_called
+            if request.url.path.endswith("/cgi_upload_image"):
+                upload_called = True
+            form = parse_qs(request.content.decode())
+            self.assertEqual(form["richval"][0], ",album,lloc,sloc,1,1,1,,1,1")
+            self.assertEqual(form["pic_bo"][0], "bo")
+            return httpx.Response(200, json={"code": 0, "tid": "fid-2"}, request=request)
+
+        client = QzoneClient(
+            SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+        )
+        await client._client.aclose()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            trust_env=False,
+            headers={"User-Agent": client.user_agent},
+        )
+        try:
+            payload = await client.publish_mood(
+                "hello",
+                photos=[{"richval": ",album,lloc,sloc,1,1,1,,1,1", "pic_bo": "bo"}],
+            )
+        finally:
+            await client.close()
+
+        self.assertFalse(upload_called)
+        self.assertEqual(payload["tid"], "fid-2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -127,6 +127,32 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             finally:
                 await service.close()
 
+    async def test_publish_post_allows_media_only_posts(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            try:
+                with patch.object(
+                    service.client,
+                    "publish_mood",
+                    new=AsyncMock(return_value={"fid": "fid-media", "message": "ok"}),
+                ) as publish:
+                    payload = await service.publish_post(
+                        content="",
+                        media=[{"kind": "image", "source": "base64://aGVsbG8=", "name": "photo.jpg"}],
+                    )
+                publish.assert_awaited_once()
+                _, kwargs = publish.await_args
+                self.assertEqual(kwargs["photos"][0]["source"], "base64://aGVsbG8=")
+                self.assertEqual(payload["fid"], "fid-media")
+                self.assertEqual(payload["photo_count"], 1)
+            finally:
+                await service.close()
+
     async def test_comment_and_like_do_not_probe_h5_index_for_token(self):
         with TemporaryDirectory() as tmp:
             service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,89 @@
+import types
+import unittest
+
+from qzone_bridge.media import collect_post_payload
+
+
+class Plain:
+    def __init__(self, text):
+        self.text = text
+
+
+class Image:
+    def __init__(self, file="", url=""):
+        self.file = file
+        self.url = url
+
+
+class File:
+    def __init__(self, file, name=""):
+        self.file = file
+        self.name = name
+
+
+class MediaPayloadTests(unittest.TestCase):
+    def event(self, components):
+        return types.SimpleNamespace(message_obj=types.SimpleNamespace(message=components))
+
+    def test_collects_command_text_and_image_components(self):
+        payload = collect_post_payload(
+            self.event([Plain("/qzone post hello "), Image(file="photo.jpg"), Plain("tail")]),
+            fallback_content="Image(file='photo.jpg')",
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "hello tail")
+        self.assertEqual(len(payload.media), 1)
+        self.assertEqual(payload.media[0].kind, "image")
+        self.assertEqual(payload.media[0].source, "photo.jpg")
+
+    def test_onebot_image_prefers_download_url(self):
+        payload = collect_post_payload(
+            self.event(
+                [
+                    {"type": "text", "data": {"text": "/qzone post"}},
+                    {"type": "image", "data": {"file": "abc.image", "url": "https://example.com/a.png"}},
+                ]
+            ),
+            fallback_content="[CQ:image,file=abc.image]",
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "")
+        self.assertEqual(payload.media[0].source, "https://example.com/a.png")
+
+    def test_non_image_file_becomes_readable_reference(self):
+        payload = collect_post_payload(
+            self.event([Plain("/qzone post report "), File(file="notes.txt", name="notes.txt")]),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.media, [])
+        self.assertEqual(payload.content, "report\n[文件: notes.txt]")
+
+    def test_llm_mode_keeps_explicit_content_and_file_reference(self):
+        payload = collect_post_payload(
+            self.event([Plain("please post this"), File(file="report.pdf", name="report.pdf")]),
+            fallback_content="weekly report",
+            include_event_text=False,
+        )
+
+        self.assertEqual(payload.content, "weekly report\n[文件: report.pdf]")
+        self.assertEqual(payload.media, [])
+
+    def test_stringified_image_fallback_is_ignored_when_image_component_exists(self):
+        payload = collect_post_payload(
+            self.event([Image(file="photo.jpg")]),
+            fallback_content="Image(file='photo.jpg')",
+            include_event_text=False,
+        )
+
+        self.assertEqual(payload.content, "")
+        self.assertEqual(len(payload.media), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Parse AstrBot/OneBot message chains into QQ Space post text plus media, so image/file components no longer get published as Python/stringified component text.
- Upload publishable image attachments before publishing and pass QQ Space `richval` / `pic_bo` through the existing mood publish endpoint.
- Preserve non-image file attachments as readable text references for file+text combinations, and document the mixed post behavior.

## Root Cause
The publish path only accepted a plain `content: str`, so message components such as images were reduced to their string representation before reaching the daemon.

## Validation
- `python -m compileall -q main.py daemon_main.py qzone_bridge tests`
- `python -m unittest discover -s tests -p test*.py -v` (50 tests)