### PR TITLE
[codex] Verify Qzone like state

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,7 +42,14 @@ from qzone_bridge.models import FeedEntry
 from qzone_bridge.onebot_cookie import fetch_cookie_text
 from qzone_bridge.parser import normalize_uin, parse_cookie_text
 from qzone_bridge.publish_renderer import RenderProfile, profile_from_event, render_publish_result_image
-from qzone_bridge.render import format_action_result, format_feed_detail, format_feed_list, format_status
+from qzone_bridge.render import (
+    format_action_result,
+    format_feed_detail,
+    format_feed_list,
+    format_like_result,
+    format_llm_feed_list,
+    format_status,
+)
 from qzone_bridge.settings import PluginSettings
 from qzone_bridge.utils import truncate
 
@@ -590,7 +597,7 @@ class QzoneStablePlugin(Star):
         except QzoneBridgeError as exc:
             yield self._command_result(event, self._error_text(exc))
             return
-        yield self._command_result(event, format_action_result("点赞成功", payload))
+        yield self._command_result(event, format_like_result(payload))
 
     @filter.llm_tool(name="qzone_get_status")
     async def tool_get_status(self, event: AstrMessageEvent):
@@ -632,7 +639,7 @@ class QzoneStablePlugin(Star):
             yield event.plain_result(self._error_text(exc))
             return
         entries = self._to_feed_entries(payload)
-        yield event.plain_result(format_feed_list(entries, cursor=str(payload.get("cursor") or ""), has_more=bool(payload.get("has_more"))))
+        yield event.plain_result(format_llm_feed_list(entries))
 
     @filter.llm_tool(name="qzone_detail_feed")
     async def tool_detail_feed(self, event: AstrMessageEvent, hostuin: int, fid: str, appid: int = 311):
@@ -748,8 +755,8 @@ class QzoneStablePlugin(Star):
     async def tool_like_post(
         self,
         event: AstrMessageEvent,
-        hostuin: int,
-        fid: str,
+        hostuin: int = 0,
+        fid: str = "",
         confirm: bool = False,
         appid: int = 311,
         unlike: bool = False,
@@ -757,8 +764,8 @@ class QzoneStablePlugin(Star):
         """点赞或取消点赞一条说说。
 
         Args:
-            hostuin (number): 目标 QQ 号。
-            fid (string): 说说 fid。
+            hostuin (number): 目标 QQ 号。为 0 且 fid 为数字时，表示最近列表中的编号。
+            fid (string): 说说 fid，或最近列表中的编号。
             confirm (boolean): 是否确认执行。
             appid (number): 应用 id。
             unlike (boolean): 是否取消点赞。
@@ -768,7 +775,8 @@ class QzoneStablePlugin(Star):
             return
         if self.settings.preview_writes and not confirm:
             action = "取消点赞" if unlike else "点赞"
-            yield event.plain_result(f"待执行草稿: {action} hostuin={hostuin}, fid={fid}。确认后将执行。")
+            target = f"第 {fid} 条" if not hostuin and str(fid).isdigit() else "指定说说"
+            yield event.plain_result(f"待执行: {action}{target}。确认后将执行。")
             return
         try:
             await self._ensure_cookie_ready(event)
@@ -777,7 +785,7 @@ class QzoneStablePlugin(Star):
         except QzoneBridgeError as exc:
             yield event.plain_result(self._error_text(exc))
             return
-        yield event.plain_result(format_action_result("点赞成功", payload))
+        yield event.plain_result(format_like_result(payload))
 
     async def terminate(self):
         try:

--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -846,6 +846,7 @@ class QzoneClient:
         *,
         appid: int = 311,
         curkey: str = "",
+        unikey: str = "",
         like: bool = True,
     ) -> dict[str, Any]:
         cached = self.feed_cache.get((hostuin, fid))
@@ -855,11 +856,12 @@ class QzoneClient:
         if not curkey:
             curkey = compute_unikey(appid, hostuin, fid)
 
-        unikey = (
+        unikey = unikey or (
             cached.unikey
             if cached and cached.unikey
             else compute_unikey(appid, hostuin, fid)
         )
+        created_at = cached.created_at if cached else 0
         path = (
             "https://user.qzone.qq.com/proxy/domain/w.qzone.qq.com/cgi-bin/likes/internal_dolike_app"
             if like
@@ -873,8 +875,17 @@ class QzoneClient:
                 "curkey": curkey,
                 "appid": appid,
                 "opuin": self.login_uin,
+                "uin": self.login_uin,
+                "hostuin": hostuin,
+                "fid": fid,
+                "from": 1,
+                "typeid": 0,
+                "abstime": created_at,
+                "active": 0,
+                "fupdate": 1,
                 "opr_type": "like" if like else "unlike",
                 "format": "purejson",
+                "qzreferrer": f"https://user.qzone.qq.com/{hostuin}/mood/{fid}",
             },
             referer=f"https://user.qzone.qq.com/{hostuin}/mood/{fid}",
             origin="https://user.qzone.qq.com",

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -17,7 +17,15 @@ from .client import FeedPageResult, QzoneClient
 from .errors import QzoneAuthError, QzoneBridgeError, QzoneNeedsRebind, QzoneParseError, QzoneRequestError
 from .media import QZONE_MAX_IMAGES, media_reference_text, normalize_media_list, split_publishable_images, strip_command_prefix
 from .models import BridgeState, FeedEntry, SessionState
-from .parser import extract_feed_page, feed_page_cursor, feed_page_has_more, normalize_uin, parse_cookie_text, unwrap_payload
+from .parser import (
+    compute_unikey,
+    extract_feed_page,
+    feed_page_cursor,
+    feed_page_has_more,
+    normalize_uin,
+    parse_cookie_text,
+    unwrap_payload,
+)
 from .protocol import SECRET_HEADER, fail, ok
 from .storage import StateStore, ensure_state_secret
 from .utils import now_iso, from_iso
@@ -51,6 +59,7 @@ class QzoneDaemonService:
         self._keepalive_task: asyncio.Task | None = None
         self._warmup_task: asyncio.Task | None = None
         self._save_task: asyncio.Task | None = None
+        self.recent_feed_entries: list[FeedEntry] = []
         self._closing = False
 
     def save(self) -> None:
@@ -97,6 +106,7 @@ class QzoneDaemonService:
             self.state.session.needs_rebind = True
             self.state.session.qzonetokens.clear()
             self.client.feed_cache.clear()
+            self.recent_feed_entries.clear()
         elif isinstance(exc, QzoneRequestError) and exc.status_code is not None and 400 <= exc.status_code < 500:
             if self.state.session.cookies and not self.state.session.needs_rebind:
                 self.health_state = "ready"
@@ -215,6 +225,7 @@ class QzoneDaemonService:
         )
         self.client.update_session(self.state.session)
         self.client.feed_cache.clear()
+        self.recent_feed_entries.clear()
         self.save()
         try:
             await self.warmup()
@@ -237,6 +248,7 @@ class QzoneDaemonService:
         )
         self.client.update_session(self.state.session)
         self.client.feed_cache.clear()
+        self.recent_feed_entries.clear()
         self.save()
         self.health_state = "needs_rebind"
         return self.snapshot()
@@ -283,10 +295,12 @@ class QzoneDaemonService:
                 break
             page_round += 1
 
+        visible_items = items[:limit]
+        self.recent_feed_entries = visible_items
         return {
             "scope": scope,
             "hostuin": hostuin,
-            "items": [asdict(item) for item in items[:limit]],
+            "items": [asdict(item) for item in visible_items],
             "has_more": has_more,
             "cursor": next_cursor,
             "count": min(len(items), limit),
@@ -384,6 +398,50 @@ class QzoneDaemonService:
             "raw": payload,
         }
 
+    def _resolve_recent_feed_reference(self, hostuin: int, fid: str, appid: int, curkey: str = "") -> tuple[int, str, int, str]:
+        fid_text = str(fid or "").strip()
+        if not hostuin and fid_text.isdigit():
+            index = int(fid_text) - 1
+            if 0 <= index < len(self.recent_feed_entries):
+                entry = self.recent_feed_entries[index]
+                return entry.hostuin, entry.fid, entry.appid or appid, curkey or entry.curkey
+        return int(hostuin or self.state.session.uin or 0), fid_text, int(appid or 311), curkey
+
+    @staticmethod
+    def _http_like_key(appid: int, hostuin: int, fid: str) -> str:
+        return compute_unikey(appid, hostuin, fid).replace("https://", "http://", 1)
+
+    async def _refresh_like_entry(self, hostuin: int, fid: str, appid: int) -> FeedEntry | None:
+        try:
+            payload = unwrap_payload(await self.client.detail(hostuin, fid, appid=appid))
+        except Exception as exc:
+            log.debug("qzone like verification refresh failed: %s", exc)
+        else:
+            if isinstance(payload, dict):
+                entry = self.client.feed_entry_from_payload(payload, default_hostuin=hostuin)
+                self.client.cache_feed_page(hostuin, [entry])
+                return entry
+
+        for fetch in (
+            self.client.legacy_recent_feeds if hostuin == self.state.session.uin else None,
+            lambda: self.client.legacy_feeds(hostuin, page=1, num=20),
+        ):
+            if fetch is None:
+                continue
+            try:
+                payload = unwrap_payload(await fetch())
+            except Exception as exc:
+                log.debug("qzone like verification feed fallback failed: %s", exc)
+                continue
+            feedpage, entries = extract_feed_page(payload, default_hostuin=hostuin)
+            if not feedpage:
+                continue
+            self.client.cache_feed_page(hostuin, entries)
+            for entry in entries:
+                if entry.fid == fid:
+                    return entry
+        return None
+
     async def like_post(
         self,
         *,
@@ -394,14 +452,65 @@ class QzoneDaemonService:
         unlike: bool = False,
     ) -> dict[str, Any]:
         self._ensure_session_ready()
+        hostuin, fid, appid, curkey = self._resolve_recent_feed_reference(hostuin, fid, appid, curkey)
+        if not hostuin or not fid:
+            raise QzoneParseError("点赞目标不完整，请先选择一条说说")
+
+        target_liked = not unlike
+        before_entry = await self._refresh_like_entry(hostuin, fid, appid)
+        if before_entry is not None and before_entry.liked == target_liked:
+            self._set_success(defer_save=True)
+            return {
+                "action": "unlike" if unlike else "like",
+                "liked": before_entry.liked,
+                "verified": True,
+                "already": True,
+                "summary": before_entry.summary,
+                "raw": {},
+            }
+
         payload = unwrap_payload(
             await self.client.like_post(hostuin, fid, appid=appid, curkey=curkey, like=not unlike)
         )
         if not isinstance(payload, dict):
             raise QzoneParseError("点赞返回结构异常")
+        verified_entry = await self._refresh_like_entry(hostuin, fid, appid)
+        if verified_entry is not None and verified_entry.liked != target_liked:
+            fallback_key = self._http_like_key(appid, hostuin, fid)
+            if fallback_key not in {curkey, compute_unikey(appid, hostuin, fid)}:
+                payload = unwrap_payload(
+                    await self.client.like_post(
+                        hostuin,
+                        fid,
+                        appid=appid,
+                        curkey=fallback_key,
+                        unikey=fallback_key,
+                        like=not unlike,
+                    )
+                )
+                if not isinstance(payload, dict):
+                    raise QzoneParseError("点赞返回结构异常")
+                verified_entry = await self._refresh_like_entry(hostuin, fid, appid)
+
+        if verified_entry is not None and verified_entry.liked != target_liked:
+            action_text = "取消点赞" if unlike else "点赞"
+            raise QzoneRequestError(
+                f"{action_text}请求已发送，但 QQ 空间未确认状态变更",
+                detail={
+                    "hostuin": hostuin,
+                    "fid": fid,
+                    "expected_liked": target_liked,
+                    "actual_liked": verified_entry.liked,
+                    "raw": payload,
+                },
+            )
         self._set_success(defer_save=True)
         return {
             "action": "unlike" if unlike else "like",
+            "liked": verified_entry.liked if verified_entry is not None else target_liked,
+            "verified": verified_entry is not None,
+            "already": False,
+            "summary": verified_entry.summary if verified_entry is not None else "",
             "message": payload.get("msg") or payload.get("message") or "",
             "raw": payload,
         }

--- a/qzone_bridge/parser.py
+++ b/qzone_bridge/parser.py
@@ -90,6 +90,22 @@ def _int(value: Any, default: int = 0) -> int:
         return default
 
 
+def _bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "y"}:
+            return True
+        if normalized in {"0", "false", "no", "n", ""}:
+            return False
+    return bool(value)
+
+
 def parse_cookie_text(cookie_text: str) -> dict[str, str]:
     cookie_text = cookie_text.strip()
     if not cookie_text:
@@ -391,7 +407,19 @@ def extract_feed_entry(feed_item: dict[str, Any], *, default_hostuin: int = 0) -
     )
     if not comment_count and isinstance(raw_comments, list):
         comment_count = len(raw_comments)
-    liked = bool(like.get("isliked") or like.get("ismylike") or feed_item.get("isliked") or False)
+    liked = _bool(
+        like.get("isliked")
+        if "isliked" in like
+        else like.get("ismylike")
+        if "ismylike" in like
+        else like.get("isLike")
+        if "isLike" in like
+        else like.get("islike")
+        if "islike" in like
+        else feed_item.get("isliked")
+        if "isliked" in feed_item
+        else feed_item.get("liked")
+    )
     busi_param = operation.get("busi_param") or {}
     if not isinstance(busi_param, dict):
         busi_param = {}
@@ -458,10 +486,7 @@ def feed_page_has_more(feedpage: dict[str, Any]) -> bool:
     for key in FEED_HAS_MORE_KEYS:
         if key not in feedpage:
             continue
-        value = feedpage.get(key)
-        if isinstance(value, str):
-            return value.strip().lower() in {"1", "true", "yes"}
-        return bool(value)
+        return _bool(feedpage.get(key))
     return False
 
 

--- a/qzone_bridge/render.py
+++ b/qzone_bridge/render.py
@@ -47,25 +47,49 @@ def format_status(status: dict) -> str:
     return "\n".join(lines)
 
 
-def format_feed_entry(entry: FeedEntry, index: int | None = None) -> str:
+def format_feed_entry(entry: FeedEntry, index: int | None = None, *, include_internal: bool = True) -> str:
     prefix = f"{index}. " if index is not None else "- "
     headline = truncate(entry.summary or "(empty)", 90)
-    lines = [
-        f"{prefix}{to_local_time_text(entry.created_at)} | {entry.nickname or entry.hostuin}",
-        f"   fid={entry.fid} appid={entry.appid} like={entry.like_count} comment={entry.comment_count} liked={entry.liked}",
-        f"   {headline}",
-    ]
+    lines = [f"{prefix}{to_local_time_text(entry.created_at)} | {entry.nickname or entry.hostuin}"]
+    if include_internal:
+        lines.append(
+            f"   fid={entry.fid} appid={entry.appid} "
+            f"like={entry.like_count} comment={entry.comment_count} liked={entry.liked}"
+        )
+    else:
+        liked_text = "已点赞" if entry.liked else "未点赞"
+        lines.append(f"   {liked_text}，{entry.like_count} 赞，{entry.comment_count} 评论")
+    lines.append(f"   {headline}")
     return "\n".join(lines)
 
 
-def format_feed_list(entries: Iterable[FeedEntry], *, cursor: str = "", has_more: bool = False) -> str:
-    rendered = [format_feed_entry(entry, i + 1) for i, entry in enumerate(entries)]
+def format_feed_list(
+    entries: Iterable[FeedEntry],
+    *,
+    cursor: str = "",
+    has_more: bool = False,
+    include_internal: bool = True,
+    include_pagination: bool = True,
+) -> str:
+    rendered = [
+        format_feed_entry(entry, i + 1, include_internal=include_internal)
+        for i, entry in enumerate(entries)
+    ]
     footer = []
-    if cursor:
-        footer.append(f"cursor={cursor}")
-    footer.append(f"has_more={has_more}")
+    if include_pagination:
+        if cursor:
+            footer.append(f"cursor={cursor}")
+        footer.append(f"has_more={has_more}")
     body = "\n".join(rendered) if rendered else "(no feeds)"
     return "\n".join([body, *footer])
+
+
+def format_llm_feed_list(entries: Iterable[FeedEntry]) -> str:
+    entries = list(entries)
+    if not entries:
+        return "没有找到可操作的说说。"
+    body = format_feed_list(entries, include_internal=False, include_pagination=False)
+    return f"{body}\n可直接让我点赞或取消点赞对应编号。"
 
 
 def format_feed_detail(entry: FeedEntry) -> str:
@@ -92,3 +116,17 @@ def format_action_result(title: str, payload: dict) -> str:
             continue
         parts.append(f"- {key}: {value}")
     return "\n".join(parts)
+
+
+def format_like_result(payload: dict) -> str:
+    action = "取消点赞" if payload.get("action") == "unlike" else "点赞"
+    summary = truncate(str(payload.get("summary") or ""), 80)
+    suffix = f"：{summary}" if summary else ""
+    if payload.get("verified"):
+        if payload.get("already"):
+            state = "已是目标状态"
+        else:
+            state = "成功"
+        liked = "当前已点赞" if payload.get("liked") else "当前未点赞"
+        return f"{action}{state}{suffix}（{liked}）。"
+    return f"{action}请求已提交，但暂未能确认 QQ 空间状态{suffix}。"

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -148,6 +148,11 @@ class ClientErrorMappingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["message"], "ok")
         self.assertEqual(seen_form["curkey"][0], "cached-curkey")
         self.assertEqual(seen_form["unikey"][0], "cached-unikey")
+        self.assertEqual(seen_form["hostuin"][0], "123456")
+        self.assertEqual(seen_form["fid"][0], "fid-1")
+        self.assertEqual(seen_form["uin"][0], "123456")
+        self.assertEqual(seen_form["from"][0], "1")
+        self.assertEqual(seen_form["fupdate"][0], "1")
 
 
 if __name__ == "__main__":

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -284,6 +284,157 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             finally:
                 await service.close()
 
+    async def test_like_post_verifies_liked_state_after_request(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            before = {
+                "tid": "fid-1",
+                "uin": 123456,
+                "content": "hello",
+                "like": {"isliked": "0"},
+            }
+            after = {
+                "tid": "fid-1",
+                "uin": 123456,
+                "content": "hello",
+                "like": {"isliked": "1"},
+            }
+            try:
+                with patch.object(service.client, "detail", new=AsyncMock(side_effect=[before, after])) as detail, patch.object(
+                    service.client,
+                    "like_post",
+                    new=AsyncMock(return_value={"message": "ok"}),
+                ) as like:
+                    payload = await service.like_post(hostuin=123456, fid="fid-1")
+                self.assertEqual(detail.await_count, 2)
+                like.assert_awaited_once()
+                self.assertTrue(payload["verified"])
+                self.assertTrue(payload["liked"])
+                self.assertFalse(payload["already"])
+            finally:
+                await service.close()
+
+    async def test_like_post_retries_http_key_when_first_request_does_not_change_state(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            false_state = {
+                "tid": "fid-1",
+                "uin": 123456,
+                "content": "hello",
+                "like": {"isliked": "0"},
+            }
+            true_state = {
+                "tid": "fid-1",
+                "uin": 123456,
+                "content": "hello",
+                "like": {"isliked": "1"},
+            }
+            try:
+                with patch.object(
+                    service.client,
+                    "detail",
+                    new=AsyncMock(side_effect=[false_state, false_state, true_state]),
+                ), patch.object(
+                    service.client,
+                    "like_post",
+                    new=AsyncMock(return_value={"message": "ok"}),
+                ) as like:
+                    payload = await service.like_post(hostuin=123456, fid="fid-1")
+                self.assertEqual(like.await_count, 2)
+                _, second_kwargs = like.await_args_list[1]
+                self.assertEqual(second_kwargs["curkey"], "http://user.qzone.qq.com/123456/mood/fid-1")
+                self.assertEqual(second_kwargs["unikey"], "http://user.qzone.qq.com/123456/mood/fid-1")
+                self.assertTrue(payload["verified"])
+                self.assertTrue(payload["liked"])
+            finally:
+                await service.close()
+
+    async def test_like_post_verification_falls_back_to_legacy_feed_page(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            before = {"msglist": [{"tid": "fid-1", "uin": 3112333596, "content": "hello", "isliked": "0"}]}
+            after = {"msglist": [{"tid": "fid-1", "uin": 3112333596, "content": "hello", "isliked": "1"}]}
+            try:
+                with patch.object(
+                    service.client,
+                    "detail",
+                    new=AsyncMock(side_effect=QzoneRequestError("detail unavailable")),
+                ), patch.object(
+                    service.client,
+                    "legacy_feeds",
+                    new=AsyncMock(side_effect=[before, after]),
+                ) as legacy, patch.object(
+                    service.client,
+                    "like_post",
+                    new=AsyncMock(return_value={"message": "ok"}),
+                ):
+                    payload = await service.like_post(hostuin=3112333596, fid="fid-1")
+                self.assertEqual(legacy.await_count, 2)
+                self.assertTrue(payload["verified"])
+                self.assertTrue(payload["liked"])
+            finally:
+                await service.close()
+
+    async def test_like_post_accepts_recent_feed_index_reference(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            service.recent_feed_entries = [
+                FeedEntry(
+                    hostuin=3112333596,
+                    fid="1c7182b96589046ad3380900",
+                    appid=311,
+                    summary="瘦了…………",
+                    liked=False,
+                    curkey="cached-curkey",
+                )
+            ]
+            before = {
+                "tid": "1c7182b96589046ad3380900",
+                "uin": 3112333596,
+                "content": "瘦了…………",
+                "like": {"isliked": "0"},
+            }
+            after = {
+                "tid": "1c7182b96589046ad3380900",
+                "uin": 3112333596,
+                "content": "瘦了…………",
+                "like": {"isliked": "1"},
+            }
+            try:
+                with patch.object(service.client, "detail", new=AsyncMock(side_effect=[before, after])), patch.object(
+                    service.client,
+                    "like_post",
+                    new=AsyncMock(return_value={"message": "ok"}),
+                ) as like:
+                    payload = await service.like_post(hostuin=0, fid="1")
+                args, kwargs = like.await_args
+                self.assertEqual(args[:2], (3112333596, "1c7182b96589046ad3380900"))
+                self.assertEqual(kwargs["curkey"], "cached-curkey")
+                self.assertTrue(payload["verified"])
+                self.assertEqual(payload["summary"], "瘦了…………")
+            finally:
+                await service.close()
+
 
 class ControllerLifecycleTests(unittest.IsolatedAsyncioTestCase):
     async def test_close_shuts_down_daemon_and_releases_port(self):

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import types
 import unittest
+from dataclasses import asdict
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -264,6 +265,56 @@ class MainPublishTests(unittest.TestCase):
         self.assertEqual(captured["profile"].nickname, "QzoneOwner")
         self.assertEqual(captured["profile"].user_id, "123456")
         self.assertIn("123456", captured["profile"].avatar_source)
+
+    def test_llm_list_feed_hides_cursor_and_internal_ids(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        entry = module.FeedEntry(
+            hostuin=3112333596,
+            fid="1c7182b96589046ad3380900",
+            appid=311,
+            summary="瘦了…………",
+            liked=False,
+        )
+        plugin.controller.list_feeds = AsyncMock(
+            return_value={
+                "items": [asdict(entry)],
+                "cursor": "back_server_info=secret",
+                "has_more": True,
+            }
+        )
+        event = Event([])
+
+        results = asyncio.run(collect_async_generator(plugin.tool_list_feed(event, limit=1)))
+
+        self.assertEqual(len(results), 1)
+        self.assertIn("瘦了", results[0])
+        self.assertIn("未点赞", results[0])
+        self.assertNotIn("cursor=", results[0])
+        self.assertNotIn("has_more", results[0])
+        self.assertNotIn("fid=", results[0])
+
+    def test_llm_like_tool_returns_natural_verified_result(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin.controller.like_post = AsyncMock(
+            return_value={
+                "action": "like",
+                "liked": True,
+                "verified": True,
+                "already": False,
+                "summary": "瘦了…………",
+            }
+        )
+        event = Event([])
+
+        results = asyncio.run(
+            collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=True))
+        )
+
+        plugin.controller.like_post.assert_awaited_once_with(hostuin=0, fid="1", appid=311, unlike=False)
+        self.assertEqual(results, ["点赞成功：瘦了…………（当前已点赞）。"])
+        self.assertNotIn("fid=", results[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -71,6 +71,27 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(entry.summary, "hello qzone")
         self.assertEqual(entry.unikey, "https://user.qzone.qq.com/123456/mood/fid-1")
 
+    def test_extract_feed_entry_parses_string_liked_flags(self):
+        entry = extract_feed_entry(
+            {
+                "tid": "fid-1",
+                "uin": 123456,
+                "content": "hello",
+                "like": {"isliked": "0"},
+            }
+        )
+        self.assertFalse(entry.liked)
+
+        entry = extract_feed_entry(
+            {
+                "tid": "fid-2",
+                "uin": 123456,
+                "content": "hello",
+                "like": {"isliked": "1"},
+            }
+        )
+        self.assertTrue(entry.liked)
+
     def test_extract_legacy_feed_entry(self):
         raw = {
             "tid": "legacy-fid",


### PR DESCRIPTION
## What changed
- Verify like/unlike operations by refreshing the target feed state after the request.
- Retry Qzone like with the legacy `http://user.qzone.qq.com/...` key when the first request returns but the liked state does not change.
- Add extra legacy like fields (`uin`, `hostuin`, `fid`, `from`, `typeid`, `abstime`, `fupdate`, `qzreferrer`) to improve compatibility with Qzone's old like endpoint.
- Let LLM like calls refer to the latest listed feed by number (`hostuin=0`, `fid=1`) so user-facing list output no longer needs to expose raw fid/cursor fields.
- Make LLM feed and like outputs natural-language summaries instead of leaking `cursor`, `has_more`, `fid`, and `appid` internals.
- Parse string liked flags such as `0` and `1` correctly.

## Why
The previous flow treated a successful HTTP/API response as liked, but Qzone can return a normal payload without actually changing the liked state when the key format or endpoint parameters are not accepted. That made the bot say success even though the post stayed unliked.

## Validation
- `python -m py_compile qzone_bridge/client.py qzone_bridge/parser.py qzone_bridge/daemon.py qzone_bridge/render.py main.py tests/test_client_errors.py tests/test_parser.py tests/test_daemon_lifecycle.py tests/test_main_publish.py`
- `python -m pytest tests/test_daemon_lifecycle.py tests/test_main_publish.py tests/test_parser.py tests/test_client_errors.py` (`43 passed`)
- `python -m pytest` (`105 passed`)