### PR TITLE
[codex] Fix qzone post command leakage

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,6 +87,15 @@ class QzoneStablePlugin(Star):
             pass
         return self._sender_id(event) in set(self.settings.admin_uins)
 
+    def _command_result(self, event: AstrMessageEvent, text: str):
+        stopper = getattr(event, "stop_event", None)
+        if callable(stopper):
+            try:
+                stopper()
+            except Exception:
+                pass
+        return event.plain_result(text)
+
     def _error_text(self, exc: QzoneBridgeError) -> str:
         if not exc.detail:
             return exc.message
@@ -278,57 +287,57 @@ class QzoneStablePlugin(Star):
                 "qzone_like_post",
             ]
         )
-        yield event.plain_result(text)
+        yield self._command_result(event, text)
 
     @qzone.command("status")
     async def qzone_status(self, event: AstrMessageEvent):
         if not self._is_admin(event):
-            yield event.plain_result("仅管理员可查看状态。")
+            yield self._command_result(event, "仅管理员可查看状态。")
             return
         try:
             payload = await self.controller.get_status()
         except QzoneBridgeError as exc:
-            yield event.plain_result(self._error_text(exc))
+            yield self._command_result(event, self._error_text(exc))
             return
-        yield event.plain_result(format_status(payload))
+        yield self._command_result(event, format_status(payload))
 
     @qzone.command("bind")
     async def qzone_bind(self, event: AstrMessageEvent, cookie: str):
         if not self._is_admin(event):
-            yield event.plain_result("仅管理员可绑定 Cookie。")
+            yield self._command_result(event, "仅管理员可绑定 Cookie。")
             return
         try:
             payload = await self.controller.bind_cookie_local(cookie)
         except QzoneBridgeError as exc:
             logger.warning("qzone bind failed: %s", exc)
-            yield event.plain_result(self._error_text(exc))
+            yield self._command_result(event, self._error_text(exc))
             return
-        yield event.plain_result(format_status(payload))
+        yield self._command_result(event, format_status(payload))
 
     @qzone.command("autobind")
     async def qzone_autobind(self, event: AstrMessageEvent):
         if not self._is_admin(event):
-            yield event.plain_result("仅管理员可自动绑定 Cookie。")
+            yield self._command_result(event, "仅管理员可自动绑定 Cookie。")
             return
         try:
             payload = await self._auto_bind_cookie(event, force=True, source="aiocqhttp")
         except QzoneBridgeError as exc:
             logger.warning("qzone autobind failed: %s", exc)
-            yield event.plain_result(self._error_text(exc))
+            yield self._command_result(event, self._error_text(exc))
             return
-        yield event.plain_result(format_status(payload))
+        yield self._command_result(event, format_status(payload))
 
     @qzone.command("unbind")
     async def qzone_unbind(self, event: AstrMessageEvent):
         if not self._is_admin(event):
-            yield event.plain_result("仅管理员可解绑。")
+            yield self._command_result(event, "仅管理员可解绑。")
             return
         try:
             payload = await self.controller.unbind_local()
         except QzoneBridgeError as exc:
-            yield event.plain_result(self._error_text(exc))
+            yield self._command_result(event, self._error_text(exc))
             return
-        yield event.plain_result(format_status(payload))
+        yield self._command_result(event, format_status(payload))
 
     @qzone.command("feed")
     async def qzone_feed(self, event: AstrMessageEvent, hostuin: int = 0, limit: int = 0, cursor: str = ""):
@@ -341,11 +350,11 @@ class QzoneStablePlugin(Star):
                 cursor=cursor,
             )
         except QzoneBridgeError as exc:
-            yield event.plain_result(self._error_text(exc))
+            yield self._command_result(event, self._error_text(exc))
             return
         entries = self._to_feed_entries(payload)
         text = format_feed_list(entries, cursor=str(payload.get("cursor") or ""), has_more=bool(payload.get("has_more")))
-        yield event.plain_result(text)
+        yield self._command_result(event, text)
 
     @qzone.command("detail")
     async def qzone_detail(self, event: AstrMessageEvent, hostuin: int, fid: str, appid: int = 311):
@@ -354,14 +363,14 @@ class QzoneStablePlugin(Star):
             await self._ensure_daemon()
             payload = await self.controller.detail_feed(hostuin=hostuin, fid=fid, appid=appid)
         except QzoneBridgeError as exc:
-            yield event.plain_result(self._error_text(exc))
+            yield self._command_result(event, self._error_text(exc))
             return
-        yield event.plain_result(self._render_detail(payload))
+        yield self._command_result(event, self._render_detail(payload))
 
     @qzone.command("post")
     async def qzone_post(self, event: AstrMessageEvent, content: str = ""):
         if not self._is_admin(event):
-            yield event.plain_result("仅管理员可发说说。")
+            yield self._command_result(event, "仅管理员可发说说。")
             return
         post = collect_post_payload(
             event,
@@ -377,37 +386,37 @@ class QzoneStablePlugin(Star):
                 media=[item.to_dict() for item in post.media],
             )
         except QzoneBridgeError as exc:
-            yield event.plain_result(self._error_text(exc))
+            yield self._command_result(event, self._error_text(exc))
             return
-        yield event.plain_result(format_action_result("发布成功", payload))
+        yield self._command_result(event, format_action_result("发布成功", payload))
 
     @qzone.command("comment")
     async def qzone_comment(self, event: AstrMessageEvent, hostuin: int, fid: str, content: str):
         if not self._is_admin(event):
-            yield event.plain_result("仅管理员可评论。")
+            yield self._command_result(event, "仅管理员可评论。")
             return
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
             payload = await self.controller.comment_post(hostuin=hostuin, fid=fid, content=content)
         except QzoneBridgeError as exc:
-            yield event.plain_result(self._error_text(exc))
+            yield self._command_result(event, self._error_text(exc))
             return
-        yield event.plain_result(format_action_result("评论成功", payload))
+        yield self._command_result(event, format_action_result("评论成功", payload))
 
     @qzone.command("like")
     async def qzone_like(self, event: AstrMessageEvent, hostuin: int, fid: str, appid: int = 311, unlike: bool = False):
         if not self._is_admin(event):
-            yield event.plain_result("仅管理员可点赞。")
+            yield self._command_result(event, "仅管理员可点赞。")
             return
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
             payload = await self.controller.like_post(hostuin=hostuin, fid=fid, appid=appid, unlike=unlike)
         except QzoneBridgeError as exc:
-            yield event.plain_result(self._error_text(exc))
+            yield self._command_result(event, self._error_text(exc))
             return
-        yield event.plain_result(format_action_result("点赞成功", payload))
+        yield self._command_result(event, format_action_result("点赞成功", payload))
 
     @filter.llm_tool(name="qzone_get_status")
     async def tool_get_status(self, event: AstrMessageEvent):
@@ -492,6 +501,7 @@ class QzoneStablePlugin(Star):
             event,
             fallback_content=content,
             include_event_text=False,
+            command_prefixes=("qzone post",),
             extra_media=media,
         )
         if self.settings.preview_writes and not confirm:

--- a/qzone_bridge/media.py
+++ b/qzone_bridge/media.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import mimetypes
 import re
 from dataclasses import asdict, dataclass
@@ -305,16 +306,26 @@ def iter_event_components(event: Any) -> list[Any]:
     for candidate in candidates:
         if candidate is None:
             continue
-        if isinstance(candidate, (list, tuple)):
+        if isinstance(candidate, (list, tuple)) and candidate:
             return list(candidate)
         inner = getattr(candidate, "chain", None) or getattr(candidate, "messages", None)
-        if isinstance(inner, (list, tuple)):
+        if isinstance(inner, (list, tuple)) and inner:
             return list(inner)
     raw = getattr(message_obj, "raw_message", None) or getattr(event, "raw_message", None)
-    if isinstance(raw, list):
+    if isinstance(raw, list) and raw:
         return list(raw)
-    if isinstance(raw, dict) and isinstance(raw.get("message"), list):
+    if isinstance(raw, dict) and isinstance(raw.get("message"), list) and raw.get("message"):
         return list(raw["message"])
+    for owner in (message_obj, event):
+        value = getattr(owner, "message_str", None)
+        if isinstance(value, str) and value:
+            return [value]
+        getter = getattr(owner, "get_message_str", None)
+        if callable(getter):
+            with contextlib.suppress(Exception):
+                value = getter()
+            if isinstance(value, str) and value:
+                return [value]
     return []
 
 
@@ -333,6 +344,29 @@ def strip_command_prefix(text: str, prefixes: Iterable[str]) -> str:
 
 def looks_like_component_string(text: str) -> bool:
     return bool(text and COMPONENT_STRING_RE.search(text))
+
+
+def join_text_parts_for_command_scan(parts: Iterable[str]) -> str:
+    text = ""
+    for part in parts:
+        if not part:
+            continue
+        if text and not text[-1].isspace() and not part[0].isspace():
+            text += " "
+        text += part
+    return text
+
+
+def strip_command_prefix_from_parts(text: str, parts: Iterable[str], prefixes: Iterable[str]) -> str:
+    stripped = strip_command_prefix(text, prefixes).strip()
+    if stripped != text:
+        return stripped
+    spaced = join_text_parts_for_command_scan(parts).strip()
+    if spaced and spaced != text:
+        stripped_spaced = strip_command_prefix(spaced, prefixes).strip()
+        if stripped_spaced != spaced:
+            return stripped_spaced
+    return stripped
 
 
 def collect_post_payload(
@@ -373,7 +407,7 @@ def collect_post_payload(
     media.extend(normalize_media_list(extra_media))
     content = "".join(content_parts).strip() if include_event_text else ""
     if content and command_prefixes and not event_prefix_stripped:
-        content = strip_command_prefix(content, command_prefixes).strip()
+        content = strip_command_prefix_from_parts(content, content_parts, command_prefixes)
     fallback = str(fallback_content or "").strip()
     if command_prefixes:
         fallback = strip_command_prefix(fallback, command_prefixes).strip()

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -1,0 +1,160 @@
+import asyncio
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+
+class Plain:
+    def __init__(self, text):
+        self.text = text
+
+
+class Event:
+    def __init__(self, components):
+        self.message_obj = types.SimpleNamespace(message=components)
+        self.stopped = False
+
+    def is_admin(self):
+        return True
+
+    def stop_event(self):
+        self.stopped = True
+
+    def plain_result(self, text):
+        return text
+
+
+def install_astrbot_stubs():
+    def identity_decorator(*args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    def command_group(*args, **kwargs):
+        def decorator(func):
+            func.command = identity_decorator
+            return func
+
+        return decorator
+
+    filter_stub = types.SimpleNamespace(
+        command_group=command_group,
+        on_platform_loaded=identity_decorator,
+        platform_adapter_type=identity_decorator,
+        llm_tool=identity_decorator,
+        PlatformAdapterType=types.SimpleNamespace(AIOCQHTTP="aiocqhttp"),
+    )
+    logger_stub = types.SimpleNamespace(
+        debug=lambda *args, **kwargs: None,
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+        exception=lambda *args, **kwargs: None,
+    )
+
+    class AstrMessageEvent:
+        pass
+
+    class Context:
+        pass
+
+    class Star:
+        def __init__(self, context):
+            self.context = context
+
+    astrbot_module = types.ModuleType("astrbot")
+    api_module = types.ModuleType("astrbot.api")
+    event_module = types.ModuleType("astrbot.api.event")
+    star_module = types.ModuleType("astrbot.api.star")
+    api_module.logger = logger_stub
+    event_module.AstrMessageEvent = AstrMessageEvent
+    event_module.filter = filter_stub
+    star_module.Context = Context
+    star_module.Star = Star
+    sys.modules["astrbot"] = astrbot_module
+    sys.modules["astrbot.api"] = api_module
+    sys.modules["astrbot.api.event"] = event_module
+    sys.modules["astrbot.api.star"] = star_module
+
+
+async def collect_async_generator(generator):
+    results = []
+    async for item in generator:
+        results.append(item)
+    return results
+
+
+class MainPublishTests(unittest.TestCase):
+    def load_main_module(self):
+        root = Path(__file__).resolve().parents[1]
+        saved_modules = {
+            name: module
+            for name, module in sys.modules.items()
+            if name == "qzone_bridge"
+            or name.startswith("qzone_bridge.")
+            or name == "astrbot"
+            or name.startswith("astrbot.")
+            or name == "_qzone_main_publish_test"
+        }
+        install_astrbot_stubs()
+        spec = importlib.util.spec_from_file_location("_qzone_main_publish_test", root / "main.py")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        self.addCleanup(self.restore_modules, saved_modules)
+        return module
+
+    @staticmethod
+    def restore_modules(saved_modules):
+        for name in list(sys.modules):
+            if (
+                name == "qzone_bridge"
+                or name.startswith("qzone_bridge.")
+                or name == "astrbot"
+                or name.startswith("astrbot.")
+                or name == "_qzone_main_publish_test"
+            ):
+                sys.modules.pop(name, None)
+        sys.modules.update(saved_modules)
+
+    def make_plugin(self, module):
+        plugin = module.QzoneStablePlugin(types.SimpleNamespace(), config={"admin_uins": []})
+        plugin._ensure_cookie_ready = AsyncMock()
+        plugin._ensure_daemon = AsyncMock()
+        plugin.controller = types.SimpleNamespace(
+            publish_post=AsyncMock(return_value={"fid": "fid-1", "message": "ok"})
+        )
+        return plugin
+
+    def test_qzone_post_stops_event_and_strips_split_command_tokens(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        event = Event([Plain("/qzone "), Plain("post"), Plain("hello")])
+
+        asyncio.run(collect_async_generator(plugin.qzone_post(event, content="/qzone post hello")))
+
+        self.assertTrue(event.stopped)
+        plugin.controller.publish_post.assert_awaited_once()
+        self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "hello")
+
+    def test_llm_publish_tool_strips_command_prefix_from_tool_content(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        event = Event([])
+
+        asyncio.run(
+            collect_async_generator(
+                plugin.tool_publish_post(event, content="/qzone post hello", confirm=True)
+            )
+        )
+
+        plugin.controller.publish_post.assert_awaited_once()
+        self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "hello")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -68,6 +68,38 @@ class MediaPayloadTests(unittest.TestCase):
         self.assertEqual(payload.content, "split text")
         self.assertEqual(payload.media, [])
 
+    def test_strips_prefix_split_across_token_components(self):
+        payload = collect_post_payload(
+            self.event([Plain("/qzone "), Plain("post"), Plain("token text")]),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "token text")
+        self.assertEqual(payload.media, [])
+
+    def test_strips_prefix_split_without_boundary_spaces(self):
+        payload = collect_post_payload(
+            self.event([Plain("/qzone"), Plain("post"), Plain("compact text")]),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "compact text")
+        self.assertEqual(payload.media, [])
+
+    def test_uses_event_message_str_when_components_are_missing(self):
+        event = types.SimpleNamespace(message_obj=types.SimpleNamespace(message=[]), message_str="/qzone post full text")
+        payload = collect_post_payload(
+            event,
+            fallback_content="full",
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "full text")
+        self.assertEqual(payload.media, [])
+
     def test_strips_fullwidth_slash_command_prefix(self):
         payload = collect_post_payload(
             self.event([Plain("\uff0fqzone post fullwidth")]),


### PR DESCRIPTION
## Summary
- Stop explicit /qzone command handlers before the same message can continue into the LLM pipeline.
- Strip /qzone post / qzone post from the LLM publish tool input as a second guard.
- Harden post payload collection for token-split text components and empty component chains that need to fall back to message_str.

## Root Cause
Previous fixes focused on direct command content extraction. In AstrBot command messages can still continue through later processing unless the event is stopped, so the same /qzone post ... message could reach the LLM tool path. That tool path did not strip command prefixes, and token-split message components like /qzone  + post + hello could also be glued into /qzone posthello, bypassing the old regex.

## Validation
- python -m compileall -q main.py daemon_main.py qzone_bridge tests
- python -m unittest tests.test_media -v
- python -m unittest tests.test_main_publish -v
- python -m unittest discover -s tests -p test*.py -v (62 tests)