### PR TITLE
[codex] Handle scalar Qzone like responses

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import json
 import sys
 import time
 from pathlib import Path
@@ -255,6 +256,43 @@ class QzoneStablePlugin(Star):
             if parts:
                 return f"{exc.message}（{', '.join(parts)}）"
         return f"{exc.message}\n{exc.detail}"
+
+    def _llm_tool_result(self, payload: dict[str, Any]) -> str:
+        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+    def _llm_like_result(self, payload: dict[str, Any]) -> str:
+        visible_payload = {
+            key: value
+            for key, value in payload.items()
+            if key not in {"raw", "detail"} and not isinstance(value, (dict, list))
+        }
+        return self._llm_tool_result(
+            {
+                "ok": True,
+                "tool": "qzone_like_post",
+                "result": visible_payload,
+                "reply_guidance": (
+                    "请根据 result 用自然语言回复用户。"
+                    "如果 verified 为 true，说明 QQ 空间状态已确认；"
+                    "如果 verified 为 false，请说明请求已提交但状态暂未确认。"
+                    "不要暴露 fid、cursor、raw 或内部字段。"
+                ),
+            }
+        )
+
+    def _llm_error_result(self, tool: str, exc: QzoneBridgeError) -> str:
+        return self._llm_tool_result(
+            {
+                "ok": False,
+                "tool": tool,
+                "error": {
+                    "type": type(exc).__name__,
+                    "code": exc.code,
+                    "message": exc.message,
+                },
+                "reply_guidance": "请根据 error 用自然语言简短告知用户失败原因，不要暴露内部字段。",
+            }
+        )
 
     async def _ensure_daemon(self, *, allow_needs_rebind: bool = False) -> None:
         status = await self.controller.get_status()
@@ -724,7 +762,7 @@ class QzoneStablePlugin(Star):
             hostuin (number): 目标 QQ 号。
             fid (string): 说说 fid。
             content (string): 评论内容。
-            confirm (boolean): 是否确认执行。
+            confirm (boolean): 兼容旧参数；点赞工具会直接执行。
             appid (number): 应用 id。
             private (boolean): 是否私密评论。
         """
@@ -771,21 +809,29 @@ class QzoneStablePlugin(Star):
             unlike (boolean): 是否取消点赞。
         """
         if not self._is_admin(event):
-            yield event.plain_result("仅管理员可点赞。")
-            return
-        if self.settings.preview_writes and not confirm:
-            action = "取消点赞" if unlike else "点赞"
-            target = f"第 {fid} 条" if not hostuin and str(fid).isdigit() else "指定说说"
-            yield event.plain_result(f"待执行: {action}{target}。确认后将执行。")
+            yield event.plain_result(
+                self._llm_tool_result(
+                    {
+                        "ok": False,
+                        "tool": "qzone_like_post",
+                        "error": {
+                            "type": "PermissionError",
+                            "code": "QZONE_PERMISSION",
+                            "message": "仅管理员可点赞。",
+                        },
+                        "reply_guidance": "请用自然语言告诉用户没有权限执行点赞。",
+                    }
+                )
+            )
             return
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
             payload = await self.controller.like_post(hostuin=hostuin, fid=fid, appid=appid, unlike=unlike)
         except QzoneBridgeError as exc:
-            yield event.plain_result(self._error_text(exc))
+            yield event.plain_result(self._llm_error_result("qzone_like_post", exc))
             return
-        yield event.plain_result(format_like_result(payload))
+        yield event.plain_result(self._llm_like_result(payload))
 
     async def terminate(self):
         try:

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -442,6 +442,13 @@ class QzoneDaemonService:
                     return entry
         return None
 
+    @staticmethod
+    def _normalize_action_payload(payload: Any) -> dict[str, Any]:
+        payload = unwrap_payload(payload)
+        if isinstance(payload, dict):
+            return payload
+        return {"value": payload}
+
     async def like_post(
         self,
         *,
@@ -469,16 +476,14 @@ class QzoneDaemonService:
                 "raw": {},
             }
 
-        payload = unwrap_payload(
+        payload = self._normalize_action_payload(
             await self.client.like_post(hostuin, fid, appid=appid, curkey=curkey, like=not unlike)
         )
-        if not isinstance(payload, dict):
-            raise QzoneParseError("点赞返回结构异常")
         verified_entry = await self._refresh_like_entry(hostuin, fid, appid)
         if verified_entry is not None and verified_entry.liked != target_liked:
             fallback_key = self._http_like_key(appid, hostuin, fid)
             if fallback_key not in {curkey, compute_unikey(appid, hostuin, fid)}:
-                payload = unwrap_payload(
+                payload = self._normalize_action_payload(
                     await self.client.like_post(
                         hostuin,
                         fid,
@@ -488,8 +493,6 @@ class QzoneDaemonService:
                         like=not unlike,
                     )
                 )
-                if not isinstance(payload, dict):
-                    raise QzoneParseError("点赞返回结构异常")
                 verified_entry = await self._refresh_like_entry(hostuin, fid, appid)
 
         if verified_entry is not None and verified_entry.liked != target_liked:

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -319,6 +319,68 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             finally:
                 await service.close()
 
+    async def test_like_post_accepts_scalar_success_response_when_verified(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            before = {
+                "tid": "fid-1",
+                "uin": 123456,
+                "content": "hello",
+                "like": {"isliked": "0"},
+            }
+            after = {
+                "tid": "fid-1",
+                "uin": 123456,
+                "content": "hello",
+                "like": {"isliked": "1"},
+            }
+            try:
+                with patch.object(service.client, "detail", new=AsyncMock(side_effect=[before, after])), patch.object(
+                    service.client,
+                    "like_post",
+                    new=AsyncMock(return_value={"data": 0}),
+                ):
+                    payload = await service.like_post(hostuin=123456, fid="fid-1")
+                self.assertTrue(payload["verified"])
+                self.assertTrue(payload["liked"])
+                self.assertEqual(payload["raw"]["value"], 0)
+            finally:
+                await service.close()
+
+    async def test_like_post_accepts_scalar_response_when_verification_unavailable(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            try:
+                with patch.object(
+                    service.client,
+                    "detail",
+                    new=AsyncMock(side_effect=QzoneRequestError("detail unavailable")),
+                ), patch.object(
+                    service.client,
+                    "legacy_feeds",
+                    new=AsyncMock(side_effect=QzoneRequestError("feed unavailable")),
+                ), patch.object(
+                    service.client,
+                    "like_post",
+                    new=AsyncMock(return_value={"data": 0}),
+                ):
+                    payload = await service.like_post(hostuin=123456, fid="fid-1")
+                self.assertFalse(payload["verified"])
+                self.assertTrue(payload["liked"])
+                self.assertEqual(payload["raw"]["value"], 0)
+            finally:
+                await service.close()
+
     async def test_like_post_retries_http_key_when_first_request_does_not_change_state(self):
         with TemporaryDirectory() as tmp:
             service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.util
+import json
 import sys
 import tempfile
 import types
@@ -294,7 +295,7 @@ class MainPublishTests(unittest.TestCase):
         self.assertNotIn("has_more", results[0])
         self.assertNotIn("fid=", results[0])
 
-    def test_llm_like_tool_returns_natural_verified_result(self):
+    def test_llm_like_tool_returns_structured_result_for_llm_reply(self):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin.controller.like_post = AsyncMock(
@@ -309,12 +310,59 @@ class MainPublishTests(unittest.TestCase):
         event = Event([])
 
         results = asyncio.run(
-            collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=True))
+            collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1"))
         )
 
         plugin.controller.like_post.assert_awaited_once_with(hostuin=0, fid="1", appid=311, unlike=False)
-        self.assertEqual(results, ["点赞成功：瘦了…………（当前已点赞）。"])
+        payload = json.loads(results[0])
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["tool"], "qzone_like_post")
+        self.assertTrue(payload["result"]["verified"])
+        self.assertTrue(payload["result"]["liked"])
+        self.assertEqual(payload["result"]["summary"], "瘦了…………")
+        self.assertIn("reply_guidance", payload)
+        self.assertNotIn("raw", payload["result"])
         self.assertNotIn("fid=", results[0])
+
+    def test_llm_like_tool_ignores_preview_confirmation(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin.settings.preview_writes = True
+        plugin.controller.like_post = AsyncMock(
+            return_value={
+                "action": "like",
+                "liked": True,
+                "verified": False,
+                "already": False,
+                "summary": "hello",
+            }
+        )
+        event = Event([])
+
+        results = asyncio.run(
+            collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
+        )
+
+        plugin.controller.like_post.assert_awaited_once()
+        payload = json.loads(results[0])
+        self.assertTrue(payload["ok"])
+        self.assertFalse(payload["result"]["verified"])
+
+    def test_llm_like_tool_returns_structured_error_for_llm_reply(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin.controller.like_post = AsyncMock(side_effect=module.QzoneBridgeError("点赞失败"))
+        event = Event([])
+
+        results = asyncio.run(
+            collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
+        )
+
+        payload = json.loads(results[0])
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["tool"], "qzone_like_post")
+        self.assertEqual(payload["error"]["message"], "点赞失败")
+        self.assertIn("reply_guidance", payload)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed
- Normalize Qzone like/unlike action responses before daemon validation so scalar or list-like responses no longer trigger `点赞返回结构异常`.
- Preserve scalar responses under `raw.value` while still using refreshed liked state as the source of truth when available.
- Let the LLM like tool execute immediately without the preview confirmation gate.
- Return structured JSON tool results for LLM like success and failure so the LLM can craft the user-facing reply instead of the plugin emitting fixed text.

## Why
Qzone's legacy like endpoint may return a scalar payload such as `0` after the client unwraps `{data:0}`. The previous daemon code required a dict and raised `点赞返回结构异常` even though the request could be valid and should be judged by follow-up state verification.

## Validation
- `python -m py_compile main.py tests/test_main_publish.py qzone_bridge/daemon.py tests/test_daemon_lifecycle.py`
- `python -m pytest tests/test_daemon_lifecycle.py tests/test_main_publish.py` (`29 passed`)
- `python -m pytest` (`109 passed`)