### PR TITLE
[codex] Harden qzone post command stripping

### DIFF
--- a/main.py
+++ b/main.py
@@ -88,13 +88,16 @@ class QzoneStablePlugin(Star):
         return self._sender_id(event) in set(self.settings.admin_uins)
 
     def _command_result(self, event: AstrMessageEvent, text: str):
+        self._stop_event(event)
+        return event.plain_result(text)
+
+    def _stop_event(self, event: AstrMessageEvent) -> None:
         stopper = getattr(event, "stop_event", None)
         if callable(stopper):
             try:
                 stopper()
             except Exception:
                 pass
-        return event.plain_result(text)
 
     def _error_text(self, exc: QzoneBridgeError) -> str:
         if not exc.detail:
@@ -369,6 +372,7 @@ class QzoneStablePlugin(Star):
 
     @qzone.command("post")
     async def qzone_post(self, event: AstrMessageEvent, content: str = ""):
+        self._stop_event(event)
         if not self._is_admin(event):
             yield self._command_result(event, "仅管理员可发说说。")
             return

--- a/qzone_bridge/media.py
+++ b/qzone_bridge/media.py
@@ -16,6 +16,8 @@ QZONE_IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"}
 TEXT_KINDS = {"plain", "text"}
 MEDIA_KINDS = {"image", "file", "video", "record", "audio", "voice"}
 COMPONENT_STRING_RE = re.compile(r"\b(?:Image|Video|File|Record|Plain)\s*\(|\[CQ:(?:image|video|file|record)\b", re.I)
+COMMAND_SEPARATOR_CHARS = ":：,，;；"
+LEADING_SPACE_CHARS = " \t\r\n\f\v\u3000\ufeff\u200b\u200c\u200d"
 
 
 @dataclass(slots=True)
@@ -230,6 +232,9 @@ def _component_mapping(component: Any) -> dict[str, Any]:
             merged.update(data)
         return merged
     data: dict[str, Any] = {}
+    component_data = getattr(component, "data", None)
+    if isinstance(component_data, dict):
+        data.update(component_data)
     for attr in (
         "text",
         "content",
@@ -291,6 +296,21 @@ def _component_media(component: Any, kind: str) -> PostMedia | None:
     return media
 
 
+def _event_message_text(event: Any) -> str:
+    message_obj = getattr(event, "message_obj", None)
+    for owner in (message_obj, event):
+        value = getattr(owner, "message_str", None)
+        if isinstance(value, str) and value:
+            return value
+        getter = getattr(owner, "get_message_str", None)
+        if callable(getter):
+            with contextlib.suppress(Exception):
+                value = getter()
+            if isinstance(value, str) and value:
+                return value
+    return ""
+
+
 def iter_event_components(event: Any) -> list[Any]:
     message_obj = getattr(event, "message_obj", None)
     candidates = [
@@ -316,29 +336,50 @@ def iter_event_components(event: Any) -> list[Any]:
         return list(raw)
     if isinstance(raw, dict) and isinstance(raw.get("message"), list) and raw.get("message"):
         return list(raw["message"])
-    for owner in (message_obj, event):
-        value = getattr(owner, "message_str", None)
-        if isinstance(value, str) and value:
-            return [value]
-        getter = getattr(owner, "get_message_str", None)
-        if callable(getter):
-            with contextlib.suppress(Exception):
-                value = getter()
-            if isinstance(value, str) and value:
-                return [value]
+    event_text = _event_message_text(event)
+    if event_text:
+        return [event_text]
     return []
 
 
+def _strip_leading_command_noise(text: str) -> tuple[str, bool]:
+    stripped_noise = False
+    value = text.lstrip(LEADING_SPACE_CHARS)
+    stripped_noise = stripped_noise or value != text
+    while value:
+        match = re.match(r"\[CQ:at,[^\]]+\]\s*", value, re.I)
+        if match:
+            value = value[match.end() :].lstrip(LEADING_SPACE_CHARS)
+            stripped_noise = True
+            continue
+        match = re.match(r"@\S+\s+", value)
+        if match:
+            value = value[match.end() :].lstrip(LEADING_SPACE_CHARS)
+            stripped_noise = True
+            continue
+        break
+    return value, stripped_noise
+
+
+def _strip_command_separator(text: str) -> str:
+    value = text.lstrip()
+    if value[:1] in COMMAND_SEPARATOR_CHARS:
+        value = value[1:].lstrip()
+    return value
+
+
 def strip_command_prefix(text: str, prefixes: Iterable[str]) -> str:
-    stripped = text.lstrip()
+    stripped, stripped_noise = _strip_leading_command_noise(text)
     for prefix in prefixes:
         prefix = prefix.strip().lstrip("/\uff0f").strip()
         if not prefix:
             continue
-        pattern = r"^[/\uFF0F]?\s*" + r"\s+".join(re.escape(part) for part in prefix.split()) + r"(?:\s+|$)"
+        pattern = r"^[/\uFF0F]?\s*" + r"\s+".join(re.escape(part) for part in prefix.split())
         match = re.match(pattern, stripped, re.I)
         if match:
-            return stripped[match.end() :].lstrip()
+            return _strip_command_separator(stripped[match.end() :])
+    if stripped_noise:
+        return text
     return text
 
 
@@ -382,8 +423,9 @@ def collect_post_payload(
     media: list[PostMedia] = []
     first_text = True
     event_prefix_stripped = False
+    components = iter_event_components(event)
 
-    for component in iter_event_components(event):
+    for component in components:
         kind = _component_kind(component)
         if kind in TEXT_KINDS:
             text = _component_text(component)
@@ -405,6 +447,10 @@ def collect_post_payload(
                 reference_parts.append(media_reference_text(item))
 
     media.extend(normalize_media_list(extra_media))
+    if include_event_text and not content_parts and components:
+        event_text = _event_message_text(event)
+        if event_text and not (media and looks_like_component_string(event_text)):
+            content_parts.append(event_text)
     content = "".join(content_parts).strip() if include_event_text else ""
     if content and command_prefixes and not event_prefix_stripped:
         content = strip_command_prefix_from_parts(content, content_parts, command_prefixes)

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -155,6 +155,20 @@ class MainPublishTests(unittest.TestCase):
         plugin.controller.publish_post.assert_awaited_once()
         self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "hello")
 
+    def test_llm_publish_tool_strips_no_space_typo_from_tool_content(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        event = Event([])
+
+        asyncio.run(
+            collect_async_generator(
+                plugin.tool_publish_post(event, content="/qzone post1", confirm=True)
+            )
+        )
+
+        plugin.controller.publish_post.assert_awaited_once()
+        self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "1")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -21,6 +21,17 @@ class File:
         self.name = name
 
 
+class ObjText:
+    type = "text"
+
+    def __init__(self, text):
+        self.data = {"text": text}
+
+
+class At:
+    type = "at"
+
+
 class MediaPayloadTests(unittest.TestCase):
     def event(self, components):
         return types.SimpleNamespace(message_obj=types.SimpleNamespace(message=components))
@@ -88,6 +99,36 @@ class MediaPayloadTests(unittest.TestCase):
         self.assertEqual(payload.content, "compact text")
         self.assertEqual(payload.media, [])
 
+    def test_strips_prefix_without_space_after_post(self):
+        payload = collect_post_payload(
+            self.event([Plain("/qzone post1")]),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "1")
+        self.assertEqual(payload.media, [])
+
+    def test_strips_prefix_without_space_before_chinese_content(self):
+        payload = collect_post_payload(
+            self.event([Plain("/qzone post\u4f60\u597d")]),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "\u4f60\u597d")
+        self.assertEqual(payload.media, [])
+
+    def test_strips_prefix_with_separator_after_post(self):
+        payload = collect_post_payload(
+            self.event([Plain("/qzone post: hello")]),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "hello")
+        self.assertEqual(payload.media, [])
+
     def test_uses_event_message_str_when_components_are_missing(self):
         event = types.SimpleNamespace(message_obj=types.SimpleNamespace(message=[]), message_str="/qzone post full text")
         payload = collect_post_payload(
@@ -98,6 +139,55 @@ class MediaPayloadTests(unittest.TestCase):
         )
 
         self.assertEqual(payload.content, "full text")
+        self.assertEqual(payload.media, [])
+
+    def test_strips_prefix_after_leading_cq_at_in_message_str(self):
+        event = types.SimpleNamespace(
+            message_obj=types.SimpleNamespace(message=[]),
+            message_str="[CQ:at,qq=123] /qzone post hello",
+        )
+        payload = collect_post_payload(
+            event,
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "hello")
+        self.assertEqual(payload.media, [])
+
+    def test_strips_prefix_after_leading_mention_in_message_str(self):
+        event = types.SimpleNamespace(message_obj=types.SimpleNamespace(message=[]), message_str="@bot /qzone post hello")
+        payload = collect_post_payload(
+            event,
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "hello")
+        self.assertEqual(payload.media, [])
+
+    def test_collects_object_data_text_components(self):
+        payload = collect_post_payload(
+            self.event([ObjText("/qzone post hello")]),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "hello")
+        self.assertEqual(payload.media, [])
+
+    def test_uses_message_str_when_only_non_text_components_exist(self):
+        event = types.SimpleNamespace(
+            message_obj=types.SimpleNamespace(message=[At()]),
+            message_str="/qzone post hello",
+        )
+        payload = collect_post_payload(
+            event,
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "hello")
         self.assertEqual(payload.media, [])
 
     def test_strips_fullwidth_slash_command_prefix(self):


### PR DESCRIPTION
## Summary
- Harden /qzone post content extraction against the cases that still leaked the command prefix after PR #15.
- Strip command prefixes after leading CQ at / text mentions, after separators like : / ：, and when the user omits the space before content such as /qzone post1 or /qzone post你好.
- Read object component .data text and fall back to message_str when a chain only exposes non-text components.
- Stop /qzone post immediately at handler entry, in addition to stopping before command results.

## Root Cause
The previous fixes covered normal Plain components, fallback content, and split text tokens, but the real AstrBot/OneBot event surface is wider: text may arrive in object .data, message_str may be the only complete text after CQ/at handling, and users often type the post content immediately after post or with punctuation. Those shapes bypassed the old prefix boundary check, so qzone post could still reach publish_post as user content.

## Deep Check Matrix
Covered command forms include:
- /qzone post hello, qzone post hello, ／qzone post hello
- split components: /qzone  + post + content, and / + qzone + post + content
- /qzone post1, /qzone post你好, /qzone post: hello, /qzone post：hello
- [CQ:at,qq=...] /qzone post hello and @bot /qzone post hello
- object text components that store text under .data[text]
- chains with only non-text components plus message_str
- LLM tool content that still contains /qzone post...

## Validation
- python -m compileall -q main.py daemon_main.py qzone_bridge tests
- python -m unittest tests.test_media -v (22 tests)
- python -m unittest tests.test_main_publish -v (3 tests)
- python -m unittest discover -s tests -p test*.py -v (70 tests)
- git diff --check (only Windows LF-to-CRLF warnings from Git, exit 0)

## Reference
AstrBot docs describe message_obj.message_str as the plain text message string and event.stop_event() as the way to stop following handlers and LLM processing: https://docs.astrbot.app/dev/star/guides/listen-message-event.html