### PR TITLE
[codex] Fix Qzone like verification replies

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import importlib
 import json
 import sys
@@ -257,42 +258,158 @@ class QzoneStablePlugin(Star):
                 return f"{exc.message}（{', '.join(parts)}）"
         return f"{exc.message}\n{exc.detail}"
 
-    def _llm_tool_result(self, payload: dict[str, Any]) -> str:
-        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    async def _maybe_await(self, value: Any) -> Any:
+        if inspect.isawaitable(value):
+            return await value
+        return value
 
-    def _llm_like_result(self, payload: dict[str, Any]) -> str:
+    @staticmethod
+    def _text_from_llm_response(response: Any) -> str:
+        if response is None:
+            return ""
+        if isinstance(response, str):
+            return response.strip()
+        for attr in ("completion_text", "text", "content", "message"):
+            value = getattr(response, attr, None)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        if isinstance(response, dict):
+            for key in ("completion_text", "text", "content", "message"):
+                value = response.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+        return ""
+
+    async def _current_provider_id(self, event: AstrMessageEvent) -> Any | None:
+        context = getattr(self, "_context", None) or getattr(self, "context", None)
+        getter = getattr(context, "get_current_chat_provider_id", None)
+        if not callable(getter):
+            return None
+        umo = getattr(event, "unified_msg_origin", None)
+        attempts: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        if umo is not None:
+            attempts.append(((), {"umo": umo}))
+            attempts.append(((umo,), {}))
+        attempts.append(((), {}))
+        for args, kwargs in attempts:
+            try:
+                provider_id = await self._maybe_await(getter(*args, **kwargs))
+            except TypeError:
+                continue
+            except Exception as exc:
+                logger.debug("qzone llm provider id lookup failed: %s", exc)
+                return None
+            if provider_id:
+                return provider_id
+        return None
+
+    async def _ask_llm_tool_reply(self, event: AstrMessageEvent, payload: dict[str, Any], fallback: str) -> str:
+        data = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+        prompt = (
+            "下面是 QQ 空间工具执行结果 JSON，只用于你组织给用户的回复，不要原样输出。"
+            f"\n{data}\n"
+            "请直接用简短中文回复用户，不要输出 JSON，不要暴露字段名、tool、code、fid、cursor、raw、detail 等内部信息。"
+            "如果 ok 为 true，按已完成或已提交处理；verified 为 false 时说明 QQ 空间状态可能稍后刷新，不要说成失败。"
+            "如果 ok 为 false，只说明失败原因即可。"
+        )
+        system_prompt = "你是 AstrBot 的 QQ 空间助手，负责把工具执行结果改写成自然、简短、对用户友好的中文回复。"
+        context = getattr(self, "_context", None) or getattr(self, "context", None)
+
+        generator = getattr(context, "llm_generate", None)
+        if callable(generator):
+            kwargs: dict[str, Any] = {"prompt": prompt, "system_prompt": system_prompt}
+            provider_id = await self._current_provider_id(event)
+            if provider_id:
+                kwargs["chat_provider_id"] = provider_id
+            try:
+                response = await self._maybe_await(generator(**kwargs))
+            except TypeError:
+                kwargs.pop("chat_provider_id", None)
+                try:
+                    response = await self._maybe_await(generator(**kwargs))
+                except Exception as exc:
+                    logger.debug("qzone llm_generate reply failed: %s", exc)
+                else:
+                    text = self._text_from_llm_response(response)
+                    if text:
+                        return text
+            except Exception as exc:
+                logger.debug("qzone llm_generate reply failed: %s", exc)
+            else:
+                text = self._text_from_llm_response(response)
+                if text:
+                    return text
+
+        provider_getter = getattr(context, "get_using_provider", None)
+        provider = None
+        if callable(provider_getter):
+            umo = getattr(event, "unified_msg_origin", None)
+            attempts: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+            if umo is not None:
+                attempts.append(((), {"umo": umo}))
+                attempts.append(((umo,), {}))
+            attempts.append(((), {}))
+            for args, kwargs in attempts:
+                try:
+                    provider = await self._maybe_await(provider_getter(*args, **kwargs))
+                except TypeError:
+                    continue
+                except Exception as exc:
+                    logger.debug("qzone provider lookup failed: %s", exc)
+                    provider = None
+                    break
+                if provider is not None:
+                    break
+
+        text_chat = getattr(provider, "text_chat", None)
+        if callable(text_chat):
+            for kwargs in (
+                {"prompt": prompt, "contexts": [], "system_prompt": system_prompt},
+                {"prompt": prompt, "context": [], "system_prompt": system_prompt},
+                {"prompt": prompt},
+            ):
+                try:
+                    response = await self._maybe_await(text_chat(**kwargs))
+                except TypeError:
+                    continue
+                except Exception as exc:
+                    logger.debug("qzone provider text_chat reply failed: %s", exc)
+                    break
+                text = self._text_from_llm_response(response)
+                if text:
+                    return text
+
+        return fallback
+
+    def _llm_like_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
         visible_payload = {
             key: value
             for key, value in payload.items()
             if key not in {"raw", "detail"} and not isinstance(value, (dict, list))
         }
-        return self._llm_tool_result(
-            {
-                "ok": True,
-                "tool": "qzone_like_post",
-                "result": visible_payload,
-                "reply_guidance": (
-                    "请根据 result 用自然语言回复用户。"
-                    "如果 verified 为 true，说明 QQ 空间状态已确认；"
-                    "如果 verified 为 false，请说明请求已提交但状态暂未确认。"
-                    "不要暴露 fid、cursor、raw 或内部字段。"
-                ),
-            }
-        )
+        return {
+            "ok": True,
+            "tool": "qzone_like_post",
+            "result": visible_payload,
+            "reply_guidance": (
+                "请根据 result 用自然语言回复用户。"
+                "如果 verified 为 true，说明 QQ 空间状态已确认；"
+                "如果 verified 为 false，请说明请求已提交但状态暂未确认。"
+                "不要暴露 fid、cursor、raw 或内部字段。"
+            ),
+        }
 
-    def _llm_error_result(self, tool: str, exc: QzoneBridgeError) -> str:
-        return self._llm_tool_result(
-            {
-                "ok": False,
-                "tool": tool,
-                "error": {
-                    "type": type(exc).__name__,
-                    "code": exc.code,
-                    "message": exc.message,
-                },
-                "reply_guidance": "请根据 error 用自然语言简短告知用户失败原因，不要暴露内部字段。",
-            }
-        )
+    def _llm_error_payload(self, tool: str, exc: QzoneBridgeError) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "tool": tool,
+            "error": {
+                "type": type(exc).__name__,
+                "code": exc.code,
+                "message": exc.message,
+            },
+            "reply_guidance": "请根据 error 用自然语言简短告知用户失败原因，不要暴露内部字段。",
+        }
 
     async def _ensure_daemon(self, *, allow_needs_rebind: bool = False) -> None:
         status = await self.controller.get_status()
@@ -809,19 +926,19 @@ class QzoneStablePlugin(Star):
             unlike (boolean): 是否取消点赞。
         """
         if not self._is_admin(event):
+            payload = {
+                "ok": False,
+                "tool": "qzone_like_post",
+                "error": {
+                    "type": "PermissionError",
+                    "code": "QZONE_PERMISSION",
+                    "message": "仅管理员可点赞。",
+                },
+                "reply_guidance": "请用自然语言告诉用户没有权限执行点赞。",
+            }
+            text = await self._ask_llm_tool_reply(event, payload, "仅管理员可点赞。")
             yield event.plain_result(
-                self._llm_tool_result(
-                    {
-                        "ok": False,
-                        "tool": "qzone_like_post",
-                        "error": {
-                            "type": "PermissionError",
-                            "code": "QZONE_PERMISSION",
-                            "message": "仅管理员可点赞。",
-                        },
-                        "reply_guidance": "请用自然语言告诉用户没有权限执行点赞。",
-                    }
-                )
+                text
             )
             return
         try:
@@ -829,9 +946,19 @@ class QzoneStablePlugin(Star):
             await self._ensure_daemon()
             payload = await self.controller.like_post(hostuin=hostuin, fid=fid, appid=appid, unlike=unlike)
         except QzoneBridgeError as exc:
-            yield event.plain_result(self._llm_error_result("qzone_like_post", exc))
+            text = await self._ask_llm_tool_reply(
+                event,
+                self._llm_error_payload("qzone_like_post", exc),
+                exc.message,
+            )
+            yield event.plain_result(text)
             return
-        yield event.plain_result(self._llm_like_result(payload))
+        text = await self._ask_llm_tool_reply(
+            event,
+            self._llm_like_payload(payload),
+            format_like_result(payload),
+        )
+        yield event.plain_result(text)
 
     async def terminate(self):
         try:

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -31,6 +31,7 @@ from .storage import StateStore, ensure_state_secret
 from .utils import now_iso, from_iso
 
 log = logging.getLogger(__name__)
+LIKE_VERIFY_RETRY_DELAYS_SECONDS = (0.35, 0.85, 1.6)
 
 
 class QzoneDaemonService:
@@ -442,6 +443,24 @@ class QzoneDaemonService:
                     return entry
         return None
 
+    async def _retry_like_entry_until_fresh(
+        self,
+        hostuin: int,
+        fid: str,
+        appid: int,
+        target_liked: bool,
+        current_entry: FeedEntry | None,
+    ) -> FeedEntry | None:
+        entry = current_entry
+        for delay in LIKE_VERIFY_RETRY_DELAYS_SECONDS:
+            await asyncio.sleep(delay)
+            refreshed = await self._refresh_like_entry(hostuin, fid, appid)
+            if refreshed is not None:
+                entry = refreshed
+            if entry is None or entry.liked == target_liked:
+                return entry
+        return entry
+
     @staticmethod
     def _normalize_action_payload(payload: Any) -> dict[str, Any]:
         payload = unwrap_payload(payload)
@@ -496,27 +515,42 @@ class QzoneDaemonService:
                 verified_entry = await self._refresh_like_entry(hostuin, fid, appid)
 
         if verified_entry is not None and verified_entry.liked != target_liked:
-            action_text = "取消点赞" if unlike else "点赞"
-            raise QzoneRequestError(
-                f"{action_text}请求已发送，但 QQ 空间未确认状态变更",
-                detail={
-                    "hostuin": hostuin,
-                    "fid": fid,
-                    "expected_liked": target_liked,
-                    "actual_liked": verified_entry.liked,
-                    "raw": payload,
-                },
+            verified_entry = await self._retry_like_entry_until_fresh(
+                hostuin,
+                fid,
+                appid,
+                target_liked,
+                verified_entry,
+            )
+
+        verification: dict[str, Any] | None = None
+        if verified_entry is not None and verified_entry.liked != target_liked:
+            verification = {
+                "expected_liked": target_liked,
+                "actual_liked": verified_entry.liked,
+            }
+            log.debug(
+                "qzone like request accepted but verification stayed stale: hostuin=%s fid=%s expected=%s actual=%s",
+                hostuin,
+                fid,
+                target_liked,
+                verified_entry.liked,
             )
         self._set_success(defer_save=True)
-        return {
+        result = {
             "action": "unlike" if unlike else "like",
-            "liked": verified_entry.liked if verified_entry is not None else target_liked,
-            "verified": verified_entry is not None,
+            "liked": verified_entry.liked
+            if verified_entry is not None and verified_entry.liked == target_liked
+            else target_liked,
+            "verified": verified_entry is not None and verified_entry.liked == target_liked,
             "already": False,
             "summary": verified_entry.summary if verified_entry is not None else "",
             "message": payload.get("msg") or payload.get("message") or "",
             "raw": payload,
         }
+        if verification is not None:
+            result["verification"] = verification
+        return result
 
     async def health(self) -> dict[str, Any]:
         if self.state.session.needs_rebind or not self.state.session.cookies or not self.state.session.uin:

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -421,6 +421,77 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             finally:
                 await service.close()
 
+    async def test_like_post_retries_stale_verification_before_marking_unconfirmed(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            false_state = {
+                "tid": "fid-1",
+                "uin": 123456,
+                "content": "hello",
+                "like": {"isliked": "0"},
+            }
+            true_state = {
+                "tid": "fid-1",
+                "uin": 123456,
+                "content": "hello",
+                "like": {"isliked": "1"},
+            }
+            try:
+                with patch("qzone_bridge.daemon.LIKE_VERIFY_RETRY_DELAYS_SECONDS", (0,)), patch.object(
+                    service.client,
+                    "detail",
+                    new=AsyncMock(side_effect=[false_state, false_state, false_state, true_state]),
+                ) as detail, patch.object(
+                    service.client,
+                    "like_post",
+                    new=AsyncMock(return_value={"message": "ok"}),
+                ) as like:
+                    payload = await service.like_post(hostuin=123456, fid="fid-1")
+                self.assertEqual(detail.await_count, 4)
+                self.assertEqual(like.await_count, 2)
+                self.assertTrue(payload["verified"])
+                self.assertTrue(payload["liked"])
+            finally:
+                await service.close()
+
+    async def test_like_post_keeps_success_when_verification_state_stays_stale(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            false_state = {
+                "tid": "fid-1",
+                "uin": 123456,
+                "content": "hello",
+                "like": {"isliked": "0"},
+            }
+            try:
+                with patch("qzone_bridge.daemon.LIKE_VERIFY_RETRY_DELAYS_SECONDS", (0,)), patch.object(
+                    service.client,
+                    "detail",
+                    new=AsyncMock(side_effect=[false_state, false_state, false_state, false_state]),
+                ), patch.object(
+                    service.client,
+                    "like_post",
+                    new=AsyncMock(return_value={"message": "ok"}),
+                ) as like:
+                    payload = await service.like_post(hostuin=123456, fid="fid-1")
+                self.assertEqual(like.await_count, 2)
+                self.assertFalse(payload["verified"])
+                self.assertTrue(payload["liked"])
+                self.assertEqual(payload["verification"]["expected_liked"], True)
+                self.assertEqual(payload["verification"]["actual_liked"], False)
+            finally:
+                await service.close()
+
     async def test_like_post_verification_falls_back_to_legacy_feed_page(self):
         with TemporaryDirectory() as tmp:
             service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -1,6 +1,5 @@
 import asyncio
 import importlib.util
-import json
 import sys
 import tempfile
 import types
@@ -295,9 +294,13 @@ class MainPublishTests(unittest.TestCase):
         self.assertNotIn("has_more", results[0])
         self.assertNotIn("fid=", results[0])
 
-    def test_llm_like_tool_returns_structured_result_for_llm_reply(self):
+    def test_llm_like_tool_asks_llm_for_natural_result_reply(self):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
+        plugin._context = types.SimpleNamespace(
+            get_current_chat_provider_id=AsyncMock(return_value="provider-1"),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="已经帮你点赞成功。")),
+        )
         plugin.controller.like_post = AsyncMock(
             return_value={
                 "action": "like",
@@ -314,19 +317,21 @@ class MainPublishTests(unittest.TestCase):
         )
 
         plugin.controller.like_post.assert_awaited_once_with(hostuin=0, fid="1", appid=311, unlike=False)
-        payload = json.loads(results[0])
-        self.assertTrue(payload["ok"])
-        self.assertEqual(payload["tool"], "qzone_like_post")
-        self.assertTrue(payload["result"]["verified"])
-        self.assertTrue(payload["result"]["liked"])
-        self.assertEqual(payload["result"]["summary"], "瘦了…………")
-        self.assertIn("reply_guidance", payload)
-        self.assertNotIn("raw", payload["result"])
+        self.assertEqual(results[0], "已经帮你点赞成功。")
+        plugin._context.llm_generate.assert_awaited_once()
+        prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
+        self.assertIn('"ok":true', prompt)
+        self.assertIn('"verified":true', prompt)
+        self.assertIn("瘦了…………", prompt)
         self.assertNotIn("fid=", results[0])
+        self.assertFalse(results[0].lstrip().startswith("{"))
 
     def test_llm_like_tool_ignores_preview_confirmation(self):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
+        plugin._context = types.SimpleNamespace(
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="点赞请求已提交，空间状态可能稍后刷新。")),
+        )
         plugin.settings.preview_writes = True
         plugin.controller.like_post = AsyncMock(
             return_value={
@@ -344,13 +349,17 @@ class MainPublishTests(unittest.TestCase):
         )
 
         plugin.controller.like_post.assert_awaited_once()
-        payload = json.loads(results[0])
-        self.assertTrue(payload["ok"])
-        self.assertFalse(payload["result"]["verified"])
+        self.assertEqual(results[0], "点赞请求已提交，空间状态可能稍后刷新。")
+        prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
+        self.assertIn('"verified":false', prompt)
+        self.assertFalse(results[0].lstrip().startswith("{"))
 
-    def test_llm_like_tool_returns_structured_error_for_llm_reply(self):
+    def test_llm_like_tool_asks_llm_for_natural_error_reply(self):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
+        plugin._context = types.SimpleNamespace(
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="点赞失败：QQ 空间暂时拒绝了请求。")),
+        )
         plugin.controller.like_post = AsyncMock(side_effect=module.QzoneBridgeError("点赞失败"))
         event = Event([])
 
@@ -358,11 +367,48 @@ class MainPublishTests(unittest.TestCase):
             collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
         )
 
-        payload = json.loads(results[0])
-        self.assertFalse(payload["ok"])
-        self.assertEqual(payload["tool"], "qzone_like_post")
-        self.assertEqual(payload["error"]["message"], "点赞失败")
-        self.assertIn("reply_guidance", payload)
+        self.assertEqual(results[0], "点赞失败：QQ 空间暂时拒绝了请求。")
+        prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
+        self.assertIn('"ok":false', prompt)
+        self.assertIn("点赞失败", prompt)
+        self.assertFalse(results[0].lstrip().startswith("{"))
+
+    def test_llm_like_tool_falls_back_to_natural_text_without_llm_provider(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin.controller.like_post = AsyncMock(
+            return_value={
+                "action": "like",
+                "liked": True,
+                "verified": False,
+                "already": False,
+                "summary": "hello",
+            }
+        )
+        event = Event([])
+
+        results = asyncio.run(
+            collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
+        )
+
+        self.assertIn("点赞请求已提交", results[0])
+        self.assertFalse(results[0].lstrip().startswith("{"))
+
+    def test_llm_like_tool_error_fallback_does_not_expose_detail(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin.controller.like_post = AsyncMock(
+            side_effect=module.QzoneBridgeError("点赞失败", detail={"fid": "secret-fid", "raw": {"code": 1}})
+        )
+        event = Event([])
+
+        results = asyncio.run(
+            collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
+        )
+
+        self.assertEqual(results[0], "点赞失败")
+        self.assertNotIn("secret-fid", results[0])
+        self.assertFalse(results[0].lstrip().startswith("{"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed
- Route `qzone_like_post` LLM-tool results through the active AstrBot LLM provider so users receive a natural-language reply instead of raw JSON.
- Keep a sanitized natural-language fallback when no provider is available, without exposing `raw`, `detail`, `fid`, or cursor-like internals.
- Treat accepted like/unlike requests with stale Qzone readback as submitted-but-unconfirmed instead of throwing a failure, and retry stale verification before marking it unconfirmed.

## Why
Qzone can report stale like state immediately after accepting a like request, so the plugin could report `未确认状态变更` even when the like later appeared successfully. The previous structured JSON reply path also leaked tool payloads directly to users in some AstrBot flows.

## Validation
- `python -m py_compile main.py qzone_bridge\daemon.py tests\test_daemon_lifecycle.py tests\test_main_publish.py`
- `python -m pytest tests\test_main_publish.py tests\test_daemon_lifecycle.py`
- `python -m pytest`