### PR TITLE
[codex] Fix Qzone result render polish

### DIFF
--- a/main.py
+++ b/main.py
@@ -92,17 +92,78 @@ class QzoneStablePlugin(Star):
         self._stop_event(event)
         return event.plain_result(text)
 
+    async def _publisher_render_profile(self, event: AstrMessageEvent) -> Any:
+        profile = profile_from_event(event)
+        status: dict[str, Any] = {}
+        try:
+            status = await self.controller.get_status()
+        except QzoneBridgeError:
+            status = {}
+
+        login_uin = int(status.get("login_uin") or 0)
+        if not login_uin:
+            return profile
+
+        nickname = str(
+            status.get("login_nickname")
+            or status.get("nickname")
+            or status.get("publisher_nickname")
+            or ""
+        ).strip()
+        avatar_source = str(status.get("login_avatar") or status.get("avatar") or "").strip()
+        if not avatar_source:
+            avatar_source = f"https://q1.qlogo.cn/g?b=qq&nk={login_uin}&s=100"
+
+        bot = self._capture_onebot_client(event)
+        if bot is not None:
+            fetched = await self._fetch_onebot_user_info(bot, login_uin)
+            if fetched:
+                nickname = nickname or str(fetched.get("nickname") or fetched.get("name") or "").strip()
+                avatar_source = str(fetched.get("avatar") or fetched.get("avatar_url") or avatar_source).strip()
+
+        profile.user_id = str(login_uin)
+        profile.nickname = nickname or str(login_uin)
+        profile.avatar_source = avatar_source
+        return profile
+
+    async def _fetch_onebot_user_info(self, bot: Any, uin: int) -> dict[str, Any]:
+        for method_name, kwargs in (
+            ("get_stranger_info", {"user_id": uin, "no_cache": False}),
+            ("get_friend_info", {"user_id": uin}),
+            ("get_user_info", {"user_id": uin}),
+        ):
+            method = getattr(bot, method_name, None)
+            if not callable(method):
+                continue
+            try:
+                result = method(**kwargs)
+                if asyncio.iscoroutine(result):
+                    result = await result
+            except TypeError:
+                try:
+                    result = method(uin)
+                    if asyncio.iscoroutine(result):
+                        result = await result
+                except Exception:
+                    continue
+            except Exception:
+                continue
+            if isinstance(result, dict):
+                return result
+        return {}
+
     async def _publish_result(self, event: AstrMessageEvent, post: PostPayload, payload: dict[str, Any]):
         text = format_action_result("发布成功", payload)
         if not self.settings.render_publish_result:
             self._stop_event(event)
             return event.plain_result(text)
+        profile = await self._publisher_render_profile(event)
         try:
             image_path = await asyncio.to_thread(
                 render_publish_result_image,
                 post,
                 self.data_dir / "rendered_posts",
-                profile=profile_from_event(event),
+                profile=profile,
                 result=payload,
                 width=self.settings.render_result_width,
             )

--- a/qzone_bridge/publish_renderer.py
+++ b/qzone_bridge/publish_renderer.py
@@ -173,9 +173,7 @@ def render_publish_result_image(
         y += attachment_height + 18
     actions_y = y + 6
     comment_y = actions_y + 54
-    footer = _result_footer(result)
-    footer_height = _line_height(scratch, meta_font, 1.2) + 10 if footer else 0
-    height = max(240, comment_y + 56 + footer_height + 22)
+    height = max(240, comment_y + 56 + 22)
 
     image = Image.new("RGB", (width, height), WHITE)
     draw = ImageDraw.Draw(image)
@@ -198,8 +196,6 @@ def render_publish_result_image(
     _draw_actions(draw, width, actions_y)
     comment_y = actions_y + 54
     _draw_comment_box(draw, margin, comment_y, content_width, 52, meta_font)
-    if footer:
-        _safe_text(draw, (margin, comment_y + 64), footer, meta_font, MUTED)
 
     path = output_dir / f"publish_result_{int(time.time())}_{uuid.uuid4().hex[:10]}.png"
     image.save(path, "PNG", optimize=True)
@@ -208,15 +204,6 @@ def render_publish_result_image(
 
 def _render_content_text(post: PostPayload) -> str:
     return str(post.content or "").strip()
-
-
-def _result_footer(result: dict[str, Any] | None) -> str:
-    if not isinstance(result, dict):
-        return ""
-    fid = result.get("fid") or result.get("tid") or result.get("id")
-    if fid:
-        return f"fid: {fid}"
-    return ""
 
 
 def _font(size: int, bold: bool = False) -> ImageFont.ImageFont:
@@ -674,8 +661,8 @@ def _draw_comment_icon(draw: ImageDraw.ImageDraw, x: int, y: int) -> None:
 
 
 def _draw_share_icon(draw: ImageDraw.ImageDraw, x: int, y: int) -> None:
-    draw.line((x + 5, y + 34, x + 28, y + 13), fill=ACTION, width=5)
-    draw.polygon([(x + 25, y + 4), (x + 43, y + 17), (x + 25, y + 30)], fill=ACTION)
+    draw.line([(x + 6, y + 34), (x + 19, y + 22), (x + 29, y + 22)], fill=ACTION, width=5, joint="curve")
+    draw.polygon([(x + 27, y + 9), (x + 45, y + 22), (x + 27, y + 35)], fill=ACTION)
 
 
 def _draw_comment_box(

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -5,7 +5,7 @@ import tempfile
 import types
 import unittest
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 
 class Plain:
@@ -19,6 +19,7 @@ class Event:
         self.message_str = message_str
         self.stopped = False
         self.images = []
+        self.bot = None
 
     def is_admin(self):
         return True
@@ -142,7 +143,8 @@ class MainPublishTests(unittest.TestCase):
         plugin._ensure_cookie_ready = AsyncMock()
         plugin._ensure_daemon = AsyncMock()
         plugin.controller = types.SimpleNamespace(
-            publish_post=AsyncMock(return_value={"fid": "fid-1", "message": "ok"})
+            get_status=AsyncMock(return_value={"login_uin": 0}),
+            publish_post=AsyncMock(return_value={"fid": "fid-1", "message": "ok"}),
         )
         return plugin
 
@@ -233,6 +235,33 @@ class MainPublishTests(unittest.TestCase):
         self.assertEqual(plugin.controller.publish_post.await_args.kwargs["media"], [])
         self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "report\n[文件: report.pdf]")
         self.assertTrue(Path(results[0]["image"]).exists())
+
+    def test_qzone_post_renders_logged_in_qzone_publisher(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin.controller.get_status = AsyncMock(return_value={"login_uin": 123456})
+        fake_image = plugin.data_dir / "rendered.png"
+        fake_image.write_bytes(b"png")
+        captured = {}
+
+        async def get_stranger_info(**kwargs):
+            self.assertEqual(kwargs["user_id"], 123456)
+            return {"nickname": "QzoneOwner"}
+
+        event = Event([Plain("/qzone post hello")])
+        event.bot = types.SimpleNamespace(get_stranger_info=get_stranger_info)
+
+        def fake_render(post, output_dir, **kwargs):
+            captured.update(kwargs)
+            return fake_image
+
+        with patch.object(module, "render_publish_result_image", side_effect=fake_render):
+            results = asyncio.run(collect_async_generator(plugin.qzone_post(event, content="/qzone post hello")))
+
+        self.assertEqual(results, [{"image": str(fake_image)}])
+        self.assertEqual(captured["profile"].nickname, "QzoneOwner")
+        self.assertEqual(captured["profile"].user_id, "123456")
+        self.assertIn("123456", captured["profile"].avatar_source)
 
 
 if __name__ == "__main__":

--- a/tests/test_publish_renderer.py
+++ b/tests/test_publish_renderer.py
@@ -2,10 +2,10 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from PIL import Image, ImageChops
+from PIL import Image, ImageChops, ImageDraw
 
 from qzone_bridge.media import PostMedia, PostPayload
-from qzone_bridge.publish_renderer import RenderProfile, render_publish_result_image
+from qzone_bridge.publish_renderer import ACTION, RenderProfile, _draw_share_icon, render_publish_result_image
 
 
 class PublishRendererTests(unittest.TestCase):
@@ -73,6 +73,42 @@ class PublishRendererTests(unittest.TestCase):
             with Image.open(rendered) as image:
                 self.assertEqual(image.format, "PNG")
                 self.assertEqual(image.width, 700)
+
+    def test_result_fid_does_not_add_footer(self):
+        with tempfile.TemporaryDirectory() as temp:
+            temp_path = Path(temp)
+            post = PostPayload(content="no footer", media=[])
+
+            without_result = render_publish_result_image(
+                post,
+                temp_path,
+                profile=RenderProfile(nickname="Coconut", time_text="06:34"),
+                width=700,
+            )
+            with_result = render_publish_result_image(
+                post,
+                temp_path,
+                profile=RenderProfile(nickname="Coconut", time_text="06:34"),
+                result={"fid": "fid-1"},
+                width=700,
+            )
+
+            with Image.open(without_result) as base, Image.open(with_result) as rendered:
+                self.assertEqual(rendered.size, base.size)
+
+    def test_share_icon_stays_within_action_bounds(self):
+        image = Image.new("RGB", (70, 60), "white")
+        draw = ImageDraw.Draw(image)
+
+        _draw_share_icon(draw, 10, 10)
+
+        mask = ImageChops.difference(image, Image.new("RGB", image.size, "white"))
+        bbox = mask.getbbox()
+        self.assertIsNotNone(bbox)
+        self.assertGreater(bbox[2] - bbox[0], 28)
+        self.assertLessEqual(bbox[2], 56)
+        self.assertLessEqual(bbox[3], 46)
+        self.assertIn(ACTION, image.getdata())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
﻿## Summary

- Render the publish result card with the logged-in Qzone account instead of the command sender, using Qzone `login_uin`, QQ avatar fallback, and OneBot nickname lookup when available.
- Remove the bottom `fid:` footer from generated publish result images.
- Redraw the share action icon to avoid the deformed arrow shape.

## Validation

- `python -m compileall qzone_bridge main.py`
- `python -m unittest tests.test_main_publish tests.test_publish_renderer`
- `python -m unittest discover -s tests` (89 tests)
