### PR TITLE
[codex] Speed up Qzone post publishing

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,6 +66,7 @@ class QzoneStablePlugin(Star):
             auto_start_daemon=self.settings.auto_start_daemon,
         )
         self._capture_onebot_client_from_context()
+        self._daemon_warmup_task: asyncio.Task | None = None
 
     def _sender_id(self, event: AstrMessageEvent) -> int:
         try:
@@ -212,7 +213,7 @@ class QzoneStablePlugin(Star):
                 raise QzoneCookieAcquireError(f"未捕获到 OneBot 客户端，无法自动获取 Cookie。{self._cookie_binding_hint()}")
 
             try:
-                status = await self.controller.get_status()
+                status = await self.controller.get_status(probe_daemon=False)
             except QzoneBridgeError:
                 status = {}
 
@@ -238,7 +239,7 @@ class QzoneStablePlugin(Star):
         source: str = "aiocqhttp",
     ) -> dict[str, Any] | None:
         try:
-            status = await self.controller.get_status()
+            status = await self.controller.get_status(probe_daemon=False)
         except QzoneBridgeError:
             status = {}
         if not force and status and int(status.get("cookie_count") or 0) > 0 and not bool(status.get("needs_rebind")):
@@ -248,11 +249,43 @@ class QzoneStablePlugin(Star):
     async def _bootstrap_auto_bind(self, trigger: str) -> None:
         client = self._capture_onebot_client_from_context()
         if client is None or not self.settings.auto_bind_cookie:
+            await self._prewarm_daemon_if_cookie_ready(trigger)
             return
         try:
             await self._ensure_cookie_ready(source="aiocqhttp")
         except QzoneBridgeError as exc:
             logger.warning("qzone auto bind on %s failed: %s", trigger, exc)
+            return
+        await self._prewarm_daemon_if_cookie_ready(trigger)
+
+    async def _prewarm_daemon_if_cookie_ready(self, trigger: str) -> None:
+        if not self.settings.auto_start_daemon:
+            return
+        try:
+            status = await self.controller.get_status(probe_daemon=False)
+        except QzoneBridgeError as exc:
+            logger.debug("qzone daemon prewarm status check on %s failed: %s", trigger, exc)
+            return
+        if int(status.get("cookie_count") or 0) <= 0 or bool(status.get("needs_rebind")):
+            return
+        self._schedule_daemon_warmup(trigger)
+
+    def _schedule_daemon_warmup(self, trigger: str) -> None:
+        if not self.settings.auto_start_daemon:
+            return
+        task = self._daemon_warmup_task
+        if task is not None and not task.done():
+            return
+
+        async def runner() -> None:
+            try:
+                await self.controller.ensure_running()
+            except QzoneBridgeError as exc:
+                logger.warning("qzone daemon prewarm on %s failed: %s", trigger, exc)
+            except Exception:
+                logger.warning("qzone daemon prewarm on %s failed unexpectedly", trigger, exc_info=True)
+
+        self._daemon_warmup_task = asyncio.create_task(runner())
 
     @filter.command_group("qzone")
     def qzone(self):
@@ -315,6 +348,7 @@ class QzoneStablePlugin(Star):
             logger.warning("qzone bind failed: %s", exc)
             yield self._command_result(event, self._error_text(exc))
             return
+        self._schedule_daemon_warmup("manual bind")
         yield self._command_result(event, format_status(payload))
 
     @qzone.command("autobind")
@@ -328,6 +362,7 @@ class QzoneStablePlugin(Star):
             logger.warning("qzone autobind failed: %s", exc)
             yield self._command_result(event, self._error_text(exc))
             return
+        self._schedule_daemon_warmup("autobind")
         yield self._command_result(event, format_status(payload))
 
     @qzone.command("unbind")
@@ -384,7 +419,6 @@ class QzoneStablePlugin(Star):
         )
         try:
             await self._ensure_cookie_ready(event)
-            await self._ensure_daemon()
             payload = await self.controller.publish_post(
                 content=post.content,
                 media=[item.to_dict() for item in post.media],
@@ -516,7 +550,6 @@ class QzoneStablePlugin(Star):
             return
         try:
             await self._ensure_cookie_ready(event)
-            await self._ensure_daemon()
             payload = await self.controller.publish_post(
                 content=post.content,
                 sync_weibo=sync_weibo,

--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -638,15 +638,43 @@ class QzoneClient:
     async def _prepare_publish_photos(self, photos: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
         if photos and len(photos) > QZONE_MAX_IMAGES:
             raise QzoneParseError(f"QQ空间说说最多支持 {QZONE_MAX_IMAGES} 张图片")
-        prepared: list[dict[str, Any]] = []
-        for photo in photos or []:
+        source_photos = list(photos or [])
+        prepared: list[dict[str, Any] | None] = [None] * len(source_photos)
+        pending: list[tuple[int, dict[str, Any]]] = []
+        for index, photo in enumerate(source_photos):
             if isinstance(photo, dict) and photo.get("richval"):
-                prepared.append(photo)
+                prepared[index] = photo
                 continue
-            prepared.append(await self.upload_photo(photo))
-        if len(prepared) > QZONE_MAX_IMAGES:
+            pending.append((index, photo))
+
+        async def upload_limited(index: int, photo: dict[str, Any], semaphore: asyncio.Semaphore) -> tuple[int, dict[str, Any]]:
+            async with semaphore:
+                return index, await self.upload_photo(photo)
+
+        if len(pending) == 1:
+            index, photo = pending[0]
+            prepared[index] = await self.upload_photo(photo)
+        elif pending:
+            semaphore = asyncio.Semaphore(min(3, len(pending)))
+            results = await asyncio.gather(
+                *(upload_limited(index, photo, semaphore) for index, photo in pending),
+                return_exceptions=True,
+            )
+            errors = [result for result in results if isinstance(result, Exception)]
+            if errors:
+                if not all(isinstance(error, QzoneRequestError) for error in errors):
+                    raise errors[0]
+                log.debug("parallel qzone image upload failed; retrying sequentially", exc_info=errors[0])
+                for index, photo in pending:
+                    prepared[index] = await self.upload_photo(photo)
+            else:
+                for index, payload in results:
+                    prepared[index] = payload
+
+        final = [photo for photo in prepared if photo is not None]
+        if len(final) > QZONE_MAX_IMAGES:
             raise QzoneParseError(f"QQ空间说说最多支持 {QZONE_MAX_IMAGES} 张图片")
-        return prepared
+        return final
 
     async def publish_mood(self, content: str, *, sync_weibo: bool = False, photos: list[dict[str, Any]] | None = None) -> dict[str, Any]:
         photos = await self._prepare_publish_photos(photos)

--- a/qzone_bridge/controller.py
+++ b/qzone_bridge/controller.py
@@ -157,27 +157,38 @@ class QzoneDaemonController:
         self._client = httpx.AsyncClient(timeout=httpx.Timeout(request_timeout), trust_env=False)
         self._lock = asyncio.Lock()
         self._process: subprocess.Popen | None = None
+        self._health_cache: tuple[int, str, bool, float] | None = None
+        self._health_cache_ttl = 1.0
 
     def _runtime(self):
-        state = ensure_state_secret(self.store.read())
+        state = self.store.read()
+        original_secret = state.runtime.secret
+        original_started_at = state.runtime.started_at
+        original_port = state.runtime.daemon_port
+        state = ensure_state_secret(state)
         if not state.runtime.daemon_port:
             state.runtime.daemon_port = self.default_port
-        if not state.runtime.secret:
-            import secrets
-
-            state.runtime.secret = secrets.token_urlsafe(32)
-        self.store.write(state)
+        if (
+            state.runtime.secret != original_secret
+            or state.runtime.started_at != original_started_at
+            or state.runtime.daemon_port != original_port
+        ):
+            self.store.write(state)
         return state.runtime
 
     def _base_url(self, port: int | None = None) -> str:
-        runtime = self._runtime()
-        return f"http://127.0.0.1:{port or runtime.daemon_port}"
+        if port is None:
+            port = self._runtime().daemon_port
+        return f"http://127.0.0.1:{port}"
 
     def _secret(self) -> str:
         return self._runtime().secret
 
     def _daemon_script(self) -> Path:
         return self.plugin_root / "daemon_main.py"
+
+    def _invalidate_health_cache(self) -> None:
+        self._health_cache = None
 
     def _spawn_daemon(self, port: int) -> subprocess.Popen:
         runtime = self._runtime()
@@ -207,29 +218,80 @@ class QzoneDaemonController:
         kwargs["env"] = env
         return subprocess.Popen(cmd, cwd=str(self.plugin_root), **kwargs)
 
-    async def _probe_health(self, port: int | None = None, *, secret: str | None = None) -> bool:
+    async def _probe_health(
+        self,
+        port: int | None = None,
+        *,
+        secret: str | None = None,
+        use_cache: bool = True,
+    ) -> bool:
         runtime = self._runtime()
+        resolved_port = int(port or runtime.daemon_port or self.default_port or 0)
+        resolved_secret = secret or runtime.secret
+        if not resolved_port or not resolved_secret:
+            self._invalidate_health_cache()
+            return False
+
+        now = asyncio.get_running_loop().time()
+        if use_cache and self._health_cache:
+            cached_port, cached_secret, cached_ok, expires_at = self._health_cache
+            if cached_port == resolved_port and cached_secret == resolved_secret and expires_at > now:
+                return cached_ok
+
         try:
             response = await self._client.get(
-                f"{self._base_url(port)}/health",
-                headers={SECRET_HEADER: secret or runtime.secret},
+                f"{self._base_url(resolved_port)}/health",
+                headers={SECRET_HEADER: resolved_secret},
             )
         except httpx.HTTPError:
+            self._invalidate_health_cache()
             return False
         if response.status_code != 200:
+            self._invalidate_health_cache()
             return False
         try:
             payload = response.json()
         except Exception:
+            self._invalidate_health_cache()
             return False
-        return bool(payload.get("ok"))
+        ok = bool(payload.get("ok"))
+        if ok:
+            self._health_cache = (
+                resolved_port,
+                resolved_secret,
+                True,
+                now + self._health_cache_ttl,
+            )
+        else:
+            self._invalidate_health_cache()
+        return ok
+
+    def _status_from_state(self, state, *, daemon_state: str) -> dict[str, Any]:
+        runtime = state.runtime
+        return {
+            "daemon_state": daemon_state,
+            "daemon_pid": runtime.daemon_pid,
+            "daemon_port": runtime.daemon_port or self.default_port,
+            "daemon_version": runtime.version,
+            "started_at": runtime.started_at,
+            "last_seen_at": runtime.last_seen_at,
+            "login_uin": state.session.uin,
+            "cookie_summary": self.cookie_summary(state.session.cookies),
+            "cookie_count": len(state.session.cookies),
+            "needs_rebind": state.session.needs_rebind or not bool(state.session.cookies),
+            "last_ok_at": state.session.last_ok_at,
+            "last_error": state.session.last_error,
+            "qzonetoken_hosts": sorted(int(k) for k in state.session.qzonetokens.keys() if str(k).isdigit()),
+            "feed_cache_size": 0,
+            "session_revision": state.session.revision,
+        }
 
     async def ensure_running(self) -> dict[str, Any]:
         async with self._lock:
             runtime = self._runtime()
             port = runtime.daemon_port or self.default_port
             if await self._probe_health(port):
-                return await self.get_status()
+                return self._status_from_state(self.store.read(), daemon_state="ready")
 
             if not _port_is_free(port):
                 candidate = port
@@ -257,7 +319,13 @@ class QzoneDaemonController:
                     state = self.store.read()
                     state.runtime = runtime
                     self.store.write(state)
-                    return await self.get_status()
+                    self._health_cache = (
+                        port,
+                        runtime.secret,
+                        True,
+                        asyncio.get_running_loop().time() + self._health_cache_ttl,
+                    )
+                    return self._status_from_state(state, daemon_state="ready")
                 if self._process and self._process.poll() is not None:
                     break
                 await asyncio.sleep(0.5)
@@ -272,19 +340,37 @@ class QzoneDaemonController:
         params: dict[str, Any] | None = None,
         json_body: dict[str, Any] | None = None,
     ) -> Any:
-        runtime = self._runtime()
-        if self.auto_start_daemon:
-            await self.ensure_running()
+        last_exc: httpx.HTTPError | None = None
+        response: httpx.Response | None = None
+        for attempt in range(2):
             runtime = self._runtime()
-        elif not await self._probe_health(runtime.daemon_port):
-            raise DaemonUnavailableError("daemon 未运行")
-        response = await self._client.request(
-            method,
-            f"{self._base_url()}{path}",
-            headers={SECRET_HEADER: runtime.secret},
-            params=params,
-            json=json_body,
-        )
+            if self.auto_start_daemon:
+                await self.ensure_running()
+                runtime = self._runtime()
+            elif not await self._probe_health(runtime.daemon_port):
+                raise DaemonUnavailableError("daemon 未运行")
+            try:
+                response = await self._client.request(
+                    method,
+                    f"{self._base_url(runtime.daemon_port)}{path}",
+                    headers={SECRET_HEADER: runtime.secret},
+                    params=params,
+                    json=json_body,
+                )
+                break
+            except httpx.HTTPError as exc:
+                self._invalidate_health_cache()
+                last_exc = exc
+                if not self.auto_start_daemon or attempt > 0:
+                    raise DaemonUnavailableError(
+                        "daemon 请求失败",
+                        detail={"error": str(exc), "path": path},
+                    ) from exc
+        if response is None:
+            raise DaemonUnavailableError(
+                "daemon 请求失败",
+                detail={"error": str(last_exc), "path": path},
+            )
         try:
             payload = response.json()
         except Exception as exc:
@@ -303,31 +389,15 @@ class QzoneDaemonController:
             raise DaemonUnavailableError(message, detail=detail)
         return payload.get("data")
 
-    async def get_status(self) -> dict[str, Any]:
+    async def get_status(self, *, probe_daemon: bool = True) -> dict[str, Any]:
         state = self.store.read()
         runtime = state.runtime
         daemon_state = "offline"
-        if runtime.daemon_port and await self._probe_health(runtime.daemon_port):
+        if probe_daemon and runtime.daemon_port and await self._probe_health(runtime.daemon_port):
             daemon_state = "ready"
         elif state.session.cookies:
             daemon_state = "degraded"
-        return {
-            "daemon_state": daemon_state,
-            "daemon_pid": runtime.daemon_pid,
-            "daemon_port": runtime.daemon_port or self.default_port,
-            "daemon_version": runtime.version,
-            "started_at": runtime.started_at,
-            "last_seen_at": runtime.last_seen_at,
-            "login_uin": state.session.uin,
-            "cookie_summary": self.cookie_summary(state.session.cookies),
-            "cookie_count": len(state.session.cookies),
-            "needs_rebind": state.session.needs_rebind or not bool(state.session.cookies),
-            "last_ok_at": state.session.last_ok_at,
-            "last_error": state.session.last_error,
-            "qzonetoken_hosts": sorted(int(k) for k in state.session.qzonetokens.keys() if str(k).isdigit()),
-            "feed_cache_size": 0,
-            "session_revision": state.session.revision,
-        }
+        return self._status_from_state(state, daemon_state=daemon_state)
 
     @staticmethod
     def cookie_summary(cookies: dict[str, str]) -> str:
@@ -554,6 +624,7 @@ class QzoneDaemonController:
         return killed
 
     def _clear_runtime_process_state(self) -> None:
+        self._invalidate_health_cache()
         state = self.store.read()
         state.runtime.daemon_pid = 0
         state.runtime.started_at = ""

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -49,6 +49,7 @@ class QzoneDaemonService:
         self.keepalive_interval = max(30, int(keepalive_interval))
         self.health_state = "idle"
         self._keepalive_task: asyncio.Task | None = None
+        self._warmup_task: asyncio.Task | None = None
         self._closing = False
 
     def save(self) -> None:
@@ -120,10 +121,8 @@ class QzoneDaemonService:
     async def bootstrap(self) -> None:
         self.save()
         if self.state.session.cookies and self.state.session.uin and not self.state.session.needs_rebind:
-            try:
-                await self.warmup()
-            except Exception as exc:
-                self._set_error(exc)
+            self.health_state = "ready"
+            self._warmup_task = asyncio.create_task(self._background_warmup())
         else:
             self.health_state = "needs_rebind"
             self.save()
@@ -131,6 +130,10 @@ class QzoneDaemonService:
 
     async def close(self) -> None:
         self._closing = True
+        if self._warmup_task:
+            self._warmup_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._warmup_task
         if self._keepalive_task:
             self._keepalive_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -147,6 +150,14 @@ class QzoneDaemonService:
         self._ensure_session_ready()
         await self.client.mfeeds_get_count()
         self._set_success()
+
+    async def _background_warmup(self) -> None:
+        try:
+            await self.warmup()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._set_error(exc)
 
     async def ensure_token(self, hostuin: int | None = None) -> None:
         self._ensure_session_ready()
@@ -451,7 +462,6 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
 
     async def health(request: web.Request) -> web.Response:
         service.touch()
-        service.save()
         return ok(service.snapshot())
 
     async def status(request: web.Request) -> web.Response:

--- a/tests/test_client_media.py
+++ b/tests/test_client_media.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest
 from urllib.parse import parse_qs
 
@@ -97,6 +98,39 @@ class ClientMediaTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(upload_called)
         self.assertEqual(payload["tid"], "fid-2")
+
+    async def test_prepare_publish_photos_uploads_concurrently_and_preserves_order(self):
+        client = QzoneClient(
+            SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+        )
+        active = 0
+        max_active = 0
+
+        async def upload_photo(photo):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0.01)
+            active -= 1
+            return {"richval": f"rich-{photo['name']}", "pic_bo": photo["name"]}
+
+        client.upload_photo = upload_photo
+        try:
+            payload = await client._prepare_publish_photos(
+                [
+                    {"kind": "image", "source": "base64://MQ==", "name": "a.jpg"},
+                    {"kind": "image", "source": "base64://Mg==", "name": "b.jpg"},
+                    {"kind": "image", "source": "base64://Mw==", "name": "c.jpg"},
+                ]
+            )
+        finally:
+            await client.close()
+
+        self.assertGreater(max_active, 1)
+        self.assertEqual([item["richval"] for item in payload], ["rich-a.jpg", "rich-b.jpg", "rich-c.jpg"])
 
 
 if __name__ == "__main__":

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -140,6 +140,7 @@ class MainPublishTests(unittest.TestCase):
 
         self.assertTrue(event.stopped)
         plugin.controller.publish_post.assert_awaited_once()
+        plugin._ensure_daemon.assert_not_awaited()
         self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "hello")
         self.assertTrue(plugin.controller.publish_post.await_args.kwargs["content_sanitized"])
 
@@ -152,6 +153,7 @@ class MainPublishTests(unittest.TestCase):
 
         self.assertTrue(event.stopped)
         plugin.controller.publish_post.assert_awaited_once()
+        plugin._ensure_daemon.assert_not_awaited()
         self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "hello")
         self.assertTrue(plugin.controller.publish_post.await_args.kwargs["content_sanitized"])
 


### PR DESCRIPTION
﻿## Summary
- Reduce duplicate daemon health probes and unnecessary state-file writes on the Qzone publish path.
- Prewarm the daemon after cookie binding/platform load so posts usually hit a ready local bridge.
- Start daemon HTTP serving before remote warmup completes, and upload multiple post images concurrently with safe fallback.

## Why
Publishing to QQ Space was slow because the plugin repeatedly checked daemon status before posting, daemon cold start waited on a remote warmup request, and image uploads were serialized. These changes keep the existing success/error semantics while removing avoidable local latency.

## Validation
- `python -m compileall main.py qzone_bridge tests`
- `python -m unittest discover -s tests` (83 tests)
