### PR TITLE
[codex] Fix Qzone render publisher chrome

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -70,5 +70,17 @@
     "type": "bool",
     "default": true,
     "hint": "LLM 工具写操作是否默认先输出草稿预览。"
+  },
+  "render_publish_result": {
+    "description": "Render publish result image",
+    "type": "bool",
+    "default": true,
+    "hint": "发布说说成功后是否返回 QQ 空间样式的实时渲染图。"
+  },
+  "render_result_width": {
+    "description": "Publish result image width",
+    "type": "int",
+    "default": 900,
+    "hint": "发布结果渲染图宽度，默认 900。"
   }
 }

--- a/main.py
+++ b/main.py
@@ -36,10 +36,11 @@ _prepare_local_qzone_bridge_imports()
 
 from qzone_bridge.controller import QzoneDaemonController
 from qzone_bridge.errors import DaemonUnavailableError, QzoneBridgeError, QzoneCookieAcquireError, QzoneNeedsRebind
-from qzone_bridge.media import collect_post_payload
+from qzone_bridge.media import PostPayload, collect_post_payload
 from qzone_bridge.models import FeedEntry
 from qzone_bridge.onebot_cookie import fetch_cookie_text
 from qzone_bridge.parser import normalize_uin, parse_cookie_text
+from qzone_bridge.publish_renderer import profile_from_event, render_publish_result_image
 from qzone_bridge.render import format_action_result, format_feed_detail, format_feed_list, format_status
 from qzone_bridge.settings import PluginSettings
 from qzone_bridge.utils import truncate
@@ -90,6 +91,32 @@ class QzoneStablePlugin(Star):
     def _command_result(self, event: AstrMessageEvent, text: str):
         self._stop_event(event)
         return event.plain_result(text)
+
+    async def _publish_result(self, event: AstrMessageEvent, post: PostPayload, payload: dict[str, Any]):
+        text = format_action_result("发布成功", payload)
+        if not self.settings.render_publish_result:
+            self._stop_event(event)
+            return event.plain_result(text)
+        try:
+            image_path = await asyncio.to_thread(
+                render_publish_result_image,
+                post,
+                self.data_dir / "rendered_posts",
+                profile=profile_from_event(event),
+                result=payload,
+                width=self.settings.render_result_width,
+            )
+        except Exception as exc:
+            logger.exception("qzone publish result render failed: %s", exc)
+            self._stop_event(event)
+            return event.plain_result(text)
+
+        image_result = getattr(event, "image_result", None)
+        if callable(image_result):
+            self._stop_event(event)
+            return image_result(str(image_path))
+        self._stop_event(event)
+        return event.plain_result(f"{text}\n渲染图: {image_path}")
 
     def _stop_event(self, event: AstrMessageEvent) -> None:
         stopper = getattr(event, "stop_event", None)
@@ -393,7 +420,7 @@ class QzoneStablePlugin(Star):
         except QzoneBridgeError as exc:
             yield self._command_result(event, self._error_text(exc))
             return
-        yield self._command_result(event, format_action_result("发布成功", payload))
+        yield await self._publish_result(event, post, payload)
 
     @qzone.command("comment")
     async def qzone_comment(self, event: AstrMessageEvent, hostuin: int, fid: str, content: str):
@@ -526,7 +553,7 @@ class QzoneStablePlugin(Star):
         except QzoneBridgeError as exc:
             yield event.plain_result(self._error_text(exc))
             return
-        yield event.plain_result(format_action_result("发布成功", payload))
+        yield await self._publish_result(event, post, payload)
 
     @filter.llm_tool(name="qzone_comment_post")
     async def tool_comment_post(

--- a/main.py
+++ b/main.py
@@ -92,17 +92,78 @@ class QzoneStablePlugin(Star):
         self._stop_event(event)
         return event.plain_result(text)
 
+    async def _publisher_render_profile(self, event: AstrMessageEvent) -> Any:
+        profile = profile_from_event(event)
+        status: dict[str, Any] = {}
+        try:
+            status = await self.controller.get_status()
+        except QzoneBridgeError:
+            status = {}
+
+        login_uin = int(status.get("login_uin") or 0)
+        if not login_uin:
+            return profile
+
+        nickname = str(
+            status.get("login_nickname")
+            or status.get("nickname")
+            or status.get("publisher_nickname")
+            or ""
+        ).strip()
+        avatar_source = str(status.get("login_avatar") or status.get("avatar") or "").strip()
+        if not avatar_source:
+            avatar_source = f"https://q1.qlogo.cn/g?b=qq&nk={login_uin}&s=100"
+
+        bot = self._capture_onebot_client(event)
+        if bot is not None:
+            fetched = await self._fetch_onebot_user_info(bot, login_uin)
+            if fetched:
+                nickname = nickname or str(fetched.get("nickname") or fetched.get("name") or "").strip()
+                avatar_source = str(fetched.get("avatar") or fetched.get("avatar_url") or avatar_source).strip()
+
+        profile.user_id = str(login_uin)
+        profile.nickname = nickname or str(login_uin)
+        profile.avatar_source = avatar_source
+        return profile
+
+    async def _fetch_onebot_user_info(self, bot: Any, uin: int) -> dict[str, Any]:
+        for method_name, kwargs in (
+            ("get_stranger_info", {"user_id": uin, "no_cache": False}),
+            ("get_friend_info", {"user_id": uin}),
+            ("get_user_info", {"user_id": uin}),
+        ):
+            method = getattr(bot, method_name, None)
+            if not callable(method):
+                continue
+            try:
+                result = method(**kwargs)
+                if asyncio.iscoroutine(result):
+                    result = await result
+            except TypeError:
+                try:
+                    result = method(uin)
+                    if asyncio.iscoroutine(result):
+                        result = await result
+                except Exception:
+                    continue
+            except Exception:
+                continue
+            if isinstance(result, dict):
+                return result
+        return {}
+
     async def _publish_result(self, event: AstrMessageEvent, post: PostPayload, payload: dict[str, Any]):
         text = format_action_result("发布成功", payload)
         if not self.settings.render_publish_result:
             self._stop_event(event)
             return event.plain_result(text)
+        profile = await self._publisher_render_profile(event)
         try:
             image_path = await asyncio.to_thread(
                 render_publish_result_image,
                 post,
                 self.data_dir / "rendered_posts",
-                profile=profile_from_event(event),
+                profile=profile,
                 result=payload,
                 width=self.settings.render_result_width,
             )

--- a/qzone_bridge/media.py
+++ b/qzone_bridge/media.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import contextlib
 import mimetypes
 import re
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 from urllib.parse import unquote, urlparse
@@ -38,6 +38,7 @@ class PostMedia:
 class PostPayload:
     content: str
     media: list[PostMedia]
+    attachments: list[PostMedia] = field(default_factory=list)
 
     def to_request_body(self) -> dict[str, Any]:
         return {
@@ -424,6 +425,7 @@ def collect_post_payload(
     content_parts: list[str] = []
     reference_parts: list[str] = []
     media: list[PostMedia] = []
+    attachments: list[PostMedia] = []
     first_text = True
     event_prefix_stripped = False
     components = iter_event_components(event)
@@ -449,9 +451,15 @@ def collect_post_payload(
             if item.kind == "image":
                 media.append(item)
             else:
+                attachments.append(item)
                 reference_parts.append(media_reference_text(item))
 
-    media.extend(normalize_media_list(extra_media))
+    for item in normalize_media_list(extra_media):
+        if item.kind == "image":
+            media.append(item)
+        else:
+            attachments.append(item)
+            reference_parts.append(media_reference_text(item))
     if include_event_text and command_prefixes and event_text:
         event_content = strip_command_prefix(event_text, command_prefixes).strip()
         if event_content != event_text.strip():
@@ -478,4 +486,4 @@ def collect_post_payload(
     if reference_parts:
         refs = "\n".join(reference_parts)
         content = "\n".join(part for part in (content, refs) if part)
-    return PostPayload(content=content, media=media)
+    return PostPayload(content=content, media=media, attachments=attachments)

--- a/qzone_bridge/publish_renderer.py
+++ b/qzone_bridge/publish_renderer.py
@@ -1,0 +1,714 @@
+"""QQ Space-style image renderer for published post results."""
+
+from __future__ import annotations
+
+import base64
+import io
+import math
+import os
+import re
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote_to_bytes, urlparse
+
+import httpx
+from PIL import Image, ImageDraw, ImageFont, ImageOps, UnidentifiedImageError
+
+from .media import PostMedia, PostPayload, source_name
+
+
+WHITE = (255, 255, 255)
+TEXT = (24, 24, 24)
+MUTED = (126, 132, 139)
+LINE = (226, 226, 226)
+ACTION = (142, 142, 142)
+CARD_BG = (250, 250, 250)
+FILE_COLORS = {
+    ".pdf": (216, 74, 64),
+    ".doc": (64, 112, 205),
+    ".docx": (64, 112, 205),
+    ".xls": (56, 145, 91),
+    ".xlsx": (56, 145, 91),
+    ".ppt": (218, 109, 57),
+    ".pptx": (218, 109, 57),
+    ".zip": (132, 102, 193),
+    ".rar": (132, 102, 193),
+    ".7z": (132, 102, 193),
+    ".mp4": (77, 145, 210),
+    ".mov": (77, 145, 210),
+    ".mp3": (205, 107, 184),
+    ".wav": (205, 107, 184),
+    ".txt": (112, 121, 130),
+    ".md": (112, 121, 130),
+}
+FONT_CACHE: dict[tuple[int, bool], ImageFont.ImageFont] = {}
+
+
+@dataclass(slots=True)
+class RenderProfile:
+    nickname: str = ""
+    user_id: str = ""
+    avatar_source: str = ""
+    time_text: str = ""
+
+
+@dataclass(slots=True)
+class _ImagePreview:
+    media: PostMedia
+    image: Image.Image | None
+    failed: bool = False
+
+
+def profile_from_event(event: Any) -> RenderProfile:
+    """Best-effort sender profile extraction from AstrBot-like events."""
+
+    message_obj = getattr(event, "message_obj", None)
+    sender = getattr(message_obj, "sender", None) or getattr(event, "sender", None)
+    owners = [event, message_obj, sender]
+
+    nickname = ""
+    for getter_name in ("get_sender_name", "get_sender_nickname"):
+        getter = getattr(event, getter_name, None)
+        if callable(getter):
+            try:
+                value = getter()
+            except Exception:
+                value = ""
+            if value:
+                nickname = str(value)
+                break
+    if not nickname:
+        for owner in owners:
+            for attr in ("card", "nickname", "nick", "name", "username", "display_name"):
+                value = getattr(owner, attr, None)
+                if value:
+                    nickname = str(value)
+                    break
+            if nickname:
+                break
+
+    user_id = ""
+    for getter_name in ("get_sender_id", "get_user_id"):
+        getter = getattr(event, getter_name, None)
+        if callable(getter):
+            try:
+                value = getter()
+            except Exception:
+                value = ""
+            if value:
+                user_id = str(value)
+                break
+    if not user_id:
+        for owner in owners:
+            value = getattr(owner, "user_id", None) or getattr(owner, "uin", None) or getattr(owner, "qq", None)
+            if value:
+                user_id = str(value)
+                break
+
+    avatar_source = ""
+    for owner in owners:
+        for attr in ("avatar", "avatar_url", "avatar_path", "face", "face_url"):
+            value = getattr(owner, attr, None)
+            if value:
+                avatar_source = str(value)
+                break
+        if avatar_source:
+            break
+
+    return RenderProfile(
+        nickname=nickname or user_id or "QQ Space",
+        user_id=user_id,
+        avatar_source=avatar_source,
+        time_text=datetime.now().strftime("%H:%M"),
+    )
+
+
+def render_publish_result_image(
+    post: PostPayload,
+    output_dir: Path,
+    *,
+    profile: RenderProfile | None = None,
+    result: dict[str, Any] | None = None,
+    width: int = 900,
+    remote_timeout: float = 1.5,
+) -> Path:
+    """Render a published post into a PNG and return the file path."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _prune_output_dir(output_dir)
+    profile = profile or RenderProfile(nickname="QQ Space", time_text=datetime.now().strftime("%H:%M"))
+    if not profile.time_text:
+        profile.time_text = datetime.now().strftime("%H:%M")
+    if not profile.nickname:
+        profile.nickname = profile.user_id or "QQ Space"
+
+    width = max(640, min(int(width or 900), 1280))
+    margin = 22
+    content_width = width - margin * 2
+    name_font = _font(28, bold=True)
+    time_font = _font(20)
+    text_font = _font(24)
+    meta_font = _font(18)
+    small_font = _font(17)
+
+    scratch = ImageDraw.Draw(Image.new("RGB", (1, 1), WHITE))
+    text_lines = _wrap_text(scratch, _render_content_text(post), text_font, content_width)
+    line_height = _line_height(scratch, text_font, 1.34)
+    text_height = len(text_lines) * line_height if text_lines else 0
+
+    previews = [_load_image_preview(item, remote_timeout=remote_timeout) for item in post.media[:9]]
+    image_height = _image_block_height(previews, content_width) if previews else 0
+    attachment_height = _attachment_block_height(post.attachments, content_width) if post.attachments else 0
+
+    y = 126
+    if text_height:
+        y += text_height + 18
+    if image_height:
+        y += image_height + 18
+    if attachment_height:
+        y += attachment_height + 18
+    actions_y = y + 6
+    comment_y = actions_y + 54
+    footer = _result_footer(result)
+    footer_height = _line_height(scratch, meta_font, 1.2) + 10 if footer else 0
+    height = max(240, comment_y + 56 + footer_height + 22)
+
+    image = Image.new("RGB", (width, height), WHITE)
+    draw = ImageDraw.Draw(image)
+    _draw_header(draw, image, profile, margin, name_font, time_font)
+
+    y = 126
+    if text_lines:
+        for line in text_lines:
+            _safe_text(draw, (margin, y), line, text_font, TEXT)
+            y += line_height
+        y += 18
+    if previews:
+        _draw_image_block(draw, image, previews, margin, y, content_width, small_font)
+        y += image_height + 18
+    if post.attachments:
+        _draw_attachment_block(draw, post.attachments, margin, y, content_width, meta_font, small_font)
+        y += attachment_height + 18
+
+    actions_y = y + 6
+    _draw_actions(draw, width, actions_y)
+    comment_y = actions_y + 54
+    _draw_comment_box(draw, margin, comment_y, content_width, 52, meta_font)
+    if footer:
+        _safe_text(draw, (margin, comment_y + 64), footer, meta_font, MUTED)
+
+    path = output_dir / f"publish_result_{int(time.time())}_{uuid.uuid4().hex[:10]}.png"
+    image.save(path, "PNG", optimize=True)
+    return path
+
+
+def _render_content_text(post: PostPayload) -> str:
+    return str(post.content or "").strip()
+
+
+def _result_footer(result: dict[str, Any] | None) -> str:
+    if not isinstance(result, dict):
+        return ""
+    fid = result.get("fid") or result.get("tid") or result.get("id")
+    if fid:
+        return f"fid: {fid}"
+    return ""
+
+
+def _font(size: int, bold: bool = False) -> ImageFont.ImageFont:
+    key = (int(size), bool(bold))
+    cached = FONT_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    regular = [
+        r"C:\Windows\Fonts\msyh.ttc",
+        r"C:\Windows\Fonts\simhei.ttf",
+        r"C:\Windows\Fonts\simsun.ttc",
+        "/System/Library/Fonts/PingFang.ttc",
+        "/Library/Fonts/Arial Unicode.ttf",
+        "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    ]
+    bold_fonts = [
+        r"C:\Windows\Fonts\msyhbd.ttc",
+        r"C:\Windows\Fonts\simhei.ttf",
+        "/System/Library/Fonts/PingFang.ttc",
+        "/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc",
+        "/usr/share/fonts/truetype/noto/NotoSansCJK-Bold.ttc",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    ]
+    for candidate in bold_fonts if bold else regular:
+        try:
+            if Path(candidate).exists():
+                font = ImageFont.truetype(candidate, size=size)
+                FONT_CACHE[key] = font
+                return font
+        except Exception:
+            continue
+    try:
+        font = ImageFont.truetype("arial.ttf", size=size)
+    except Exception:
+        font = ImageFont.load_default()
+    FONT_CACHE[key] = font
+    return font
+
+
+def _line_height(draw: ImageDraw.ImageDraw, font: ImageFont.ImageFont, factor: float = 1.25) -> int:
+    box = draw.textbbox((0, 0), "Ag", font=font)
+    return max(12, int((box[3] - box[1]) * factor))
+
+
+def _measure(draw: ImageDraw.ImageDraw, text: str, font: ImageFont.ImageFont) -> int:
+    if not text:
+        return 0
+    try:
+        box = draw.textbbox((0, 0), text, font=font)
+    except UnicodeEncodeError:
+        box = draw.textbbox((0, 0), _ascii_fallback(text), font=font)
+    return max(0, box[2] - box[0])
+
+
+def _safe_text(
+    draw: ImageDraw.ImageDraw,
+    xy: tuple[int, int],
+    text: str,
+    font: ImageFont.ImageFont,
+    fill: tuple[int, int, int],
+) -> None:
+    try:
+        draw.text(xy, text, font=font, fill=fill)
+    except UnicodeEncodeError:
+        draw.text(xy, _ascii_fallback(text), font=font, fill=fill)
+
+
+def _ascii_fallback(text: str) -> str:
+    return text.encode("ascii", "replace").decode("ascii")
+
+
+def _wrap_text(draw: ImageDraw.ImageDraw, text: str, font: ImageFont.ImageFont, max_width: int) -> list[str]:
+    text = str(text or "").replace("\r\n", "\n").replace("\r", "\n")
+    if not text.strip():
+        return []
+    lines: list[str] = []
+    for paragraph in text.split("\n"):
+        if not paragraph:
+            lines.append("")
+            continue
+        current = ""
+        for char in paragraph.replace("\t", " "):
+            candidate = current + char
+            if _measure(draw, candidate, font) <= max_width:
+                current = candidate
+                continue
+            if current:
+                lines.append(current.rstrip())
+                current = char.lstrip()
+            else:
+                lines.append(char)
+                current = ""
+        if current:
+            lines.append(current.rstrip())
+    return lines
+
+
+def _truncate_to_width(draw: ImageDraw.ImageDraw, text: str, font: ImageFont.ImageFont, max_width: int) -> str:
+    if _measure(draw, text, font) <= max_width:
+        return text
+    suffix = "..."
+    current = ""
+    for char in text:
+        candidate = current + char + suffix
+        if _measure(draw, candidate, font) > max_width:
+            break
+        current += char
+    return (current.rstrip() + suffix) if current else suffix
+
+
+def _load_image_preview(media: PostMedia, *, remote_timeout: float) -> _ImagePreview:
+    data = _read_source_bytes(media.source, max_bytes=12 * 1024 * 1024, remote_timeout=remote_timeout)
+    if not data:
+        return _ImagePreview(media=media, image=None, failed=True)
+    try:
+        with Image.open(io.BytesIO(data)) as opened:
+            opened.seek(0)
+            preview = ImageOps.exif_transpose(opened)
+            if preview.mode not in {"RGB", "RGBA"}:
+                preview = preview.convert("RGB")
+            elif preview.mode == "RGBA":
+                base = Image.new("RGB", preview.size, WHITE)
+                base.paste(preview, mask=preview.getchannel("A"))
+                preview = base
+            else:
+                preview = preview.copy()
+            preview.thumbnail((2048, 2048), Image.Resampling.LANCZOS)
+            return _ImagePreview(media=media, image=preview, failed=False)
+    except (OSError, UnidentifiedImageError):
+        return _ImagePreview(media=media, image=None, failed=True)
+
+
+def _read_source_bytes(source: str, *, max_bytes: int, remote_timeout: float) -> bytes:
+    source = str(source or "").strip()
+    if not source:
+        return b""
+    if source.startswith("base64://"):
+        try:
+            return base64.b64decode(source[len("base64://") :], validate=False)[:max_bytes]
+        except Exception:
+            return b""
+    if source.startswith("data:"):
+        try:
+            header, encoded = source.split(",", 1)
+        except ValueError:
+            return b""
+        if ";base64" in header:
+            try:
+                return base64.b64decode(encoded, validate=False)[:max_bytes]
+            except Exception:
+                return b""
+        return unquote_to_bytes(encoded)[:max_bytes]
+
+    parsed = urlparse(source)
+    if parsed.scheme.lower() in {"http", "https"}:
+        try:
+            with httpx.Client(timeout=httpx.Timeout(remote_timeout), follow_redirects=True, trust_env=False) as client:
+                response = client.get(source)
+            if response.status_code >= 400:
+                return b""
+            length = response.headers.get("content-length")
+            if length and int(length) > max_bytes:
+                return b""
+            return response.content[:max_bytes]
+        except Exception:
+            return b""
+
+    if source.startswith("file://"):
+        parsed = urlparse(source)
+        source = parsed.path or ""
+    path = Path(source)
+    try:
+        if not path.exists() or not path.is_file() or path.stat().st_size > max_bytes:
+            return b""
+        return path.read_bytes()
+    except OSError:
+        return b""
+
+
+def _image_block_height(previews: list[_ImagePreview], width: int) -> int:
+    if len(previews) == 1:
+        return _single_image_size(previews[0], width)[1]
+    cols = _grid_columns(len(previews))
+    gap = 8
+    tile = (width - gap * (cols - 1)) // cols
+    rows = math.ceil(len(previews) / cols)
+    return rows * tile + gap * (rows - 1)
+
+
+def _single_image_size(preview: _ImagePreview, width: int) -> tuple[int, int]:
+    max_w = min(width, 540)
+    max_h = 690
+    if preview.image is None:
+        return min(max_w, 420), 280
+    source_w, source_h = preview.image.size
+    if source_w <= 0 or source_h <= 0:
+        return min(max_w, 420), 280
+    scale = min(max_w / source_w, max_h / source_h)
+    if scale > 1:
+        scale = min(scale, 1.35)
+    return max(120, int(source_w * scale)), max(120, int(source_h * scale))
+
+
+def _grid_columns(count: int) -> int:
+    if count <= 1:
+        return 1
+    if count in {2, 4}:
+        return 2
+    return 3
+
+
+def _attachment_block_height(attachments: list[PostMedia], width: int) -> int:
+    cols = 2 if width >= 620 else 1
+    rows = math.ceil(len(attachments) / cols)
+    gap = 10
+    card_h = 76
+    return rows * card_h + gap * (rows - 1)
+
+
+def _draw_header(
+    draw: ImageDraw.ImageDraw,
+    image: Image.Image,
+    profile: RenderProfile,
+    margin: int,
+    name_font: ImageFont.ImageFont,
+    time_font: ImageFont.ImageFont,
+) -> None:
+    avatar_size = 76
+    avatar_x = margin
+    avatar_y = 26
+    _draw_avatar(draw, image, profile, avatar_x, avatar_y, avatar_size)
+    text_x = avatar_x + avatar_size + 18
+    _safe_text(draw, (text_x, 32), profile.nickname, name_font, TEXT)
+    _safe_text(draw, (text_x, 72), profile.time_text, time_font, MUTED)
+
+    x = image.width - 44
+    y = 32
+    draw.line([(x, y), (x + 10, y + 10), (x + 20, y)], fill=ACTION, width=3)
+
+
+def _draw_avatar(
+    draw: ImageDraw.ImageDraw,
+    image: Image.Image,
+    profile: RenderProfile,
+    x: int,
+    y: int,
+    size: int,
+) -> None:
+    avatar_media = PostMedia(kind="image", source=profile.avatar_source, name="avatar")
+    preview = _load_image_preview(avatar_media, remote_timeout=0.8) if profile.avatar_source else None
+    mask = Image.new("L", (size, size), 0)
+    mask_draw = ImageDraw.Draw(mask)
+    mask_draw.ellipse((0, 0, size - 1, size - 1), fill=255)
+    if preview and preview.image:
+        avatar = ImageOps.fit(preview.image, (size, size), method=Image.Resampling.LANCZOS)
+        image.paste(avatar, (x, y), mask)
+        return
+
+    color = _profile_color(profile.nickname or profile.user_id)
+    draw.ellipse((x, y, x + size, y + size), fill=color)
+    initial = (profile.nickname or profile.user_id or "Q")[:1].upper()
+    font = _font(34, bold=True)
+    box = draw.textbbox((0, 0), initial, font=font)
+    _safe_text(
+        draw,
+        (x + (size - (box[2] - box[0])) // 2, y + (size - (box[3] - box[1])) // 2 - 2),
+        initial,
+        font,
+        WHITE,
+    )
+
+
+def _profile_color(seed: str) -> tuple[int, int, int]:
+    palette = [
+        (73, 128, 200),
+        (74, 154, 126),
+        (196, 102, 86),
+        (143, 117, 190),
+        (201, 136, 73),
+    ]
+    return palette[sum(seed.encode("utf-8", "ignore")) % len(palette)]
+
+
+def _draw_image_block(
+    draw: ImageDraw.ImageDraw,
+    image: Image.Image,
+    previews: list[_ImagePreview],
+    x: int,
+    y: int,
+    width: int,
+    small_font: ImageFont.ImageFont,
+) -> None:
+    if len(previews) == 1:
+        target_w, target_h = _single_image_size(previews[0], width)
+        _draw_preview_tile(draw, image, previews[0], x, y, target_w, target_h, small_font, crop=False)
+        return
+
+    cols = _grid_columns(len(previews))
+    gap = 8
+    tile = (width - gap * (cols - 1)) // cols
+    for index, preview in enumerate(previews):
+        col = index % cols
+        row = index // cols
+        tx = x + col * (tile + gap)
+        ty = y + row * (tile + gap)
+        _draw_preview_tile(draw, image, preview, tx, ty, tile, tile, small_font, crop=True)
+
+
+def _draw_preview_tile(
+    draw: ImageDraw.ImageDraw,
+    image: Image.Image,
+    preview: _ImagePreview,
+    x: int,
+    y: int,
+    width: int,
+    height: int,
+    small_font: ImageFont.ImageFont,
+    *,
+    crop: bool,
+) -> None:
+    if preview.image is not None:
+        if crop:
+            rendered = ImageOps.fit(preview.image, (width, height), method=Image.Resampling.LANCZOS)
+        else:
+            rendered = ImageOps.contain(preview.image, (width, height), method=Image.Resampling.LANCZOS)
+            width, height = rendered.size
+        image.paste(rendered, (x, y))
+        return
+
+    draw.rectangle((x, y, x + width, y + height), fill=(244, 245, 247), outline=LINE)
+    label = source_name(preview.media.source) or preview.media.name or "image"
+    label = _truncate_to_width(draw, label, small_font, max(20, width - 24))
+    icon_w = min(64, max(42, width // 5))
+    icon_x = x + (width - icon_w) // 2
+    icon_y = y + max(18, (height - icon_w) // 2 - 12)
+    draw.rectangle((icon_x, icon_y, icon_x + icon_w, icon_y + icon_w), outline=ACTION, width=2)
+    draw.line((icon_x + 10, icon_y + icon_w - 14, icon_x + 24, icon_y + icon_w - 30), fill=ACTION, width=2)
+    draw.line((icon_x + 24, icon_y + icon_w - 30, icon_x + icon_w - 12, icon_y + icon_w - 10), fill=ACTION, width=2)
+    _safe_text(draw, (x + 12, y + height - 30), label, small_font, MUTED)
+
+
+def _draw_attachment_block(
+    draw: ImageDraw.ImageDraw,
+    attachments: list[PostMedia],
+    x: int,
+    y: int,
+    width: int,
+    meta_font: ImageFont.ImageFont,
+    small_font: ImageFont.ImageFont,
+) -> None:
+    cols = 2 if width >= 620 else 1
+    gap = 10
+    card_h = 76
+    card_w = (width - gap * (cols - 1)) // cols
+    for index, item in enumerate(attachments):
+        col = index % cols
+        row = index // cols
+        cx = x + col * (card_w + gap)
+        cy = y + row * (card_h + gap)
+        _draw_file_card(draw, item, cx, cy, card_w, card_h, meta_font, small_font)
+
+
+def _draw_file_card(
+    draw: ImageDraw.ImageDraw,
+    item: PostMedia,
+    x: int,
+    y: int,
+    width: int,
+    height: int,
+    meta_font: ImageFont.ImageFont,
+    small_font: ImageFont.ImageFont,
+) -> None:
+    draw.rounded_rectangle((x, y, x + width, y + height), radius=6, fill=CARD_BG, outline=LINE, width=1)
+    name = item.name or source_name(item.source) or item.kind or "file"
+    suffix = Path(name).suffix.lower()
+    color = FILE_COLORS.get(suffix, (91, 128, 167))
+    icon_x = x + 14
+    icon_y = y + 14
+    icon_w = 48
+    draw.rounded_rectangle((icon_x, icon_y, icon_x + icon_w, icon_y + icon_w), radius=5, fill=color)
+    ext = suffix[1:5].upper() if suffix else (item.kind or "FILE")[:4].upper()
+    ext_font = _font(13, bold=True)
+    box = draw.textbbox((0, 0), ext, font=ext_font)
+    _safe_text(
+        draw,
+        (icon_x + (icon_w - (box[2] - box[0])) // 2, icon_y + (icon_w - (box[3] - box[1])) // 2),
+        ext,
+        ext_font,
+        WHITE,
+    )
+    text_x = icon_x + icon_w + 12
+    title = _truncate_to_width(draw, name, meta_font, max(20, width - (text_x - x) - 12))
+    _safe_text(draw, (text_x, y + 13), title, meta_font, TEXT)
+    meta = item.mime_type or _format_size(item.size) or _kind_label(item.kind)
+    if item.size and item.mime_type:
+        meta = f"{item.mime_type} | {_format_size(item.size)}"
+    meta = _truncate_to_width(draw, meta, small_font, max(20, width - (text_x - x) - 12))
+    _safe_text(draw, (text_x, y + 43), meta, small_font, MUTED)
+
+
+def _kind_label(kind: str) -> str:
+    return {
+        "file": "file",
+        "video": "video",
+        "audio": "audio",
+        "record": "audio",
+        "voice": "audio",
+    }.get(kind, "attachment")
+
+
+def _format_size(size: int) -> str:
+    if not size:
+        return ""
+    value = float(size)
+    for unit in ("B", "KB", "MB", "GB"):
+        if value < 1024 or unit == "GB":
+            if unit == "B":
+                return f"{int(value)} {unit}"
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return ""
+
+
+def _draw_actions(draw: ImageDraw.ImageDraw, width: int, y: int) -> None:
+    spacing = 120
+    start_x = width - 294
+    _draw_like_icon(draw, start_x, y + 4)
+    _draw_comment_icon(draw, start_x + spacing, y + 4)
+    _draw_share_icon(draw, start_x + spacing * 2, y + 4)
+
+
+def _draw_like_icon(draw: ImageDraw.ImageDraw, x: int, y: int) -> None:
+    draw.rounded_rectangle((x + 4, y + 14, x + 12, y + 34), radius=2, fill=ACTION)
+    points = [
+        (x + 14, y + 34),
+        (x + 14, y + 15),
+        (x + 22, y + 4),
+        (x + 27, y + 6),
+        (x + 25, y + 17),
+        (x + 36, y + 17),
+        (x + 39, y + 21),
+        (x + 34, y + 34),
+    ]
+    draw.polygon(points, fill=ACTION)
+
+
+def _draw_comment_icon(draw: ImageDraw.ImageDraw, x: int, y: int) -> None:
+    draw.rounded_rectangle((x + 4, y + 8, x + 34, y + 30), radius=4, fill=ACTION)
+    draw.polygon([(x + 14, y + 30), (x + 14, y + 38), (x + 23, y + 30)], fill=ACTION)
+    for offset in (11, 19, 27):
+        draw.ellipse((x + offset, y + 17, x + offset + 4, y + 21), fill=WHITE)
+
+
+def _draw_share_icon(draw: ImageDraw.ImageDraw, x: int, y: int) -> None:
+    draw.line((x + 5, y + 34, x + 28, y + 13), fill=ACTION, width=5)
+    draw.polygon([(x + 25, y + 4), (x + 43, y + 17), (x + 25, y + 30)], fill=ACTION)
+
+
+def _draw_comment_box(
+    draw: ImageDraw.ImageDraw,
+    x: int,
+    y: int,
+    width: int,
+    height: int,
+    font: ImageFont.ImageFont,
+) -> None:
+    draw.rectangle((x, y, x + width, y + height), outline=LINE, width=1)
+    _safe_text(draw, (x + 16, y + 14), "\u8bc4\u8bba", font, MUTED)
+    camera_x = x + width - 48
+    camera_y = y + 13
+    draw.rounded_rectangle((camera_x, camera_y + 8, camera_x + 28, camera_y + 26), radius=3, fill=ACTION)
+    draw.rectangle((camera_x + 8, camera_y + 4, camera_x + 20, camera_y + 10), fill=ACTION)
+    draw.ellipse((camera_x + 9, camera_y + 12, camera_x + 19, camera_y + 22), fill=WHITE)
+    draw.ellipse((camera_x + 12, camera_y + 15, camera_x + 16, camera_y + 19), fill=ACTION)
+
+
+def _prune_output_dir(output_dir: Path, *, keep: int = 128, max_age_seconds: int = 3 * 24 * 3600) -> None:
+    try:
+        files = sorted(
+            [path for path in output_dir.glob("publish_result_*.png") if path.is_file()],
+            key=lambda path: path.stat().st_mtime,
+            reverse=True,
+        )
+    except OSError:
+        return
+    cutoff = time.time() - max_age_seconds
+    for index, path in enumerate(files):
+        try:
+            if index >= keep or path.stat().st_mtime < cutoff:
+                os.remove(path)
+        except OSError:
+            continue

--- a/qzone_bridge/publish_renderer.py
+++ b/qzone_bridge/publish_renderer.py
@@ -173,9 +173,7 @@ def render_publish_result_image(
         y += attachment_height + 18
     actions_y = y + 6
     comment_y = actions_y + 54
-    footer = _result_footer(result)
-    footer_height = _line_height(scratch, meta_font, 1.2) + 10 if footer else 0
-    height = max(240, comment_y + 56 + footer_height + 22)
+    height = max(240, comment_y + 56 + 22)
 
     image = Image.new("RGB", (width, height), WHITE)
     draw = ImageDraw.Draw(image)
@@ -198,8 +196,6 @@ def render_publish_result_image(
     _draw_actions(draw, width, actions_y)
     comment_y = actions_y + 54
     _draw_comment_box(draw, margin, comment_y, content_width, 52, meta_font)
-    if footer:
-        _safe_text(draw, (margin, comment_y + 64), footer, meta_font, MUTED)
 
     path = output_dir / f"publish_result_{int(time.time())}_{uuid.uuid4().hex[:10]}.png"
     image.save(path, "PNG", optimize=True)
@@ -208,15 +204,6 @@ def render_publish_result_image(
 
 def _render_content_text(post: PostPayload) -> str:
     return str(post.content or "").strip()
-
-
-def _result_footer(result: dict[str, Any] | None) -> str:
-    if not isinstance(result, dict):
-        return ""
-    fid = result.get("fid") or result.get("tid") or result.get("id")
-    if fid:
-        return f"fid: {fid}"
-    return ""
 
 
 def _font(size: int, bold: bool = False) -> ImageFont.ImageFont:
@@ -674,8 +661,8 @@ def _draw_comment_icon(draw: ImageDraw.ImageDraw, x: int, y: int) -> None:
 
 
 def _draw_share_icon(draw: ImageDraw.ImageDraw, x: int, y: int) -> None:
-    draw.line((x + 5, y + 34, x + 28, y + 13), fill=ACTION, width=5)
-    draw.polygon([(x + 25, y + 4), (x + 43, y + 17), (x + 25, y + 30)], fill=ACTION)
+    draw.line([(x + 6, y + 34), (x + 19, y + 22), (x + 29, y + 22)], fill=ACTION, width=5, joint="curve")
+    draw.polygon([(x + 27, y + 9), (x + 45, y + 22), (x + 27, y + 35)], fill=ACTION)
 
 
 def _draw_comment_box(

--- a/qzone_bridge/settings.py
+++ b/qzone_bridge/settings.py
@@ -69,6 +69,8 @@ class PluginSettings:
     admin_uins: list[int] = field(default_factory=list)
     user_agent: str = DEFAULT_USER_AGENT
     preview_writes: bool = True
+    render_publish_result: bool = True
+    render_result_width: int = 900
 
     @classmethod
     def from_mapping(cls, config: Any) -> "PluginSettings":
@@ -92,4 +94,6 @@ class PluginSettings:
             admin_uins=[int(v) for v in admin_uins if str(v).isdigit()],
             user_agent=str(_pick(mapping, "user_agent", DEFAULT_USER_AGENT) or DEFAULT_USER_AGENT),
             preview_writes=_as_bool(_pick(mapping, "preview_writes", True), True),
+            render_publish_result=_as_bool(_pick(mapping, "render_publish_result", True), True),
+            render_result_width=int(_pick(mapping, "render_result_width", 900) or 900),
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 httpx>=0.27,<1
 # AstrBot 4.24.x ships aiohttp 3.13.5; keep this aligned with the core runtime.
 aiohttp>=3.13.5,<4
-Pillow>=10,<12
+Pillow>=10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 httpx>=0.27,<1
 # AstrBot 4.24.x ships aiohttp 3.13.5; keep this aligned with the core runtime.
 aiohttp>=3.13.5,<4
+Pillow>=10,<12

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -5,7 +5,7 @@ import tempfile
 import types
 import unittest
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 
 class Plain:
@@ -19,6 +19,7 @@ class Event:
         self.message_str = message_str
         self.stopped = False
         self.images = []
+        self.bot = None
 
     def is_admin(self):
         return True
@@ -142,7 +143,8 @@ class MainPublishTests(unittest.TestCase):
         plugin._ensure_cookie_ready = AsyncMock()
         plugin._ensure_daemon = AsyncMock()
         plugin.controller = types.SimpleNamespace(
-            publish_post=AsyncMock(return_value={"fid": "fid-1", "message": "ok"})
+            get_status=AsyncMock(return_value={"login_uin": 0}),
+            publish_post=AsyncMock(return_value={"fid": "fid-1", "message": "ok"}),
         )
         return plugin
 
@@ -233,6 +235,33 @@ class MainPublishTests(unittest.TestCase):
         self.assertEqual(plugin.controller.publish_post.await_args.kwargs["media"], [])
         self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "report\n[文件: report.pdf]")
         self.assertTrue(Path(results[0]["image"]).exists())
+
+    def test_qzone_post_renders_logged_in_qzone_publisher(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin.controller.get_status = AsyncMock(return_value={"login_uin": 123456})
+        fake_image = plugin.data_dir / "rendered.png"
+        fake_image.write_bytes(b"png")
+        captured = {}
+
+        async def get_stranger_info(**kwargs):
+            self.assertEqual(kwargs["user_id"], 123456)
+            return {"nickname": "QzoneOwner"}
+
+        event = Event([Plain("/qzone post hello")])
+        event.bot = types.SimpleNamespace(get_stranger_info=get_stranger_info)
+
+        def fake_render(post, output_dir, **kwargs):
+            captured.update(kwargs)
+            return fake_image
+
+        with patch.object(module, "render_publish_result_image", side_effect=fake_render):
+            results = asyncio.run(collect_async_generator(plugin.qzone_post(event, content="/qzone post hello")))
+
+        self.assertEqual(results, [{"image": str(fake_image)}])
+        self.assertEqual(captured["profile"].nickname, "QzoneOwner")
+        self.assertEqual(captured["profile"].user_id, "123456")
+        self.assertIn("123456", captured["profile"].avatar_source)
 
 
 if __name__ == "__main__":

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib.util
 import sys
+import tempfile
 import types
 import unittest
 from pathlib import Path
@@ -17,6 +18,7 @@ class Event:
         self.message_obj = types.SimpleNamespace(message=components)
         self.message_str = message_str
         self.stopped = False
+        self.images = []
 
     def is_admin(self):
         return True
@@ -26,6 +28,16 @@ class Event:
 
     def plain_result(self, text):
         return text
+
+    def image_result(self, path):
+        self.images.append(path)
+        return {"image": path}
+
+
+class File:
+    def __init__(self, file, name=""):
+        self.file = file
+        self.name = name
 
 
 def install_astrbot_stubs():
@@ -124,6 +136,9 @@ class MainPublishTests(unittest.TestCase):
 
     def make_plugin(self, module):
         plugin = module.QzoneStablePlugin(types.SimpleNamespace(), config={"admin_uins": []})
+        data_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(data_dir.cleanup)
+        plugin.data_dir = Path(data_dir.name)
         plugin._ensure_cookie_ready = AsyncMock()
         plugin._ensure_daemon = AsyncMock()
         plugin.controller = types.SimpleNamespace(
@@ -195,6 +210,29 @@ class MainPublishTests(unittest.TestCase):
         plugin.controller.publish_post.assert_awaited_once()
         self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "1")
         self.assertTrue(plugin.controller.publish_post.await_args.kwargs["content_sanitized"])
+
+    def test_qzone_post_returns_rendered_image_result(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        event = Event([Plain("/qzone post hello")])
+
+        results = asyncio.run(collect_async_generator(plugin.qzone_post(event, content="/qzone post hello")))
+
+        self.assertEqual(len(results), 1)
+        self.assertIn("image", results[0])
+        self.assertTrue(Path(results[0]["image"]).exists())
+
+    def test_qzone_post_keeps_files_out_of_publish_media_but_renders_success(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        event = Event([Plain("/qzone post report "), File(file="report.pdf", name="report.pdf")])
+
+        results = asyncio.run(collect_async_generator(plugin.qzone_post(event, content="/qzone post report")))
+
+        plugin.controller.publish_post.assert_awaited_once()
+        self.assertEqual(plugin.controller.publish_post.await_args.kwargs["media"], [])
+        self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "report\n[文件: report.pdf]")
+        self.assertTrue(Path(results[0]["image"]).exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -306,6 +306,8 @@ class MediaPayloadTests(unittest.TestCase):
         )
 
         self.assertEqual(payload.media, [])
+        self.assertEqual(len(payload.attachments), 1)
+        self.assertEqual(payload.attachments[0].name, "notes.txt")
         self.assertEqual(payload.content, "report\n[文件: notes.txt]")
 
     def test_llm_mode_keeps_explicit_content_and_file_reference(self):
@@ -317,6 +319,8 @@ class MediaPayloadTests(unittest.TestCase):
 
         self.assertEqual(payload.content, "weekly report\n[文件: report.pdf]")
         self.assertEqual(payload.media, [])
+        self.assertEqual(len(payload.attachments), 1)
+        self.assertEqual(payload.attachments[0].name, "report.pdf")
 
     def test_stringified_image_fallback_is_ignored_when_image_component_exists(self):
         payload = collect_post_payload(

--- a/tests/test_publish_renderer.py
+++ b/tests/test_publish_renderer.py
@@ -1,0 +1,79 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from PIL import Image, ImageChops
+
+from qzone_bridge.media import PostMedia, PostPayload
+from qzone_bridge.publish_renderer import RenderProfile, render_publish_result_image
+
+
+class PublishRendererTests(unittest.TestCase):
+    def make_image(self, path: Path, size: tuple[int, int], color: tuple[int, int, int]) -> None:
+        image = Image.new("RGB", size, color)
+        image.save(path)
+
+    def test_render_text_images_and_files_to_png(self):
+        with tempfile.TemporaryDirectory() as temp:
+            temp_path = Path(temp)
+            photo_a = temp_path / "a.jpg"
+            photo_b = temp_path / "b.png"
+            self.make_image(photo_a, (320, 640), (120, 180, 210))
+            self.make_image(photo_b, (520, 280), (210, 150, 100))
+
+            post = PostPayload(
+                content="hello from qzone\nsecond line wraps cleanly",
+                media=[
+                    PostMedia(kind="image", source=str(photo_a), name="a.jpg"),
+                    PostMedia(kind="image", source=str(photo_b), name="b.png"),
+                ],
+                attachments=[
+                    PostMedia(
+                        kind="file",
+                        source="report.pdf",
+                        name="report.pdf",
+                        mime_type="application/pdf",
+                        size=2048,
+                    )
+                ],
+            )
+
+            rendered = render_publish_result_image(
+                post,
+                temp_path,
+                profile=RenderProfile(nickname="Coconut", time_text="06:34"),
+                result={"fid": "fid-1"},
+                width=760,
+            )
+
+            self.assertTrue(rendered.exists())
+            with Image.open(rendered) as image:
+                self.assertEqual(image.format, "PNG")
+                self.assertEqual(image.width, 760)
+                self.assertGreater(image.height, 400)
+                diff = ImageChops.difference(image.convert("RGB"), Image.new("RGB", image.size, "white"))
+                self.assertIsNotNone(diff.getbbox())
+
+    def test_render_missing_image_source_uses_placeholder(self):
+        with tempfile.TemporaryDirectory() as temp:
+            temp_path = Path(temp)
+            post = PostPayload(
+                content="image placeholder",
+                media=[PostMedia(kind="image", source=str(temp_path / "missing.jpg"), name="missing.jpg")],
+            )
+
+            rendered = render_publish_result_image(
+                post,
+                temp_path,
+                profile=RenderProfile(nickname="Coconut", time_text="06:34"),
+                width=700,
+            )
+
+            self.assertTrue(rendered.exists())
+            with Image.open(rendered) as image:
+                self.assertEqual(image.format, "PNG")
+                self.assertEqual(image.width, 700)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_publish_renderer.py
+++ b/tests/test_publish_renderer.py
@@ -2,10 +2,10 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from PIL import Image, ImageChops
+from PIL import Image, ImageChops, ImageDraw
 
 from qzone_bridge.media import PostMedia, PostPayload
-from qzone_bridge.publish_renderer import RenderProfile, render_publish_result_image
+from qzone_bridge.publish_renderer import ACTION, RenderProfile, _draw_share_icon, render_publish_result_image
 
 
 class PublishRendererTests(unittest.TestCase):
@@ -73,6 +73,42 @@ class PublishRendererTests(unittest.TestCase):
             with Image.open(rendered) as image:
                 self.assertEqual(image.format, "PNG")
                 self.assertEqual(image.width, 700)
+
+    def test_result_fid_does_not_add_footer(self):
+        with tempfile.TemporaryDirectory() as temp:
+            temp_path = Path(temp)
+            post = PostPayload(content="no footer", media=[])
+
+            without_result = render_publish_result_image(
+                post,
+                temp_path,
+                profile=RenderProfile(nickname="Coconut", time_text="06:34"),
+                width=700,
+            )
+            with_result = render_publish_result_image(
+                post,
+                temp_path,
+                profile=RenderProfile(nickname="Coconut", time_text="06:34"),
+                result={"fid": "fid-1"},
+                width=700,
+            )
+
+            with Image.open(without_result) as base, Image.open(with_result) as rendered:
+                self.assertEqual(rendered.size, base.size)
+
+    def test_share_icon_stays_within_action_bounds(self):
+        image = Image.new("RGB", (70, 60), "white")
+        draw = ImageDraw.Draw(image)
+
+        _draw_share_icon(draw, 10, 10)
+
+        mask = ImageChops.difference(image, Image.new("RGB", image.size, "white"))
+        bbox = mask.getbbox()
+        self.assertIsNotNone(bbox)
+        self.assertGreater(bbox[2] - bbox[0], 28)
+        self.assertLessEqual(bbox[2], 56)
+        self.assertLessEqual(bbox[3], 46)
+        self.assertIn(ACTION, image.getdata())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
﻿## Summary

- Render the post card publisher from the logged-in Qzone account instead of the command sender, with QQ avatar URL fallback and OneBot nickname lookup when available.
- Remove the `fid:` footer from rendered publish result images.
- Redraw the share action icon so it stays within a stable action-button box.

## Validation

- `python -m compileall qzone_bridge main.py`
- `python -m unittest tests.test_main_publish tests.test_publish_renderer`
- `python -m unittest discover -s tests` (89 tests)
