### PR TITLE
[codex] Fix qzone post prefix stripping

### DIFF
--- a/qzone_bridge/media.py
+++ b/qzone_bridge/media.py
@@ -319,12 +319,13 @@ def iter_event_components(event: Any) -> list[Any]:
 def strip_command_prefix(text: str, prefixes: Iterable[str]) -> str:
     stripped = text.lstrip()
     for prefix in prefixes:
-        prefix = prefix.strip()
+        prefix = prefix.strip().lstrip("/／").strip()
         if not prefix:
             continue
-        for candidate in (prefix, f"/{prefix}" if not prefix.startswith("/") else prefix[1:]):
-            if stripped.lower().startswith(candidate.lower()):
-                return stripped[len(candidate) :].lstrip()
+        pattern = r"^[/／]?\s*" + r"\s+".join(re.escape(part) for part in prefix.split()) + r"(?:\s+|$)"
+        match = re.match(pattern, stripped, re.I)
+        if match:
+            return stripped[match.end() :].lstrip()
     return text
 
 
@@ -367,6 +368,8 @@ def collect_post_payload(
     media.extend(normalize_media_list(extra_media))
     content = "".join(content_parts).strip() if include_event_text else ""
     fallback = str(fallback_content or "").strip()
+    if command_prefixes:
+        fallback = strip_command_prefix(fallback, command_prefixes).strip()
     use_fallback = bool(fallback and not (media and looks_like_component_string(fallback)))
     if not content and use_fallback:
         content = fallback

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -38,6 +38,38 @@ class MediaPayloadTests(unittest.TestCase):
         self.assertEqual(payload.media[0].kind, "image")
         self.assertEqual(payload.media[0].source, "photo.jpg")
 
+    def test_collects_text_after_qzone_post_without_slash(self):
+        payload = collect_post_payload(
+            self.event([Plain("qzone post 6:25")]),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "6:25")
+        self.assertEqual(payload.media, [])
+
+    def test_strips_command_prefix_from_fallback_content(self):
+        payload = collect_post_payload(
+            self.event([]),
+            fallback_content="qzone post 6:25",
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "6:25")
+        self.assertEqual(payload.media, [])
+
+    def test_strips_slash_command_prefix_from_fallback_content(self):
+        payload = collect_post_payload(
+            self.event([]),
+            fallback_content="/qzone   post   6:25",
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "6:25")
+        self.assertEqual(payload.media, [])
+
     def test_onebot_image_prefers_download_url(self):
         payload = collect_post_payload(
             self.event(


### PR DESCRIPTION
## Summary
- Strip `qzone post` / `/qzone post` from fallback publish content, not only from message-chain Plain segments.
- Make command prefix matching tolerate no slash, full-width slash, and extra spaces between `qzone` and `post`.
- Add regressions for `qzone post 6:25`, `/qzone   post   6:25`, and message-chain-only command text.

## Root Cause
The media post adapter preferred message-chain text when available, but only stripped the command prefix from the first Plain component. In some AstrBot dispatch paths the command callback `content` fallback can still be the full raw command string (`qzone post 6:25`), so that fallback was published verbatim.

## Validation
- `python -m compileall -q main.py daemon_main.py qzone_bridge tests`
- `python -m unittest tests.test_media -v`
- `python -m unittest discover -s tests -p test*.py -v` (53 tests)