### PR TITLE
[codex] Fix Qzone JSON-ish response parsing

### DIFF
--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -30,7 +30,7 @@ from .parser import (
     unwrap_payload,
 )
 from .render import cookie_summary
-from .utils import extract_callback_json, now_iso
+from .utils import extract_callback_json, json_loads, now_iso
 
 log = logging.getLogger(__name__)
 
@@ -316,6 +316,40 @@ class QzoneClient:
         assert last_exc is not None
         raise last_exc
 
+    @staticmethod
+    def _parse_response_payload(text: str, response: httpx.Response) -> Any:
+        if not text:
+            return {}
+
+        json_like = text.startswith(("{", "["))
+        callback_error: Exception | None = None
+        if not json_like:
+            try:
+                callback_payload = extract_callback_json(text)
+            except Exception as exc:
+                callback_error = exc
+            else:
+                if callback_payload is not None:
+                    return callback_payload
+
+        try:
+            return json.loads(text)
+        except Exception as json_exc:
+            if not json_like:
+                detail = {"text": text[:500], "url": str(response.request.url)}
+                raise QzoneParseError(
+                    "QQ 空间接口返回了非 JSON 响应",
+                    detail=detail,
+                ) from (callback_error or json_exc)
+            try:
+                return json_loads(text)
+            except Exception as js_exc:
+                detail = {"text": text[:500], "url": str(response.request.url)}
+                raise QzoneParseError(
+                    "无法解析 QQ 空间 JSON 响应",
+                    detail=detail,
+                ) from (js_exc or json_exc)
+
     async def _request_json(
         self,
         method: str,
@@ -342,27 +376,8 @@ class QzoneClient:
             attach_token=attach_token,
             login_required=login_required,
         )
-        payload: Any
         text = response.text.strip()
-        if not text:
-            payload = {}
-        elif text.startswith("{") or text.startswith("["):
-            try:
-                payload = response.json()
-            except Exception as exc:
-                raise QzoneParseError("无法解析 QQ 空间 JSON 响应", detail={"text": text[:500]}) from exc
-        else:
-            callback_payload = extract_callback_json(text)
-            if callback_payload is not None:
-                payload = callback_payload
-            else:
-                try:
-                    payload = json.loads(text)
-                except Exception:
-                    raise QzoneParseError(
-                        "QQ 空间接口返回了非 JSON 响应",
-                        detail={"text": text[:500], "url": str(response.request.url)},
-                    )
+        payload = self._parse_response_payload(text, response)
         self._raise_payload_error(payload, response)
         payload = unwrap_payload(payload)
         self._raise_payload_error(payload, response)
@@ -833,14 +848,18 @@ class QzoneClient:
         curkey: str = "",
         like: bool = True,
     ) -> dict[str, Any]:
+        cached = self.feed_cache.get((hostuin, fid))
         if not curkey:
-            cached = self.feed_cache.get((hostuin, fid))
             if cached and cached.curkey:
                 curkey = cached.curkey
         if not curkey:
             curkey = compute_unikey(appid, hostuin, fid)
 
-        unikey = compute_unikey(appid, hostuin, fid)
+        unikey = (
+            cached.unikey
+            if cached and cached.unikey
+            else compute_unikey(appid, hostuin, fid)
+        )
         path = (
             "https://user.qzone.qq.com/proxy/domain/w.qzone.qq.com/cgi-bin/likes/internal_dolike_app"
             if like

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -17,7 +17,7 @@ from .client import FeedPageResult, QzoneClient
 from .errors import QzoneAuthError, QzoneBridgeError, QzoneNeedsRebind, QzoneParseError, QzoneRequestError
 from .media import QZONE_MAX_IMAGES, media_reference_text, normalize_media_list, split_publishable_images, strip_command_prefix
 from .models import BridgeState, FeedEntry, SessionState
-from .parser import extract_feed_entry, extract_feed_page, normalize_uin, parse_cookie_text, unwrap_payload
+from .parser import extract_feed_page, feed_page_cursor, feed_page_has_more, normalize_uin, parse_cookie_text, unwrap_payload
 from .protocol import SECRET_HEADER, fail, ok
 from .storage import StateStore, ensure_state_secret
 from .utils import now_iso, from_iso
@@ -264,38 +264,21 @@ class QzoneDaemonService:
                         payload = await self.client.legacy_recent_feeds()
                 else:
                     payload = unwrap_payload(await self.client.get_active_feeds(next_cursor))
-                feedpage = payload.get("data") if isinstance(payload, dict) and isinstance(payload.get("data"), dict) else payload
+                feedpage = payload
             else:
                 if page_round == 0 and not next_cursor:
                     payload = await self.client.profile(hostuin)
                 else:
                     payload = unwrap_payload(await self.client.get_feeds(hostuin, next_cursor))
-                if isinstance(payload, dict) and isinstance(payload.get("feedpage"), dict):
-                    feedpage = payload["feedpage"]
-                else:
-                    feedpage = payload
+                feedpage = payload
 
+            feedpage, page_items = extract_feed_page(feedpage, default_hostuin=hostuin)
             if not isinstance(feedpage, dict):
                 break
-            raw_items = feedpage.get("vFeeds") or feedpage.get("vfeeds") or feedpage.get("msglist") or feedpage.get("data") or []
-            if isinstance(raw_items, dict):
-                raw_items = raw_items.get("vFeeds") or raw_items.get("vfeeds") or raw_items.get("msglist") or raw_items.get("data") or []
-            if not isinstance(raw_items, list):
-                raw_items = []
-            page_items = [
-                self.client.feed_entry_from_payload(item, default_hostuin=hostuin)
-                for item in raw_items
-                if isinstance(item, dict)
-            ]
             self.client.cache_feed_page(hostuin, page_items)
             items.extend(page_items)
-            has_more = bool(feedpage.get("hasmore") or feedpage.get("hasMore") or False)
-            next_cursor = str(
-                feedpage.get("attachinfo")
-                or feedpage.get("attach_info")
-                or feedpage.get("attachInfo")
-                or ""
-            )
+            has_more = feed_page_has_more(feedpage)
+            next_cursor = feed_page_cursor(feedpage)
             if not has_more or not next_cursor:
                 break
             page_round += 1

--- a/qzone_bridge/parser.py
+++ b/qzone_bridge/parser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html as html_lib
 import json
 import re
 from typing import Any
@@ -19,6 +20,14 @@ COOKIE_KEY_ALIASES = {
     "bkn": "g_tk",
     "csrf_token": "g_tk",
 }
+FEED_CONTAINER_KEYS = ("feedpage", "main")
+FEED_LIST_KEYS = ("vFeeds", "vfeeds", "msglist", "data", "feeds", "feedlist", "feedList")
+FEED_CURSOR_KEYS = ("attachinfo", "attach_info", "attachInfo", "attach", "externparam", "res_attach")
+FEED_HAS_MORE_KEYS = ("hasmore", "hasMore", "hasMoreFeeds", "has_more")
+HTML_ATTR_RE_TEMPLATE = r"""\b{name}\s*=\s*(["'])(.*?)\1"""
+HTML_BREAK_RE = re.compile(r"<\s*br\s*/?\s*>", re.I)
+HTML_BLOCK_RE = re.compile(r"</\s*(?:p|div|li|tr)\s*>", re.I)
+HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 
 def _dig(value: Any, *keys: str) -> Any:
@@ -50,6 +59,28 @@ def _text(value: Any) -> str:
                     return result
         return ""
     return str(value)
+
+
+def _html_to_text(value: Any) -> str:
+    text = _text(value)
+    if not text:
+        return ""
+    text = HTML_BREAK_RE.sub("\n", text)
+    text = HTML_BLOCK_RE.sub("\n", text)
+    text = HTML_TAG_RE.sub("", text)
+    text = html_lib.unescape(text)
+    return re.sub(r"[ \t\r\f\v]+", " ", text).strip()
+
+
+def _html_attr(markup: Any, name: str) -> str:
+    text = _text(markup)
+    if not text:
+        return ""
+    pattern = HTML_ATTR_RE_TEMPLATE.format(name=re.escape(name))
+    match = re.search(pattern, text, re.S | re.I)
+    if not match:
+        return ""
+    return html_lib.unescape(match.group(2)).strip()
 
 
 def _int(value: Any, default: int = 0) -> int:
@@ -223,10 +254,13 @@ def unwrap_payload(payload: Any) -> Any:
 
 
 def extract_hostuin(feed_item: dict[str, Any], default: int = 0) -> int:
+    html_markup = feed_item.get("html")
     candidates = [
         feed_item.get("uin"),
         feed_item.get("hostuin"),
         feed_item.get("hostUin"),
+        _html_attr(html_markup, "data-uin"),
+        _html_attr(html_markup, "uin"),
         _dig(feed_item, "userinfo", "uin"),
         _dig(feed_item, "user", "uin"),
         _dig(feed_item, "userinfo", "user", "uin"),
@@ -245,10 +279,19 @@ def extract_hostuin(feed_item: dict[str, Any], default: int = 0) -> int:
 
 
 def extract_fid(feed_item: dict[str, Any]) -> str:
+    html_markup = feed_item.get("html")
     candidates = [
         feed_item.get("fid"),
         feed_item.get("tid"),
         feed_item.get("cellid"),
+        feed_item.get("key"),
+        feed_item.get("ugckey"),
+        feed_item.get("ugcrightkey"),
+        _html_attr(html_markup, "data-fid"),
+        _html_attr(html_markup, "fid"),
+        _html_attr(html_markup, "data-tid"),
+        _html_attr(html_markup, "tid"),
+        _html_attr(html_markup, "data-cellid"),
         _dig(feed_item, "id", "cellid"),
         _dig(feed_item, "common", "ugcrightkey"),
         _dig(feed_item, "common", "ugckey"),
@@ -267,6 +310,7 @@ def extract_summary_text(feed_item: dict[str, Any]) -> str:
         _text(feed_item.get("summary")),
         _dig(feed_item, "original", "summary", "summary"),
         _text(feed_item.get("text")),
+        _html_to_text(feed_item.get("html")),
     ]
     for candidate in candidates:
         if candidate:
@@ -293,9 +337,16 @@ def extract_feed_entry(feed_item: dict[str, Any], *, default_hostuin: int = 0) -
     original = feed_item.get("original") or {}
     if not isinstance(original, dict):
         original = {}
+    html_markup = feed_item.get("html")
 
     hostuin = extract_hostuin(feed_item, default_hostuin)
-    appid = _int(common.get("appid") or feed_item.get("appid") or 311, 311)
+    appid = _int(
+        common.get("appid")
+        or feed_item.get("appid")
+        or _html_attr(html_markup, "data-appid")
+        or 311,
+        311,
+    )
     fid = extract_fid(feed_item)
     created_at = _int(common.get("time") or feed_item.get("abstime") or feed_item.get("created_time") or 0)
     summary = extract_summary_text(feed_item)
@@ -307,12 +358,24 @@ def extract_feed_entry(feed_item: dict[str, Any], *, default_hostuin: int = 0) -
         or feed_item.get("curlikekey")
         or common.get("curkey")
         or common.get("curlikekey")
+        or _html_attr(html_markup, "data-curkey")
+        or _html_attr(html_markup, "curkey")
         or compute_unikey(appid, hostuin, fid)
         or ""
     )
-    unikey = compute_unikey(appid, hostuin, fid)
+    unikey = (
+        _html_attr(html_markup, "data-unikey")
+        or _html_attr(html_markup, "unikey")
+        or compute_unikey(appid, hostuin, fid)
+    )
     topic = topic_id(appid, hostuin, fid, created_at)
-    nickname = str(feed_item.get("name") or userinfo.get("nickname") or userinfo.get("name") or "")
+    nickname = str(
+        feed_item.get("name")
+        or feed_item.get("nickname")
+        or userinfo.get("nickname")
+        or userinfo.get("name")
+        or ""
+    )
     like_count = _int(
         like.get("num")
         or like.get("likeNum")
@@ -351,14 +414,73 @@ def extract_feed_entry(feed_item: dict[str, Any], *, default_hostuin: int = 0) -
     )
 
 
+def _looks_like_feed_page(value: dict[str, Any]) -> bool:
+    return any(key in value for key in (*FEED_LIST_KEYS, *FEED_CURSOR_KEYS, *FEED_HAS_MORE_KEYS))
+
+
+def normalize_feed_page(payload: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    for key in FEED_CONTAINER_KEYS:
+        value = payload.get(key)
+        if isinstance(value, dict):
+            return value
+
+    data = payload.get("data")
+    if isinstance(data, dict):
+        for key in FEED_CONTAINER_KEYS:
+            value = data.get(key)
+            if isinstance(value, dict):
+                return value
+        if _looks_like_feed_page(data):
+            return data
+
+    return payload
+
+
+def extract_raw_feeds(feedpage: dict[str, Any]) -> list[Any]:
+    if not isinstance(feedpage, dict):
+        return []
+    raw_feeds: Any = []
+    for key in FEED_LIST_KEYS:
+        value = feedpage.get(key)
+        if value:
+            raw_feeds = value
+            break
+    if isinstance(raw_feeds, dict):
+        raw_feeds = extract_raw_feeds(raw_feeds)
+    if not isinstance(raw_feeds, list):
+        return []
+    return raw_feeds
+
+
+def feed_page_has_more(feedpage: dict[str, Any]) -> bool:
+    for key in FEED_HAS_MORE_KEYS:
+        if key not in feedpage:
+            continue
+        value = feedpage.get(key)
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes"}
+        return bool(value)
+    return False
+
+
+def feed_page_cursor(feedpage: dict[str, Any]) -> str:
+    for key in FEED_CURSOR_KEYS:
+        value = feedpage.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return ""
+
+
 def extract_feed_page(payload: dict[str, Any], *, default_hostuin: int = 0) -> tuple[dict[str, Any], list[FeedEntry]]:
-    feedpage = payload.get("feedpage") if isinstance(payload.get("feedpage"), dict) else payload
+    feedpage = normalize_feed_page(payload)
     if not isinstance(feedpage, dict):
         return {}, []
-    raw_feeds = feedpage.get("vFeeds") or feedpage.get("vfeeds") or feedpage.get("msglist") or feedpage.get("data") or []
-    if isinstance(raw_feeds, dict):
-        raw_feeds = raw_feeds.get("vFeeds") or raw_feeds.get("vfeeds") or raw_feeds.get("msglist") or raw_feeds.get("data") or []
-    if not isinstance(raw_feeds, list):
-        raw_feeds = []
-    items = [extract_feed_entry(item, default_hostuin=default_hostuin) for item in raw_feeds if isinstance(item, dict)]
+    raw_feeds = extract_raw_feeds(feedpage)
+    items = [
+        extract_feed_entry(item, default_hostuin=default_hostuin)
+        for item in raw_feeds
+        if isinstance(item, dict)
+    ]
     return feedpage, items

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -1,10 +1,11 @@
 import unittest
+from urllib.parse import parse_qs
 
 import httpx
 
 from qzone_bridge.client import QzoneClient
-from qzone_bridge.errors import QzoneNeedsRebind, QzoneRequestError
-from qzone_bridge.models import SessionState
+from qzone_bridge.errors import QzoneNeedsRebind, QzoneParseError, QzoneRequestError
+from qzone_bridge.models import FeedEntry, SessionState
 
 
 class ClientErrorMappingTests(unittest.IsolatedAsyncioTestCase):
@@ -90,6 +91,63 @@ class ClientErrorMappingTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(QzoneRequestError) as caught:
             await self.client._request_json("GET", "https://mobile.qzone.qq.com/feeds/mfeeds_get_count")
         self.assertNotIsInstance(caught.exception, QzoneNeedsRebind)
+
+    async def test_jsonish_qzone_payload_falls_back_to_js_literal_parser(self):
+        text = """
+        {
+            "code":0,
+            "subcode":0,
+            "message":"",
+            "default":0,
+            "data": {
+                main:{
+                    attach:'',
+                    hasMoreFeeds:true,
+                    pagenum:'2',
+                    externparam:'basetime=1778625269&pagenum=2',
+                    data:[{uin:123456, tid:'fid-1', content:'hello'}]
+                }
+            }
+        }
+        """
+        await self._use_response(lambda request: httpx.Response(200, text=text, request=request))
+
+        payload = await self.client._request_json(
+            "GET",
+            "https://user.qzone.qq.com/proxy/domain/ic2.qzone.qq.com/cgi-bin/feeds/feeds3_html_more",
+        )
+
+        self.assertTrue(payload["main"]["hasMoreFeeds"])
+        self.assertEqual(payload["main"]["data"][0]["tid"], "fid-1")
+
+    async def test_plain_non_json_text_still_fails_as_parse_error(self):
+        await self._use_response(lambda request: httpx.Response(200, text="ok", request=request))
+
+        with self.assertRaises(QzoneParseError):
+            await self.client._request_json("GET", "https://mobile.qzone.qq.com/feeds/mfeeds_get_count")
+
+    async def test_like_uses_cached_legacy_unikey_and_curkey(self):
+        seen_form = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_form.update(parse_qs(request.content.decode()))
+            return httpx.Response(200, json={"code": 0, "message": "ok"}, request=request)
+
+        await self._use_response(handler)
+        self.client.feed_cache[(123456, "fid-1")] = FeedEntry(
+            hostuin=123456,
+            fid="fid-1",
+            appid=311,
+            summary="hello",
+            curkey="cached-curkey",
+            unikey="cached-unikey",
+        )
+
+        payload = await self.client.like_post(123456, "fid-1")
+
+        self.assertEqual(payload["message"], "ok")
+        self.assertEqual(seen_form["curkey"][0], "cached-curkey")
+        self.assertEqual(seen_form["unikey"][0], "cached-unikey")
 
 
 if __name__ == "__main__":

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -99,7 +99,14 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
                 ) as index, patch.object(
                     service.client,
                     "legacy_recent_feeds",
-                    new=AsyncMock(return_value={"msglist": [{"tid": "fid-1", "uin": 123456, "content": "hello"}]}),
+                    new=AsyncMock(
+                        return_value={
+                            "main": {
+                                "hasMoreFeeds": False,
+                                "data": [{"tid": "fid-1", "uin": 123456, "content": "hello"}],
+                            }
+                        }
+                    ),
                 ) as legacy:
                     payload = await service.list_feeds(limit=1)
                 index.assert_awaited_once()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,6 +3,8 @@ import unittest
 from qzone_bridge.parser import (
     extract_feed_entry,
     extract_feed_page,
+    feed_page_cursor,
+    feed_page_has_more,
     parse_cookie_text,
     parse_index_html,
     parse_profile_html,
@@ -88,6 +90,35 @@ class ParserTests(unittest.TestCase):
         feedpage, items = extract_feed_page({"msglist": [{"tid": "fid-1", "uin": 123456, "content": "hello"}]})
         self.assertEqual(feedpage["msglist"][0]["tid"], "fid-1")
         self.assertEqual(items[0].fid, "fid-1")
+
+    def test_extract_feed_page_accepts_legacy_main_container(self):
+        feedpage, items = extract_feed_page(
+            {
+                "main": {
+                    "hasMoreFeeds": True,
+                    "attach": "",
+                    "externparam": "basetime=1778625269&pagenum=2",
+                    "data": [
+                        {
+                            "key": "fid-legacy",
+                            "nickname": "Alice",
+                            "html": (
+                                "<div data-uin='123456' data-fid='fid-legacy' "
+                                "data-appid='311' data-curkey='cur-key' "
+                                "data-unikey='uni-key'>hello<br>legacy</div>"
+                            ),
+                        }
+                    ],
+                }
+            }
+        )
+        self.assertTrue(feed_page_has_more(feedpage))
+        self.assertEqual(feed_page_cursor(feedpage), "basetime=1778625269&pagenum=2")
+        self.assertEqual(items[0].fid, "fid-legacy")
+        self.assertEqual(items[0].hostuin, 123456)
+        self.assertEqual(items[0].curkey, "cur-key")
+        self.assertEqual(items[0].unikey, "uni-key")
+        self.assertIn("hello", items[0].summary)
 
     def test_unwrap_payload_keeps_legacy_data_behavior(self):
         payload = {"data": {"code": -3000, "message": "登录态失效"}}


### PR DESCRIPTION
## What changed
- Added a strict JSON -> JSONP/callback -> QQ-style JS literal parsing fallback for Qzone responses.
- Normalized legacy feed pages that arrive under `data.main`, including `hasMoreFeeds`, `attach`, and `externparam` pagination fields.
- Extracted legacy HTML feed `data-curkey` / `data-unikey` values and made like/unlike use cached keys when available.
- Added regression coverage for the mixed JSON/JS response shape, plain non-JSON failures, legacy `main` feed pages, and cached like keys.

## Why
Some Qzone endpoints can return a JSON-looking outer object whose `data` value is a JavaScript object literal with unquoted keys, single-quoted strings, and booleans. The old parser treated any `{...}` response as strict JSON and raised `无法解析 QQ 空间 JSON 响应`, which broke feed reading and downstream actions such as like/unlike.

## Validation
- `python -m py_compile qzone_bridge/client.py qzone_bridge/parser.py qzone_bridge/daemon.py tests/test_client_errors.py tests/test_parser.py tests/test_daemon_lifecycle.py`
- `python -m pytest` (`98 passed`)