### PR TITLE
[codex] Harden qzone post content sanitization

### DIFF
--- a/main.py
+++ b/main.py
@@ -388,6 +388,7 @@ class QzoneStablePlugin(Star):
             payload = await self.controller.publish_post(
                 content=post.content,
                 media=[item.to_dict() for item in post.media],
+                content_sanitized=True,
             )
         except QzoneBridgeError as exc:
             yield self._command_result(event, self._error_text(exc))
@@ -520,6 +521,7 @@ class QzoneStablePlugin(Star):
                 content=post.content,
                 sync_weibo=sync_weibo,
                 media=[item.to_dict() for item in post.media],
+                content_sanitized=True,
             )
         except QzoneBridgeError as exc:
             yield event.plain_result(self._error_text(exc))

--- a/qzone_bridge/controller.py
+++ b/qzone_bridge/controller.py
@@ -16,6 +16,7 @@ from typing import Any
 import httpx
 
 from .errors import DaemonUnavailableError, QzoneAuthError, QzoneBridgeError, QzoneNeedsRebind, QzoneParseError, QzoneRequestError
+from .media import strip_command_prefix
 from .models import SessionState
 from .parser import normalize_uin, parse_cookie_text
 from .protocol import SECRET_HEADER
@@ -415,11 +416,20 @@ class QzoneDaemonController:
         content: str,
         sync_weibo: bool = False,
         media: list[dict[str, Any]] | None = None,
+        content_sanitized: bool = False,
     ) -> dict[str, Any]:
+        content = str(content or "")
+        if not content_sanitized:
+            content = strip_command_prefix(content, ("qzone post",)).strip()
         return await self._request(
             "POST",
             "/post",
-            json_body={"content": content, "sync_weibo": sync_weibo, "media": media or []},
+            json_body={
+                "content": content,
+                "sync_weibo": sync_weibo,
+                "media": media or [],
+                "content_sanitized": True,
+            },
         )
 
     async def comment_post(

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -15,7 +15,7 @@ from aiohttp import web
 
 from .client import FeedPageResult, QzoneClient
 from .errors import QzoneAuthError, QzoneBridgeError, QzoneNeedsRebind, QzoneParseError, QzoneRequestError
-from .media import QZONE_MAX_IMAGES, media_reference_text, normalize_media_list, split_publishable_images
+from .media import QZONE_MAX_IMAGES, media_reference_text, normalize_media_list, split_publishable_images, strip_command_prefix
 from .models import BridgeState, FeedEntry, SessionState
 from .parser import extract_feed_entry, extract_feed_page, normalize_uin, parse_cookie_text, unwrap_payload
 from .protocol import SECRET_HEADER, fail, ok
@@ -311,7 +311,11 @@ class QzoneDaemonService:
         content: str,
         sync_weibo: bool = False,
         media: list[dict[str, Any]] | None = None,
+        content_sanitized: bool = False,
     ) -> dict[str, Any]:
+        content = str(content or "")
+        if not content_sanitized:
+            content = strip_command_prefix(content, ("qzone post",)).strip()
         normalized_media = normalize_media_list(media)
         photos, fallback_media = split_publishable_images(normalized_media)
         if len(photos) > QZONE_MAX_IMAGES:
@@ -500,8 +504,14 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
         content = str(body.get("content") or "")
         sync_weibo = bool(body.get("sync_weibo") or False)
         media = body.get("media") or body.get("attachments") or body.get("photos") or []
+        content_sanitized = bool(body.get("content_sanitized") or False)
         try:
-            payload = await service.publish_post(content=content, sync_weibo=sync_weibo, media=media)
+            payload = await service.publish_post(
+                content=content,
+                sync_weibo=sync_weibo,
+                media=media,
+                content_sanitized=content_sanitized,
+            )
         except QzoneBridgeError as exc:
             service._set_error(exc)
             return fail(exc.code, exc.message, detail=exc.detail)

--- a/qzone_bridge/media.py
+++ b/qzone_bridge/media.py
@@ -16,7 +16,8 @@ QZONE_IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"}
 TEXT_KINDS = {"plain", "text"}
 MEDIA_KINDS = {"image", "file", "video", "record", "audio", "voice"}
 COMPONENT_STRING_RE = re.compile(r"\b(?:Image|Video|File|Record|Plain)\s*\(|\[CQ:(?:image|video|file|record)\b", re.I)
-COMMAND_SEPARATOR_CHARS = ":：,，;；"
+COMMAND_SEPARATOR_CHARS = ":\uFF1A,\uFF0C;\uFF1B"
+COMMAND_PREFIX_CHARS = "/\uFF0F!\uFF01#\uFF03.\uFF0E\u3002~\uFF5E?\uFF1F"
 LEADING_SPACE_CHARS = " \t\r\n\f\v\u3000\ufeff\u200b\u200c\u200d"
 
 
@@ -298,7 +299,7 @@ def _component_media(component: Any, kind: str) -> PostMedia | None:
 
 def _event_message_text(event: Any) -> str:
     message_obj = getattr(event, "message_obj", None)
-    for owner in (message_obj, event):
+    for owner in (event, message_obj):
         value = getattr(owner, "message_str", None)
         if isinstance(value, str) and value:
             return value
@@ -352,7 +353,8 @@ def _strip_leading_command_noise(text: str) -> tuple[str, bool]:
             value = value[match.end() :].lstrip(LEADING_SPACE_CHARS)
             stripped_noise = True
             continue
-        match = re.match(r"@\S+\s+", value)
+        mention_boundary = re.escape(LEADING_SPACE_CHARS + COMMAND_SEPARATOR_CHARS + COMMAND_PREFIX_CHARS)
+        match = re.match(r"@\S+?(?:[" + mention_boundary + r"]+|$)", value)
         if match:
             value = value[match.end() :].lstrip(LEADING_SPACE_CHARS)
             stripped_noise = True
@@ -374,7 +376,8 @@ def strip_command_prefix(text: str, prefixes: Iterable[str]) -> str:
         prefix = prefix.strip().lstrip("/\uff0f").strip()
         if not prefix:
             continue
-        pattern = r"^[/\uFF0F]?\s*" + r"\s+".join(re.escape(part) for part in prefix.split())
+        command_marker = r"(?:[" + re.escape(COMMAND_PREFIX_CHARS) + r"]+\s*)?"
+        pattern = r"^" + command_marker + r"\s*" + r"\s+".join(re.escape(part) for part in prefix.split())
         match = re.match(pattern, stripped, re.I)
         if match:
             return _strip_command_separator(stripped[match.end() :])
@@ -424,6 +427,8 @@ def collect_post_payload(
     first_text = True
     event_prefix_stripped = False
     components = iter_event_components(event)
+    event_text = _event_message_text(event)
+    event_text_consumed = False
 
     for component in components:
         kind = _component_kind(component)
@@ -447,8 +452,16 @@ def collect_post_payload(
                 reference_parts.append(media_reference_text(item))
 
     media.extend(normalize_media_list(extra_media))
-    if include_event_text and not content_parts and components:
-        event_text = _event_message_text(event)
+    if include_event_text and command_prefixes and event_text:
+        event_content = strip_command_prefix(event_text, command_prefixes).strip()
+        if event_content != event_text.strip():
+            event_text_consumed = True
+            if media and looks_like_component_string(event_content):
+                content_parts = []
+            else:
+                content_parts = [event_content] if event_content else []
+            event_prefix_stripped = True
+    if include_event_text and not content_parts and components and not event_text_consumed:
         if event_text and not (media and looks_like_component_string(event_text)):
             content_parts.append(event_text)
     content = "".join(content_parts).strip() if include_event_text else ""

--- a/tests/test_controller_bind.py
+++ b/tests/test_controller_bind.py
@@ -83,6 +83,51 @@ class ControllerBindTests(unittest.IsolatedAsyncioTestCase):
             finally:
                 await controller.close()
 
+    async def test_publish_post_strips_command_prefix_before_daemon_request(self):
+        with TemporaryDirectory() as tmp:
+            controller = QzoneDaemonController(
+                plugin_root=Path(tmp),
+                data_dir=Path(tmp) / "data",
+                default_port=19009,
+                request_timeout=1.0,
+                start_timeout=1.0,
+                keepalive_interval=30,
+                user_agent="test-agent",
+            )
+            try:
+                with patch.object(controller, "_request", new=AsyncMock(return_value={"fid": "fid-1"})) as request:
+                    payload = await controller.publish_post(content="!qzone post hello")
+                request.assert_awaited_once()
+                self.assertEqual(request.await_args.kwargs["json_body"]["content"], "hello")
+                self.assertTrue(request.await_args.kwargs["json_body"]["content_sanitized"])
+                self.assertEqual(payload["fid"], "fid-1")
+            finally:
+                await controller.close()
+
+    async def test_publish_post_preserves_content_marked_sanitized(self):
+        with TemporaryDirectory() as tmp:
+            controller = QzoneDaemonController(
+                plugin_root=Path(tmp),
+                data_dir=Path(tmp) / "data",
+                default_port=19009,
+                request_timeout=1.0,
+                start_timeout=1.0,
+                keepalive_interval=30,
+                user_agent="test-agent",
+            )
+            try:
+                with patch.object(controller, "_request", new=AsyncMock(return_value={"fid": "fid-1"})) as request:
+                    payload = await controller.publish_post(
+                        content="qzone post literal",
+                        content_sanitized=True,
+                    )
+                request.assert_awaited_once()
+                self.assertEqual(request.await_args.kwargs["json_body"]["content"], "qzone post literal")
+                self.assertTrue(request.await_args.kwargs["json_body"]["content_sanitized"])
+                self.assertEqual(payload["fid"], "fid-1")
+            finally:
+                await controller.close()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -1,14 +1,20 @@
 import asyncio
 import socket
+import warnings
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import AsyncMock, patch
 
+import httpx
+from aiohttp import web
+from aiohttp.web_app import NotAppKeyWarning
+
 from qzone_bridge.controller import QzoneDaemonController, _port_is_free
-from qzone_bridge.daemon import QzoneDaemonService
+from qzone_bridge.daemon import QzoneDaemonService, create_app
 from qzone_bridge.errors import QzoneNeedsRebind, QzoneRequestError
 from qzone_bridge.models import FeedEntry, SessionState
+from qzone_bridge.protocol import SECRET_HEADER
 from qzone_bridge.storage import StateStore
 
 
@@ -125,6 +131,92 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
                 publish.assert_awaited_once()
                 self.assertEqual(payload["fid"], "fid-1")
             finally:
+                await service.close()
+
+    async def test_publish_post_strips_command_prefix_before_client_publish(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            try:
+                with patch.object(
+                    service.client,
+                    "publish_mood",
+                    new=AsyncMock(return_value={"fid": "fid-1", "message": "ok"}),
+                ) as publish:
+                    payload = await service.publish_post(content="!qzone post hello")
+                publish.assert_awaited_once()
+                self.assertEqual(publish.await_args.args[0], "hello")
+                self.assertEqual(payload["fid"], "fid-1")
+            finally:
+                await service.close()
+
+    async def test_publish_post_preserves_content_marked_sanitized(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            try:
+                with patch.object(
+                    service.client,
+                    "publish_mood",
+                    new=AsyncMock(return_value={"fid": "fid-1", "message": "ok"}),
+                ) as publish:
+                    payload = await service.publish_post(
+                        content="qzone post literal",
+                        content_sanitized=True,
+                    )
+                publish.assert_awaited_once()
+                self.assertEqual(publish.await_args.args[0], "qzone post literal")
+                self.assertEqual(payload["fid"], "fid-1")
+            finally:
+                await service.close()
+
+    async def test_post_route_strips_raw_prefix_but_preserves_sanitized_content(self):
+        with TemporaryDirectory() as tmp:
+            port = free_port()
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=port)
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", NotAppKeyWarning)
+                app = create_app(service)
+            runner = web.AppRunner(app, access_log=None)
+            await runner.setup()
+            site = web.TCPSite(runner, host="127.0.0.1", port=port)
+            try:
+                await site.start()
+                with patch.object(
+                    service.client,
+                    "publish_mood",
+                    new=AsyncMock(return_value={"fid": "fid-1", "message": "ok"}),
+                ) as publish:
+                    async with httpx.AsyncClient(timeout=httpx.Timeout(5.0), trust_env=False) as client:
+                        raw_response = await client.post(
+                            f"http://127.0.0.1:{port}/post",
+                            headers={SECRET_HEADER: "secret"},
+                            json={"content": "!qzone post hello"},
+                        )
+                        sanitized_response = await client.post(
+                            f"http://127.0.0.1:{port}/post",
+                            headers={SECRET_HEADER: "secret"},
+                            json={"content": "qzone post literal", "content_sanitized": True},
+                        )
+                self.assertEqual(raw_response.status_code, 200)
+                self.assertEqual(sanitized_response.status_code, 200)
+                self.assertEqual(publish.await_args_list[0].args[0], "hello")
+                self.assertEqual(publish.await_args_list[1].args[0], "qzone post literal")
+            finally:
+                await runner.cleanup()
                 await service.close()
 
     async def test_publish_post_allows_media_only_posts(self):

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -13,8 +13,9 @@ class Plain:
 
 
 class Event:
-    def __init__(self, components):
+    def __init__(self, components, message_str=""):
         self.message_obj = types.SimpleNamespace(message=components)
+        self.message_str = message_str
         self.stopped = False
 
     def is_admin(self):
@@ -140,6 +141,30 @@ class MainPublishTests(unittest.TestCase):
         self.assertTrue(event.stopped)
         plugin.controller.publish_post.assert_awaited_once()
         self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "hello")
+        self.assertTrue(plugin.controller.publish_post.await_args.kwargs["content_sanitized"])
+
+    def test_qzone_post_prefers_pipeline_text_over_raw_custom_wake_prefix(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        event = Event([Plain("bot qzone post hello")], message_str="qzone post hello")
+
+        asyncio.run(collect_async_generator(plugin.qzone_post(event, content="hello")))
+
+        self.assertTrue(event.stopped)
+        plugin.controller.publish_post.assert_awaited_once()
+        self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "hello")
+        self.assertTrue(plugin.controller.publish_post.await_args.kwargs["content_sanitized"])
+
+    def test_qzone_post_keeps_literal_command_text_after_real_command(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        event = Event([Plain("/qzone post qzone post literal")])
+
+        asyncio.run(collect_async_generator(plugin.qzone_post(event, content="/qzone post qzone post literal")))
+
+        plugin.controller.publish_post.assert_awaited_once()
+        self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "qzone post literal")
+        self.assertTrue(plugin.controller.publish_post.await_args.kwargs["content_sanitized"])
 
     def test_llm_publish_tool_strips_command_prefix_from_tool_content(self):
         module = self.load_main_module()
@@ -154,6 +179,7 @@ class MainPublishTests(unittest.TestCase):
 
         plugin.controller.publish_post.assert_awaited_once()
         self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "hello")
+        self.assertTrue(plugin.controller.publish_post.await_args.kwargs["content_sanitized"])
 
     def test_llm_publish_tool_strips_no_space_typo_from_tool_content(self):
         module = self.load_main_module()
@@ -168,6 +194,7 @@ class MainPublishTests(unittest.TestCase):
 
         plugin.controller.publish_post.assert_awaited_once()
         self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "1")
+        self.assertTrue(plugin.controller.publish_post.await_args.kwargs["content_sanitized"])
 
 
 if __name__ == "__main__":

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -33,8 +33,8 @@ class At:
 
 
 class MediaPayloadTests(unittest.TestCase):
-    def event(self, components):
-        return types.SimpleNamespace(message_obj=types.SimpleNamespace(message=components))
+    def event(self, components, **attrs):
+        return types.SimpleNamespace(message_obj=types.SimpleNamespace(message=components), **attrs)
 
     def test_collects_command_text_and_image_components(self):
         payload = collect_post_payload(
@@ -139,6 +139,56 @@ class MediaPayloadTests(unittest.TestCase):
         )
 
         self.assertEqual(payload.content, "full text")
+        self.assertEqual(payload.media, [])
+
+    def test_prefers_pipeline_message_str_over_raw_symbol_wake_prefix(self):
+        payload = collect_post_payload(
+            self.event([Plain("!qzone post hello")], message_str="qzone post hello"),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "hello")
+        self.assertEqual(payload.media, [])
+
+    def test_prefers_pipeline_message_str_over_raw_word_wake_prefix(self):
+        payload = collect_post_payload(
+            self.event([Plain("bot qzone post hello")], message_str="qzone post hello"),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "hello")
+        self.assertEqual(payload.media, [])
+
+    def test_strips_common_symbol_wake_prefix_without_pipeline_text(self):
+        payload = collect_post_payload(
+            self.event([Plain("!qzone post hello")]),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "hello")
+        self.assertEqual(payload.media, [])
+
+    def test_strips_prefix_after_mention_with_chinese_comma(self):
+        payload = collect_post_payload(
+            self.event([Plain("@bot\uff0c/qzone post hello")]),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "hello")
+        self.assertEqual(payload.media, [])
+
+    def test_strips_prefix_after_mention_without_separator(self):
+        payload = collect_post_payload(
+            self.event([Plain("@bot/qzone post hello")]),
+            include_event_text=True,
+            command_prefixes=("qzone post",),
+        )
+
+        self.assertEqual(payload.content, "hello")
         self.assertEqual(payload.media, [])
 
     def test_strips_prefix_after_leading_cq_at_in_message_str(self):


### PR DESCRIPTION
## Summary
- Prefer AstrBot's normalized `message_str` when extracting `/qzone post` content so raw message-chain wake prefixes do not leak into Qzone posts.
- Strip command prefixes at controller/daemon boundaries for raw direct calls, while passing a `content_sanitized` marker for already-cleaned AstrBot content so literal text like `qzone post literal` is preserved.
- Broaden regression coverage for custom wake prefixes, symbol prefixes, mentions, split command tokens, media-only posts, LLM tool calls, controller forwarding, daemon service, and the `/post` HTTP route.

## Root Cause
Previous fixes focused on the first text component and fallback content. In real AstrBot flows, the normalized command text can live in `event.message_str` while `message_obj.message` still contains the raw wake prefix, so the publish payload could be built from the wrong source and send `qzone post` along with the user's content. A naive daemon-side cleanup also risks stripping legitimate content a second time, so this PR makes sanitization state explicit.

## Validation
- `python -m unittest discover -s tests -v` (82 tests)
- `python -m compileall -q main.py qzone_bridge tests`
- `git diff --check`
- Additional manual 35-case payload matrix covering slash/no-slash/fullwidth/symbol prefixes, separators, mentions, split tokens, media-only posts, custom wake-prefix normalization, and literal `qzone post` text.