### PR TITLE
[codex] Handle split qzone post command text

### DIFF
--- a/qzone_bridge/media.py
+++ b/qzone_bridge/media.py
@@ -200,6 +200,8 @@ def media_reference_text(media: PostMedia) -> str:
 
 
 def _component_kind(component: Any) -> str:
+    if isinstance(component, str):
+        return "plain"
     if isinstance(component, dict):
         raw = component.get("type") or component.get("kind") or component.get("message_type") or ""
     else:
@@ -319,10 +321,10 @@ def iter_event_components(event: Any) -> list[Any]:
 def strip_command_prefix(text: str, prefixes: Iterable[str]) -> str:
     stripped = text.lstrip()
     for prefix in prefixes:
-        prefix = prefix.strip().lstrip("/／").strip()
+        prefix = prefix.strip().lstrip("/\uff0f").strip()
         if not prefix:
             continue
-        pattern = r"^[/／]?\s*" + r"\s+".join(re.escape(part) for part in prefix.split()) + r"(?:\s+|$)"
+        pattern = r"^[/\uFF0F]?\s*" + r"\s+".join(re.escape(part) for part in prefix.split()) + r"(?:\s+|$)"
         match = re.match(pattern, stripped, re.I)
         if match:
             return stripped[match.end() :].lstrip()
@@ -345,13 +347,16 @@ def collect_post_payload(
     reference_parts: list[str] = []
     media: list[PostMedia] = []
     first_text = True
+    event_prefix_stripped = False
 
     for component in iter_event_components(event):
         kind = _component_kind(component)
         if kind in TEXT_KINDS:
             text = _component_text(component)
             if first_text and command_prefixes:
+                original_text = text
                 text = strip_command_prefix(text, command_prefixes)
+                event_prefix_stripped = text != original_text
             first_text = False
             if include_event_text and text:
                 content_parts.append(text)
@@ -367,6 +372,8 @@ def collect_post_payload(
 
     media.extend(normalize_media_list(extra_media))
     content = "".join(content_parts).strip() if include_event_text else ""
+    if content and command_prefixes and not event_prefix_stripped:
+        content = strip_command_prefix(content, command_prefixes).strip()
     fallback = str(fallback_content or "").strip()
     if command_prefixes:
         fallback = strip_command_prefix(fallback, command_prefixes).strip()

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -48,6 +48,46 @@ class MediaPayloadTests(unittest.TestCase):
         self.assertEqual(payload.content, "6:25")
         self.assertEqual(payload.media, [])
 
+    def test_collects_text_from_raw_string_component(self):
+        payload = collect_post_payload(
+            self.event(["/qzone post raw text"]),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "raw text")
+        self.assertEqual(payload.media, [])
+
+    def test_strips_prefix_split_across_text_components(self):
+        payload = collect_post_payload(
+            self.event([Plain("/qzone "), Plain("post split text")]),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "split text")
+        self.assertEqual(payload.media, [])
+
+    def test_strips_fullwidth_slash_command_prefix(self):
+        payload = collect_post_payload(
+            self.event([Plain("\uff0fqzone post fullwidth")]),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "fullwidth")
+        self.assertEqual(payload.media, [])
+
+    def test_event_prefix_is_stripped_only_once(self):
+        payload = collect_post_payload(
+            self.event([Plain("/qzone post qzone post literal")]),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "qzone post literal")
+        self.assertEqual(payload.media, [])
+
     def test_strips_command_prefix_from_fallback_content(self):
         payload = collect_post_payload(
             self.event([]),


### PR DESCRIPTION
## What changed
- Treat raw string message-chain items as text so `/qzone post ...` can be stripped before publishing.
- Add a second, guarded prefix strip after joining text parts, covering AstrBot/OneBot cases where `/qzone` and `post ...` arrive as separate text components.
- Keep stripping to one command prefix only, so intentional content that starts with `qzone post` is preserved.

## Why
The previous fix handled normal text objects and fallback content, but some event shapes can expose text as raw strings or split the command prefix across multiple text components. In those cases the prefix stripper never saw the full `qzone post` command, so the published Qzone content could still include the command text.

## Validation
- `python -m unittest tests.test_media -v`
- `python -m unittest discover -s tests -v` (57 tests)