### PR TITLE
[codex] Further reduce Qzone publish latency

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -82,5 +82,11 @@
     "type": "int",
     "default": 900,
     "hint": "发布结果渲染图宽度，默认 900。"
+  },
+  "render_remote_timeout": {
+    "description": "Publish result remote image timeout",
+    "type": "float",
+    "default": 0.35,
+    "hint": "发布结果图渲染远程头像或图片预览的单个资源超时，越小越快。"
   }
 }

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -40,7 +41,7 @@ from qzone_bridge.media import PostPayload, collect_post_payload
 from qzone_bridge.models import FeedEntry
 from qzone_bridge.onebot_cookie import fetch_cookie_text
 from qzone_bridge.parser import normalize_uin, parse_cookie_text
-from qzone_bridge.publish_renderer import profile_from_event, render_publish_result_image
+from qzone_bridge.publish_renderer import RenderProfile, profile_from_event, render_publish_result_image
 from qzone_bridge.render import format_action_result, format_feed_detail, format_feed_list, format_status
 from qzone_bridge.settings import PluginSettings
 from qzone_bridge.utils import truncate
@@ -68,6 +69,7 @@ class QzoneStablePlugin(Star):
         )
         self._capture_onebot_client_from_context()
         self._daemon_warmup_task: asyncio.Task | None = None
+        self._publisher_profile_cache: tuple[int, float, Any] | None = None
 
     def _sender_id(self, event: AstrMessageEvent) -> int:
         try:
@@ -97,13 +99,25 @@ class QzoneStablePlugin(Star):
         profile = profile_from_event(event)
         status: dict[str, Any] = {}
         try:
-            status = await self.controller.get_status()
+            status = await self.controller.get_status(probe_daemon=False)
         except QzoneBridgeError:
             status = {}
 
         login_uin = int(status.get("login_uin") or 0)
         if not login_uin:
             return profile
+
+        now = time.monotonic()
+        cached = self._publisher_profile_cache
+        if cached is not None:
+            cached_uin, expires_at, cached_profile = cached
+            if cached_uin == login_uin and expires_at > now:
+                return RenderProfile(
+                    nickname=cached_profile.nickname,
+                    user_id=cached_profile.user_id,
+                    avatar_source=cached_profile.avatar_source,
+                    time_text=profile.time_text,
+                )
 
         nickname = str(
             status.get("login_nickname")
@@ -117,7 +131,10 @@ class QzoneStablePlugin(Star):
 
         bot = self._capture_onebot_client(event)
         if bot is not None:
-            fetched = await self._fetch_onebot_user_info(bot, login_uin)
+            try:
+                fetched = await asyncio.wait_for(self._fetch_onebot_user_info(bot, login_uin), timeout=0.35)
+            except Exception:
+                fetched = {}
             if fetched:
                 nickname = nickname or str(fetched.get("nickname") or fetched.get("name") or "").strip()
                 avatar_source = str(fetched.get("avatar") or fetched.get("avatar_url") or avatar_source).strip()
@@ -125,6 +142,16 @@ class QzoneStablePlugin(Star):
         profile.user_id = str(login_uin)
         profile.nickname = nickname or str(login_uin)
         profile.avatar_source = avatar_source
+        self._publisher_profile_cache = (
+            login_uin,
+            now + 10 * 60,
+            RenderProfile(
+                nickname=profile.nickname,
+                user_id=profile.user_id,
+                avatar_source=profile.avatar_source,
+                time_text="",
+            ),
+        )
         return profile
 
     async def _fetch_onebot_user_info(self, bot: Any, uin: int) -> dict[str, Any]:
@@ -153,12 +180,27 @@ class QzoneStablePlugin(Star):
                 return result
         return {}
 
-    async def _publish_result(self, event: AstrMessageEvent, post: PostPayload, payload: dict[str, Any]):
+    def _schedule_publisher_profile(self, event: AstrMessageEvent) -> asyncio.Task | None:
+        if not self.settings.render_publish_result:
+            return None
+        return asyncio.create_task(self._publisher_render_profile(event))
+
+    async def _publish_result(
+        self,
+        event: AstrMessageEvent,
+        post: PostPayload,
+        payload: dict[str, Any],
+        *,
+        profile_task: asyncio.Task | None = None,
+    ):
         text = format_action_result("发布成功", payload)
         if not self.settings.render_publish_result:
             self._stop_event(event)
             return event.plain_result(text)
-        profile = await self._publisher_render_profile(event)
+        try:
+            profile = await profile_task if profile_task is not None else await self._publisher_render_profile(event)
+        except Exception:
+            profile = profile_from_event(event)
         try:
             image_path = await asyncio.to_thread(
                 render_publish_result_image,
@@ -167,6 +209,7 @@ class QzoneStablePlugin(Star):
                 profile=profile,
                 result=payload,
                 width=self.settings.render_result_width,
+                remote_timeout=self.settings.render_remote_timeout,
             )
         except Exception as exc:
             logger.exception("qzone publish result render failed: %s", exc)
@@ -505,17 +548,21 @@ class QzoneStablePlugin(Star):
             include_event_text=True,
             command_prefixes=("qzone post",),
         )
+        profile_task: asyncio.Task | None = None
         try:
             await self._ensure_cookie_ready(event)
+            profile_task = self._schedule_publisher_profile(event)
             payload = await self.controller.publish_post(
                 content=post.content,
                 media=[item.to_dict() for item in post.media],
                 content_sanitized=True,
             )
         except QzoneBridgeError as exc:
+            if profile_task is not None:
+                profile_task.cancel()
             yield self._command_result(event, self._error_text(exc))
             return
-        yield await self._publish_result(event, post, payload)
+        yield await self._publish_result(event, post, payload, profile_task=profile_task)
 
     @qzone.command("comment")
     async def qzone_comment(self, event: AstrMessageEvent, hostuin: int, fid: str, content: str):
@@ -636,8 +683,10 @@ class QzoneStablePlugin(Star):
             suffix = f"；附件 {len(post.media)} 个" if post.media else ""
             yield event.plain_result(f"待发布草稿: {draft}{suffix}。确认后将执行。")
             return
+        profile_task: asyncio.Task | None = None
         try:
             await self._ensure_cookie_ready(event)
+            profile_task = self._schedule_publisher_profile(event)
             payload = await self.controller.publish_post(
                 content=post.content,
                 sync_weibo=sync_weibo,
@@ -645,9 +694,11 @@ class QzoneStablePlugin(Star):
                 content_sanitized=True,
             )
         except QzoneBridgeError as exc:
+            if profile_task is not None:
+                profile_task.cancel()
             yield event.plain_result(self._error_text(exc))
             return
-        yield await self._publish_result(event, post, payload)
+        yield await self._publish_result(event, post, payload, profile_task=profile_task)
 
     @filter.llm_tool(name="qzone_comment_post")
     async def tool_comment_post(

--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -6,6 +6,8 @@ import asyncio
 import base64
 import json
 import logging
+import time
+from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -36,6 +38,11 @@ AUTH_ERROR_CODES = {-3000}
 AUTH_ERROR_KEYWORDS = ("登录", "失效", "请先登录", "skey", "g_tk", "cookie", "expired", "login")
 LOGIN_REDIRECT_HOSTS = ("ptlogin", "ui.ptlogin", "xui.ptlogin", "ssl.ptlogin", "login")
 QZONE_IMAGE_UPLOAD_URL = "https://up.qzone.qq.com/cgi-bin/upload/cgi_upload_image"
+MAX_UPLOAD_IMAGE_BYTES = 32 * 1024 * 1024
+IMAGE_SOURCE_CACHE_TTL_SECONDS = 10 * 60
+IMAGE_SOURCE_CACHE_MAX_ITEMS = 16
+IMAGE_SOURCE_CACHE_MAX_ITEM_BYTES = 8 * 1024 * 1024
+IMAGE_SOURCE_CACHE_MAX_TOTAL_BYTES = 64 * 1024 * 1024
 
 
 @dataclass(slots=True)
@@ -73,6 +80,7 @@ class QzoneClient:
             headers={"User-Agent": self.user_agent},
         )
         self.feed_cache: dict[tuple[int, str], FeedEntry] = {}
+        self._image_source_cache: OrderedDict[str, tuple[float, bytes, str]] = OrderedDict()
 
     def _normalize_session(self) -> None:
         self.session.cookies = normalize_cookie_fields(dict(self.session.cookies or {}))
@@ -103,6 +111,34 @@ class QzoneClient:
     def update_session(self, session: SessionState) -> None:
         self.session = session
         self._normalize_session()
+
+    def _cached_image_source(self, source: str) -> tuple[bytes, str] | None:
+        cached = self._image_source_cache.get(source)
+        if cached is None:
+            return None
+        expires_at, data, mime_type = cached
+        if expires_at <= time.monotonic():
+            self._image_source_cache.pop(source, None)
+            return None
+        self._image_source_cache.move_to_end(source)
+        return data, mime_type
+
+    def _store_image_source_cache(self, source: str, data: bytes, mime_type: str) -> None:
+        if not source or not data or len(data) > IMAGE_SOURCE_CACHE_MAX_ITEM_BYTES:
+            return
+        now = time.monotonic()
+        for key, (expires_at, _, _) in list(self._image_source_cache.items()):
+            if expires_at <= now:
+                self._image_source_cache.pop(key, None)
+        self._image_source_cache[source] = (now + IMAGE_SOURCE_CACHE_TTL_SECONDS, data, mime_type)
+        self._image_source_cache.move_to_end(source)
+        total_bytes = sum(len(item[1]) for item in self._image_source_cache.values())
+        while (
+            len(self._image_source_cache) > IMAGE_SOURCE_CACHE_MAX_ITEMS
+            or total_bytes > IMAGE_SOURCE_CACHE_MAX_TOTAL_BYTES
+        ):
+            _, (_, evicted_data, _) = self._image_source_cache.popitem(last=False)
+            total_bytes -= len(evicted_data)
 
     @staticmethod
     def _payload_needs_rebind(code: int, message: str) -> bool:
@@ -513,6 +549,11 @@ class QzoneClient:
         source = item.source.strip()
         filename = item.name or source_name(source) or "image.jpg"
         mime_type = item.mime_type
+        parsed = urlparse(source)
+        cached = self._cached_image_source(source) if parsed.scheme.lower() in {"http", "https"} else None
+        if cached is not None:
+            cached_data, cached_mime = cached
+            return cached_data, filename, mime_type or cached_mime
         if source.startswith("base64://"):
             try:
                 return base64.b64decode(source[len("base64://") :], validate=False), filename, mime_type
@@ -532,30 +573,55 @@ class QzoneClient:
                 raise QzoneParseError("无法解析 data URI 图片数据") from exc
             return data, filename, mime_type or header_mime
 
-        parsed = urlparse(source)
         if parsed.scheme.lower() in {"http", "https"}:
             try:
-                response = await self._client.get(
+                async with self._client.stream(
+                    "GET",
                     source,
                     headers=self._headers(referer=f"https://user.qzone.qq.com/{self.login_uin}"),
                     follow_redirects=True,
-                )
+                ) as response:
+                    self._persist_cookie_response(response)
+                    if response.status_code >= 400:
+                        text = (await response.aread()).decode("utf-8", errors="ignore")
+                        raise QzoneRequestError(
+                            f"下载图片返回 HTTP {response.status_code}",
+                            status_code=response.status_code,
+                            detail={"url": source, "text": text[:500]},
+                        )
+                    length = response.headers.get("content-length")
+                    try:
+                        if length and int(length) > MAX_UPLOAD_IMAGE_BYTES:
+                            raise QzoneParseError("图片文件过大，无法快速上传", detail={"url": source})
+                    except ValueError:
+                        pass
+                    chunks: list[bytes] = []
+                    total = 0
+                    async for chunk in response.aiter_bytes():
+                        if not chunk:
+                            continue
+                        total += len(chunk)
+                        if total > MAX_UPLOAD_IMAGE_BYTES:
+                            raise QzoneParseError("图片文件过大，无法快速上传", detail={"url": source})
+                        chunks.append(chunk)
             except httpx.HTTPError as exc:
                 raise QzoneRequestError("下载图片失败", detail={"url": source}) from exc
-            self._persist_cookie_response(response)
-            if response.status_code >= 400:
-                raise QzoneRequestError(
-                    f"下载图片返回 HTTP {response.status_code}",
-                    status_code=response.status_code,
-                    detail={"url": source, "text": response.text[:500]},
-                )
             content_type = response.headers.get("content-type", "").split(";", 1)[0]
-            return response.content, filename, mime_type or content_type
+            data = b"".join(chunks)
+            self._store_image_source_cache(source, data, content_type)
+            return data, filename, mime_type or content_type
 
         path = Path(source)
-        if not path.exists() or not path.is_file():
-            raise QzoneParseError("图片文件不存在", detail={"path": source})
-        return path.read_bytes(), filename or path.name, mime_type
+        def read_local_image() -> bytes:
+            if not path.exists() or not path.is_file():
+                raise QzoneParseError("图片文件不存在", detail={"path": source})
+            stat = path.stat()
+            if stat.st_size > MAX_UPLOAD_IMAGE_BYTES:
+                raise QzoneParseError("图片文件过大，无法快速上传", detail={"path": source})
+            return path.read_bytes()
+
+        data = await asyncio.to_thread(read_local_image)
+        return data, filename or path.name, mime_type
 
     @staticmethod
     def _photo_payload_from_upload(payload: dict[str, Any], *, filename: str = "", mime_type: str = "") -> dict[str, Any]:
@@ -593,7 +659,8 @@ class QzoneClient:
         if not data:
             raise QzoneParseError("图片内容为空，无法上传", detail={"name": filename})
 
-        encoded = base64.b64encode(data).decode("ascii")
+        encoded_bytes = await asyncio.to_thread(base64.b64encode, data)
+        encoded = encoded_bytes.decode("ascii")
         skey = self.session.cookies.get("skey") or self.session.cookies.get("p_skey") or ""
         p_skey = self.session.cookies.get("p_skey") or self.session.cookies.get("skey") or ""
         upload_payload = await self._request_json(
@@ -655,7 +722,7 @@ class QzoneClient:
             index, photo = pending[0]
             prepared[index] = await self.upload_photo(photo)
         elif pending:
-            semaphore = asyncio.Semaphore(min(3, len(pending)))
+            semaphore = asyncio.Semaphore(min(5, len(pending)))
             results = await asyncio.gather(
                 *(upload_limited(index, photo, semaphore) for index, photo in pending),
                 return_exceptions=True,
@@ -664,9 +731,13 @@ class QzoneClient:
             if errors:
                 if not all(isinstance(error, QzoneRequestError) for error in errors):
                     raise errors[0]
-                log.debug("parallel qzone image upload failed; retrying sequentially", exc_info=errors[0])
-                for index, photo in pending:
-                    prepared[index] = await self.upload_photo(photo)
+                log.debug("parallel qzone image upload failed; retrying failed items sequentially", exc_info=errors[0])
+                for (index, photo), result in zip(pending, results):
+                    if isinstance(result, Exception):
+                        prepared[index] = await self.upload_photo(photo)
+                    else:
+                        _, payload = result
+                        prepared[index] = payload
             else:
                 for index, payload in results:
                     prepared[index] = payload

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -50,6 +50,7 @@ class QzoneDaemonService:
         self.health_state = "idle"
         self._keepalive_task: asyncio.Task | None = None
         self._warmup_task: asyncio.Task | None = None
+        self._save_task: asyncio.Task | None = None
         self._closing = False
 
     def save(self) -> None:
@@ -63,13 +64,32 @@ class QzoneDaemonService:
         if self.state.session.needs_rebind or not self.state.session.cookies or not self.state.session.uin:
             raise QzoneNeedsRebind()
 
-    def _set_success(self) -> None:
+    def _schedule_save(self) -> None:
+        if self._closing:
+            return
+        task = self._save_task
+        if task is not None and not task.done():
+            return
+
+        async def runner() -> None:
+            await asyncio.sleep(0.05)
+            try:
+                self.save()
+            except Exception:
+                log.warning("qzone daemon deferred state save failed", exc_info=True)
+
+        self._save_task = asyncio.create_task(runner())
+
+    def _set_success(self, *, defer_save: bool = False) -> None:
         self.health_state = "ready" if self.state.session.cookies else "needs_rebind"
         self.state.session.last_ok_at = now_iso()
         self.state.session.last_error = None
         self.state.session.needs_rebind = not bool(self.state.session.cookies)
         self.touch()
-        self.save()
+        if defer_save:
+            self._schedule_save()
+        else:
+            self.save()
 
     def _set_error(self, exc: Exception) -> None:
         if isinstance(exc, (QzoneNeedsRebind, QzoneAuthError)):
@@ -138,6 +158,9 @@ class QzoneDaemonService:
             self._keepalive_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await self._keepalive_task
+        if self._save_task:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._save_task
         self.health_state = "offline"
         self.state.runtime.daemon_pid = 0
         self.state.runtime.started_at = ""
@@ -149,7 +172,7 @@ class QzoneDaemonService:
     async def warmup(self) -> None:
         self._ensure_session_ready()
         await self.client.mfeeds_get_count()
-        self._set_success()
+        self._set_success(defer_save=True)
 
     async def _background_warmup(self) -> None:
         try:
@@ -346,7 +369,7 @@ class QzoneDaemonService:
         )
         if not isinstance(payload, dict):
             raise QzoneParseError("发布说说返回结构异常")
-        self._set_success()
+        self._set_success(defer_save=True)
         return {
             "fid": payload.get("fid") or payload.get("tid") or "",
             "message": payload.get("msg") or payload.get("message") or "",
@@ -370,7 +393,7 @@ class QzoneDaemonService:
         payload = unwrap_payload(await self.client.add_comment(hostuin, fid, content, appid=appid, private=private))
         if not isinstance(payload, dict):
             raise QzoneParseError("评论返回结构异常")
-        self._set_success()
+        self._set_success(defer_save=True)
         return {
             "commentid": payload.get("commentid") or payload.get("commentId") or 0,
             "commentLikekey": payload.get("commentLikekey") or "",
@@ -393,7 +416,7 @@ class QzoneDaemonService:
         )
         if not isinstance(payload, dict):
             raise QzoneParseError("点赞返回结构异常")
-        self._set_success()
+        self._set_success(defer_save=True)
         return {
             "action": "unlike" if unlike else "like",
             "message": payload.get("msg") or payload.get("message") or "",

--- a/qzone_bridge/media.py
+++ b/qzone_bridge/media.py
@@ -276,6 +276,9 @@ def _choose_media_source(data: dict[str, Any]) -> str:
     ]
     normalized = [normalize_source(value) for value in candidates if value not in (None, "")]
     for value in normalized:
+        if _is_base64_source(value) or (not _is_url(value) and _looks_like_path(value)):
+            return value
+    for value in normalized:
         if _is_url(value) or _is_base64_source(value) or _looks_like_path(value):
             return value
     return normalized[0] if normalized else ""

--- a/qzone_bridge/publish_renderer.py
+++ b/qzone_bridge/publish_renderer.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import base64
+from concurrent.futures import ThreadPoolExecutor
 import io
 import math
 import os
 import re
+import threading
 import time
 import uuid
 from dataclasses import dataclass
@@ -46,6 +48,16 @@ FILE_COLORS = {
     ".md": (112, 121, 130),
 }
 FONT_CACHE: dict[tuple[int, bool], ImageFont.ImageFont] = {}
+FAST_RESAMPLE = Image.Resampling.BILINEAR
+PREVIEW_EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="qzone-render")
+_THREAD_LOCAL = threading.local()
+_BYTES_CACHE: dict[str, tuple[float, bytes]] = {}
+_BYTES_CACHE_LOCK = threading.Lock()
+_BYTES_CACHE_TTL = 10 * 60
+_BYTES_CACHE_MAX_ITEMS = 64
+_BYTES_CACHE_MAX_ITEM_SIZE = 4 * 1024 * 1024
+_LAST_PRUNE_AT = 0.0
+_PRUNE_INTERVAL_SECONDS = 60.0
 
 
 @dataclass(slots=True)
@@ -160,7 +172,15 @@ def render_publish_result_image(
     line_height = _line_height(scratch, text_font, 1.34)
     text_height = len(text_lines) * line_height if text_lines else 0
 
-    previews = [_load_image_preview(item, remote_timeout=remote_timeout) for item in post.media[:9]]
+    preview_targets: list[PostMedia] = []
+    avatar_offset = 0
+    if profile.avatar_source:
+        preview_targets.append(PostMedia(kind="image", source=profile.avatar_source, name="avatar"))
+        avatar_offset = 1
+    preview_targets.extend(post.media[:9])
+    loaded_previews = _load_image_previews(preview_targets, remote_timeout=remote_timeout)
+    avatar_preview = loaded_previews[0] if avatar_offset else None
+    previews = loaded_previews[avatar_offset:]
     image_height = _image_block_height(previews, content_width) if previews else 0
     attachment_height = _attachment_block_height(post.attachments, content_width) if post.attachments else 0
 
@@ -177,7 +197,7 @@ def render_publish_result_image(
 
     image = Image.new("RGB", (width, height), WHITE)
     draw = ImageDraw.Draw(image)
-    _draw_header(draw, image, profile, margin, name_font, time_font)
+    _draw_header(draw, image, profile, margin, name_font, time_font, avatar_preview=avatar_preview)
 
     y = 126
     if text_lines:
@@ -198,7 +218,7 @@ def render_publish_result_image(
     _draw_comment_box(draw, margin, comment_y, content_width, 52, meta_font)
 
     path = output_dir / f"publish_result_{int(time.time())}_{uuid.uuid4().hex[:10]}.png"
-    image.save(path, "PNG", optimize=True)
+    image.save(path, "PNG", optimize=False, compress_level=1)
     return path
 
 
@@ -333,16 +353,38 @@ def _load_image_preview(media: PostMedia, *, remote_timeout: float) -> _ImagePre
                 preview = base
             else:
                 preview = preview.copy()
-            preview.thumbnail((2048, 2048), Image.Resampling.LANCZOS)
+            preview.thumbnail((900, 900), FAST_RESAMPLE)
             return _ImagePreview(media=media, image=preview, failed=False)
     except (OSError, UnidentifiedImageError):
         return _ImagePreview(media=media, image=None, failed=True)
+
+
+def _load_image_previews(items: list[PostMedia], *, remote_timeout: float) -> list[_ImagePreview]:
+    if not items:
+        return []
+    if len(items) == 1:
+        return [_load_image_preview(items[0], remote_timeout=remote_timeout)]
+    futures = [
+        PREVIEW_EXECUTOR.submit(_load_image_preview, item, remote_timeout=remote_timeout)
+        for item in items
+    ]
+    previews: list[_ImagePreview] = []
+    for item, future in zip(items, futures):
+        try:
+            previews.append(future.result())
+        except Exception:
+            previews.append(_ImagePreview(media=item, image=None, failed=True))
+    return previews
 
 
 def _read_source_bytes(source: str, *, max_bytes: int, remote_timeout: float) -> bytes:
     source = str(source or "").strip()
     if not source:
         return b""
+    cache_key = _bytes_cache_key(source)
+    cached = _get_cached_bytes(cache_key)
+    if cached:
+        return cached[:max_bytes]
     if source.startswith("base64://"):
         try:
             return base64.b64decode(source[len("base64://") :], validate=False)[:max_bytes]
@@ -363,14 +405,30 @@ def _read_source_bytes(source: str, *, max_bytes: int, remote_timeout: float) ->
     parsed = urlparse(source)
     if parsed.scheme.lower() in {"http", "https"}:
         try:
-            with httpx.Client(timeout=httpx.Timeout(remote_timeout), follow_redirects=True, trust_env=False) as client:
-                response = client.get(source)
-            if response.status_code >= 400:
-                return b""
-            length = response.headers.get("content-length")
-            if length and int(length) > max_bytes:
-                return b""
-            return response.content[:max_bytes]
+            client = _thread_http_client()
+            with client.stream(
+                "GET",
+                source,
+                timeout=httpx.Timeout(remote_timeout),
+                follow_redirects=True,
+            ) as response:
+                if response.status_code >= 400:
+                    return b""
+                length = response.headers.get("content-length")
+                if length and int(length) > max_bytes:
+                    return b""
+                chunks: list[bytes] = []
+                total = 0
+                for chunk in response.iter_bytes():
+                    if not chunk:
+                        continue
+                    total += len(chunk)
+                    if total > max_bytes:
+                        return b""
+                    chunks.append(chunk)
+            data = b"".join(chunks)
+            _store_cached_bytes(cache_key, data)
+            return data
         except Exception:
             return b""
 
@@ -379,11 +437,59 @@ def _read_source_bytes(source: str, *, max_bytes: int, remote_timeout: float) ->
         source = parsed.path or ""
     path = Path(source)
     try:
-        if not path.exists() or not path.is_file() or path.stat().st_size > max_bytes:
+        stat = path.stat()
+        if not path.is_file() or stat.st_size > max_bytes:
             return b""
-        return path.read_bytes()
+        local_key = f"file:{path.resolve()}:{stat.st_mtime_ns}:{stat.st_size}"
+        cached = _get_cached_bytes(local_key)
+        if cached:
+            return cached[:max_bytes]
+        data = path.read_bytes()
+        _store_cached_bytes(local_key, data)
+        return data
     except OSError:
         return b""
+
+
+def _thread_http_client() -> httpx.Client:
+    client = getattr(_THREAD_LOCAL, "http_client", None)
+    if client is None:
+        client = httpx.Client(trust_env=False)
+        _THREAD_LOCAL.http_client = client
+    return client
+
+
+def _bytes_cache_key(source: str) -> str:
+    parsed = urlparse(source)
+    if parsed.scheme.lower() in {"http", "https"}:
+        return f"url:{source}"
+    return ""
+
+
+def _get_cached_bytes(key: str) -> bytes:
+    if not key:
+        return b""
+    now = time.monotonic()
+    with _BYTES_CACHE_LOCK:
+        cached = _BYTES_CACHE.get(key)
+        if not cached:
+            return b""
+        expires_at, data = cached
+        if expires_at <= now:
+            _BYTES_CACHE.pop(key, None)
+            return b""
+        return data
+
+
+def _store_cached_bytes(key: str, data: bytes) -> None:
+    if not key or not data or len(data) > _BYTES_CACHE_MAX_ITEM_SIZE:
+        return
+    now = time.monotonic()
+    with _BYTES_CACHE_LOCK:
+        if len(_BYTES_CACHE) >= _BYTES_CACHE_MAX_ITEMS:
+            oldest_key = min(_BYTES_CACHE, key=lambda item: _BYTES_CACHE[item][0])
+            _BYTES_CACHE.pop(oldest_key, None)
+        _BYTES_CACHE[key] = (now + _BYTES_CACHE_TTL, data)
 
 
 def _image_block_height(previews: list[_ImagePreview], width: int) -> int:
@@ -433,11 +539,13 @@ def _draw_header(
     margin: int,
     name_font: ImageFont.ImageFont,
     time_font: ImageFont.ImageFont,
+    *,
+    avatar_preview: _ImagePreview | None = None,
 ) -> None:
     avatar_size = 76
     avatar_x = margin
     avatar_y = 26
-    _draw_avatar(draw, image, profile, avatar_x, avatar_y, avatar_size)
+    _draw_avatar(draw, image, profile, avatar_x, avatar_y, avatar_size, preview=avatar_preview)
     text_x = avatar_x + avatar_size + 18
     _safe_text(draw, (text_x, 32), profile.nickname, name_font, TEXT)
     _safe_text(draw, (text_x, 72), profile.time_text, time_font, MUTED)
@@ -454,14 +562,14 @@ def _draw_avatar(
     x: int,
     y: int,
     size: int,
+    *,
+    preview: _ImagePreview | None = None,
 ) -> None:
-    avatar_media = PostMedia(kind="image", source=profile.avatar_source, name="avatar")
-    preview = _load_image_preview(avatar_media, remote_timeout=0.8) if profile.avatar_source else None
     mask = Image.new("L", (size, size), 0)
     mask_draw = ImageDraw.Draw(mask)
     mask_draw.ellipse((0, 0, size - 1, size - 1), fill=255)
     if preview and preview.image:
-        avatar = ImageOps.fit(preview.image, (size, size), method=Image.Resampling.LANCZOS)
+        avatar = ImageOps.fit(preview.image, (size, size), method=FAST_RESAMPLE)
         image.paste(avatar, (x, y), mask)
         return
 
@@ -529,9 +637,9 @@ def _draw_preview_tile(
 ) -> None:
     if preview.image is not None:
         if crop:
-            rendered = ImageOps.fit(preview.image, (width, height), method=Image.Resampling.LANCZOS)
+            rendered = ImageOps.fit(preview.image, (width, height), method=FAST_RESAMPLE)
         else:
-            rendered = ImageOps.contain(preview.image, (width, height), method=Image.Resampling.LANCZOS)
+            rendered = ImageOps.contain(preview.image, (width, height), method=FAST_RESAMPLE)
             width, height = rendered.size
         image.paste(rendered, (x, y))
         return
@@ -684,6 +792,11 @@ def _draw_comment_box(
 
 
 def _prune_output_dir(output_dir: Path, *, keep: int = 128, max_age_seconds: int = 3 * 24 * 3600) -> None:
+    global _LAST_PRUNE_AT
+    now = time.monotonic()
+    if now - _LAST_PRUNE_AT < _PRUNE_INTERVAL_SECONDS:
+        return
+    _LAST_PRUNE_AT = now
     try:
         files = sorted(
             [path for path in output_dir.glob("publish_result_*.png") if path.is_file()],

--- a/qzone_bridge/settings.py
+++ b/qzone_bridge/settings.py
@@ -71,6 +71,7 @@ class PluginSettings:
     preview_writes: bool = True
     render_publish_result: bool = True
     render_result_width: int = 900
+    render_remote_timeout: float = 0.35
 
     @classmethod
     def from_mapping(cls, config: Any) -> "PluginSettings":
@@ -96,4 +97,5 @@ class PluginSettings:
             preview_writes=_as_bool(_pick(mapping, "preview_writes", True), True),
             render_publish_result=_as_bool(_pick(mapping, "render_publish_result", True), True),
             render_result_width=int(_pick(mapping, "render_result_width", 900) or 900),
+            render_remote_timeout=float(_pick(mapping, "render_remote_timeout", 0.35) or 0.35),
         )

--- a/tests/test_client_media.py
+++ b/tests/test_client_media.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qs
 import httpx
 
 from qzone_bridge.client import QzoneClient
+from qzone_bridge.errors import QzoneRequestError
 from qzone_bridge.models import SessionState
 
 
@@ -131,6 +132,80 @@ class ClientMediaTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertGreater(max_active, 1)
         self.assertEqual([item["richval"] for item in payload], ["rich-a.jpg", "rich-b.jpg", "rich-c.jpg"])
+
+    async def test_prepare_publish_photos_retries_only_failed_parallel_uploads(self):
+        client = QzoneClient(
+            SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+        )
+        attempts = {}
+
+        async def upload_photo(photo):
+            name = photo["name"]
+            attempts[name] = attempts.get(name, 0) + 1
+            if name == "b.jpg" and attempts[name] == 1:
+                raise QzoneRequestError("temporary upload failure")
+            return {"richval": f"rich-{name}", "pic_bo": name}
+
+        client.upload_photo = upload_photo
+        try:
+            payload = await client._prepare_publish_photos(
+                [
+                    {"kind": "image", "source": "base64://MQ==", "name": "a.jpg"},
+                    {"kind": "image", "source": "base64://Mg==", "name": "b.jpg"},
+                    {"kind": "image", "source": "base64://Mw==", "name": "c.jpg"},
+                ]
+            )
+        finally:
+            await client.close()
+
+        self.assertEqual(attempts, {"a.jpg": 1, "b.jpg": 2, "c.jpg": 1})
+        self.assertEqual([item["richval"] for item in payload], ["rich-a.jpg", "rich-b.jpg", "rich-c.jpg"])
+
+    async def test_upload_photo_reuses_downloaded_remote_image_bytes(self):
+        download_calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal download_calls
+            if request.url.path == "/photo.jpg":
+                download_calls += 1
+                return httpx.Response(
+                    200,
+                    content=b"image-bytes",
+                    headers={"content-type": "image/jpeg"},
+                    request=request,
+                )
+            return httpx.Response(
+                200,
+                text=(
+                    '_Callback({"ret":0,"data":{"albumid":"album","lloc":"lloc",'
+                    '"sloc":"sloc","type":1,"height":1,"width":1}})'
+                ),
+                request=request,
+            )
+
+        client = QzoneClient(
+            SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+        )
+        await client._client.aclose()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            trust_env=False,
+            headers={"User-Agent": client.user_agent},
+        )
+        try:
+            media = {"kind": "image", "source": "https://example.com/photo.jpg", "name": "photo.jpg"}
+            await client.upload_photo(media)
+            await client.upload_photo(media)
+        finally:
+            await client.close()
+
+        self.assertEqual(download_calls, 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,5 +1,7 @@
 import types
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from qzone_bridge.media import collect_post_payload
 
@@ -297,6 +299,31 @@ class MediaPayloadTests(unittest.TestCase):
 
         self.assertEqual(payload.content, "")
         self.assertEqual(payload.media[0].source, "https://example.com/a.png")
+
+    def test_onebot_image_prefers_existing_local_file_over_url(self):
+        with TemporaryDirectory() as temp:
+            image_path = Path(temp) / "photo.png"
+            image_path.write_bytes(b"image")
+
+            payload = collect_post_payload(
+                self.event(
+                    [
+                        {"type": "text", "data": {"text": "/qzone post"}},
+                        {
+                            "type": "image",
+                            "data": {
+                                "file": str(image_path),
+                                "url": "https://example.com/slow.png",
+                            },
+                        },
+                    ]
+                ),
+                include_event_text=True,
+                command_prefixes=("qzone post",),
+            )
+
+        self.assertEqual(payload.content, "")
+        self.assertEqual(payload.media[0].source, str(image_path))
 
     def test_non_image_file_becomes_readable_reference(self):
         payload = collect_post_payload(

--- a/tests/test_publish_renderer.py
+++ b/tests/test_publish_renderer.py
@@ -1,6 +1,9 @@
+import io
 import tempfile
+import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from PIL import Image, ImageChops, ImageDraw
 
@@ -109,6 +112,44 @@ class PublishRendererTests(unittest.TestCase):
         self.assertLessEqual(bbox[2], 56)
         self.assertLessEqual(bbox[3], 46)
         self.assertIn(ACTION, image.getdata())
+
+    def test_render_loads_multiple_previews_concurrently(self):
+        with tempfile.TemporaryDirectory() as temp:
+            temp_path = Path(temp)
+            active = 0
+            max_active = 0
+
+            def fake_read(source, *, max_bytes, remote_timeout):
+                nonlocal active, max_active
+                active += 1
+                max_active = max(max_active, active)
+                time.sleep(0.03)
+                active -= 1
+                image = Image.new("RGB", (64, 64), (120, 180, 210))
+                buffer = io.BytesIO()
+                image.save(buffer, format="PNG")
+                buffer.seek(0)
+                return buffer.read()
+
+            post = PostPayload(
+                content="parallel",
+                media=[
+                    PostMedia(kind="image", source="a.png", name="a.png"),
+                    PostMedia(kind="image", source="b.png", name="b.png"),
+                    PostMedia(kind="image", source="c.png", name="c.png"),
+                ],
+            )
+
+            with patch("qzone_bridge.publish_renderer._read_source_bytes", side_effect=fake_read):
+                rendered = render_publish_result_image(
+                    post,
+                    temp_path,
+                    profile=RenderProfile(nickname="Coconut", time_text="06:34"),
+                    width=700,
+                )
+
+            self.assertTrue(rendered.exists())
+            self.assertGreater(max_active, 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_storage_settings.py
+++ b/tests/test_storage_settings.py
@@ -26,6 +26,7 @@ class StorageSettingsTests(unittest.TestCase):
                 "public_feed_limit": 7,
                 "auto_bind_cookie": False,
                 "cookie_domain": "https://user.qzone.qq.com/",
+                "render_remote_timeout": 0.25,
             }
         )
         self.assertEqual(settings.daemon_port, 19001)
@@ -33,6 +34,7 @@ class StorageSettingsTests(unittest.TestCase):
         self.assertEqual(settings.public_feed_limit, 7)
         self.assertFalse(settings.auto_bind_cookie)
         self.assertEqual(settings.cookie_domain, "https://user.qzone.qq.com/")
+        self.assertEqual(settings.render_remote_timeout, 0.25)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- overlaps publisher profile lookup with the Qzone publish request and caches publisher profile data
- parallelizes publish-result image preview loading, caches preview bytes, lowers preview decode size, and writes fast PNGs
- speeds image upload preparation with bounded parallelism, remote image byte caching, streamed downloads, async local file reads, and retry-only-failed upload fallback
- defers non-critical daemon success-state saves and throttles render output pruning

## Validation
- `python -m compileall main.py qzone_bridge tests`
- `python -m unittest tests.test_client_media tests.test_media tests.test_publish_renderer tests.test_storage_settings`
- `python -m unittest discover -s tests` (94 tests OK; asyncio slow-task debug logs printed, no failures)
- `git diff --check`