### PR TITLE
[codex] Improve Qzone like targeting and replies

### DIFF
--- a/main.py
+++ b/main.py
@@ -258,6 +258,7 @@ class QzoneStablePlugin(Star):
                 return f"{exc.message}（{', '.join(parts)}）"
         return f"{exc.message}\n{exc.detail}"
 
+
     async def _maybe_await(self, value: Any) -> Any:
         if inspect.isawaitable(value):
             return await value
@@ -915,15 +916,19 @@ class QzoneStablePlugin(Star):
         confirm: bool = False,
         appid: int = 311,
         unlike: bool = False,
+        latest: bool = False,
+        index: int = 0,
     ):
         """点赞或取消点赞一条说说。
 
         Args:
-            hostuin (number): 目标 QQ 号。为 0 且 fid 为数字时，表示最近列表中的编号。
-            fid (string): 说说 fid，或最近列表中的编号。
-            confirm (boolean): 是否确认执行。
-            appid (number): 应用 id。
-            unlike (boolean): 是否取消点赞。
+            hostuin (number): 目标 QQ 号。`0` 表示当前登录 QQ，也可以复用最近一次列出的说说列表上下文。
+            fid (string): 精确的说说 fid。若按“最新一条”或“第 N 条”操作，优先使用 `latest` / `index`，也兼容 `latest`、`第3条` 这类文本引用。
+            confirm (boolean): 兼容旧参数；该工具会直接执行。
+            appid (number): 说说 appid，通常为 `311`。
+            unlike (boolean): 为 `true` 时取消点赞，否则执行点赞。
+            latest (boolean): 为 `true` 时自动定位目标 QQ 的最新一条说说。
+            index (number): 自动定位目标 QQ 的第 N 条说说；`1` 表示最新一条。
         """
         if not self._is_admin(event):
             payload = {
@@ -937,14 +942,19 @@ class QzoneStablePlugin(Star):
                 "reply_guidance": "请用自然语言告诉用户没有权限执行点赞。",
             }
             text = await self._ask_llm_tool_reply(event, payload, "仅管理员可点赞。")
-            yield event.plain_result(
-                text
-            )
+            yield event.plain_result(text)
             return
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
-            payload = await self.controller.like_post(hostuin=hostuin, fid=fid, appid=appid, unlike=unlike)
+            payload = await self.controller.like_post(
+                hostuin=hostuin,
+                fid=fid,
+                appid=appid,
+                unlike=unlike,
+                latest=latest,
+                index=index,
+            )
         except QzoneBridgeError as exc:
             text = await self._ask_llm_tool_reply(
                 event,

--- a/qzone_bridge/controller.py
+++ b/qzone_bridge/controller.py
@@ -531,6 +531,8 @@ class QzoneDaemonController:
         appid: int = 311,
         curkey: str = "",
         unlike: bool = False,
+        latest: bool = False,
+        index: int = 0,
     ) -> dict[str, Any]:
         return await self._request(
             "POST",
@@ -541,6 +543,8 @@ class QzoneDaemonController:
                 "appid": appid,
                 "curkey": curkey,
                 "unlike": unlike,
+                "latest": latest,
+                "index": index,
             },
         )
 

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import logging
 import os
+import re
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -32,6 +33,17 @@ from .utils import now_iso, from_iso
 
 log = logging.getLogger(__name__)
 LIKE_VERIFY_RETRY_DELAYS_SECONDS = (0.35, 0.85, 1.6)
+LATEST_FEED_REFERENCES = {
+    "latest",
+    "newest",
+    "recent",
+    "last",
+    "最新",
+    "最新一条",
+    "最近一条",
+    "最后一条",
+}
+FEED_REFERENCE_PATTERN = re.compile(r"^第?\s*(\d+)\s*条?$")
 
 
 class QzoneDaemonService:
@@ -399,14 +411,68 @@ class QzoneDaemonService:
             "raw": payload,
         }
 
-    def _resolve_recent_feed_reference(self, hostuin: int, fid: str, appid: int, curkey: str = "") -> tuple[int, str, int, str]:
+    @staticmethod
+    def _feed_reference_index(fid: str, *, hostuin: int, latest: bool = False, index: int = 0) -> int:
+        if latest:
+            return 1
+        if index > 0:
+            return int(index)
         fid_text = str(fid or "").strip()
+        if not fid_text:
+            return 0
         if not hostuin and fid_text.isdigit():
-            index = int(fid_text) - 1
-            if 0 <= index < len(self.recent_feed_entries):
-                entry = self.recent_feed_entries[index]
-                return entry.hostuin, entry.fid, entry.appid or appid, curkey or entry.curkey
-        return int(hostuin or self.state.session.uin or 0), fid_text, int(appid or 311), curkey
+            return int(fid_text)
+        if fid_text.lower() in LATEST_FEED_REFERENCES or fid_text in LATEST_FEED_REFERENCES:
+            return 1
+        match = FEED_REFERENCE_PATTERN.fullmatch(fid_text)
+        if match and fid_text != match.group(1):
+            return int(match.group(1))
+        return 0
+
+    def _recent_feed_reference(self, reference_index: int, *, hostuin: int) -> FeedEntry | None:
+        if reference_index <= 0 or reference_index > len(self.recent_feed_entries):
+            return None
+        entry = self.recent_feed_entries[reference_index - 1]
+        if hostuin and entry.hostuin != hostuin:
+            return None
+        return entry
+
+    async def _resolve_recent_feed_reference(
+        self,
+        hostuin: int,
+        fid: str,
+        appid: int,
+        curkey: str = "",
+        *,
+        latest: bool = False,
+        index: int = 0,
+    ) -> tuple[int, str, int, str]:
+        fid_text = str(fid or "").strip()
+        target_hostuin = int(hostuin or self.state.session.uin or 0)
+        reference_index = self._feed_reference_index(
+            fid_text,
+            hostuin=int(hostuin or 0),
+            latest=latest,
+            index=index,
+        )
+        if reference_index > 0:
+            cached_entry = self._recent_feed_reference(reference_index, hostuin=target_hostuin if hostuin else 0)
+            if cached_entry is not None:
+                return (
+                    cached_entry.hostuin,
+                    cached_entry.fid,
+                    cached_entry.appid or appid,
+                    curkey or cached_entry.curkey,
+                )
+            if not target_hostuin:
+                raise QzoneNeedsRebind()
+            feed_payload = await self.list_feeds(hostuin=target_hostuin, limit=reference_index, scope="profile")
+            items = feed_payload.get("items") or []
+            if reference_index > len(items):
+                raise QzoneParseError(f"未找到第 {reference_index} 条可点赞的说说")
+            entry = FeedEntry(**items[reference_index - 1])
+            return entry.hostuin, entry.fid, entry.appid or appid, curkey or entry.curkey
+        return target_hostuin, fid_text, int(appid or 311), curkey
 
     @staticmethod
     def _http_like_key(appid: int, hostuin: int, fid: str) -> str:
@@ -443,6 +509,13 @@ class QzoneDaemonService:
                     return entry
         return None
 
+    @staticmethod
+    def _normalize_action_payload(payload: Any) -> dict[str, Any]:
+        payload = unwrap_payload(payload)
+        if isinstance(payload, dict):
+            return payload
+        return {"value": payload}
+
     async def _retry_like_entry_until_fresh(
         self,
         hostuin: int,
@@ -461,13 +534,6 @@ class QzoneDaemonService:
                 return entry
         return entry
 
-    @staticmethod
-    def _normalize_action_payload(payload: Any) -> dict[str, Any]:
-        payload = unwrap_payload(payload)
-        if isinstance(payload, dict):
-            return payload
-        return {"value": payload}
-
     async def like_post(
         self,
         *,
@@ -476,9 +542,18 @@ class QzoneDaemonService:
         appid: int = 311,
         curkey: str = "",
         unlike: bool = False,
+        latest: bool = False,
+        index: int = 0,
     ) -> dict[str, Any]:
         self._ensure_session_ready()
-        hostuin, fid, appid, curkey = self._resolve_recent_feed_reference(hostuin, fid, appid, curkey)
+        hostuin, fid, appid, curkey = await self._resolve_recent_feed_reference(
+            hostuin,
+            fid,
+            appid,
+            curkey,
+            latest=latest,
+            index=index,
+        )
         if not hostuin or not fid:
             raise QzoneParseError("点赞目标不完整，请先选择一条说说")
 
@@ -703,6 +778,8 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
                 appid=int(body.get("appid") or 311),
                 curkey=str(body.get("curkey") or ""),
                 unlike=bool(body.get("unlike") or False),
+                latest=bool(body.get("latest") or False),
+                index=int(body.get("index") or 0),
             )
         except QzoneBridgeError as exc:
             service._set_error(exc)

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -569,6 +569,126 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
                 await service.close()
 
 
+    async def test_like_post_resolves_latest_reference_from_self_profile(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            before = {
+                "tid": "fid-latest",
+                "uin": 123456,
+                "content": "latest self post",
+                "like": {"isliked": "0"},
+            }
+            after = {
+                "tid": "fid-latest",
+                "uin": 123456,
+                "content": "latest self post",
+                "like": {"isliked": "1"},
+            }
+            try:
+                with patch.object(
+                    service,
+                    "list_feeds",
+                    new=AsyncMock(
+                        return_value={
+                            "items": [
+                                {
+                                    "hostuin": 123456,
+                                    "fid": "fid-latest",
+                                    "appid": 311,
+                                    "summary": "latest self post",
+                                    "curkey": "latest-curkey",
+                                }
+                            ]
+                        }
+                    ),
+                ) as feeds, patch.object(
+                    service.client,
+                    "detail",
+                    new=AsyncMock(side_effect=[before, after]),
+                ), patch.object(
+                    service.client,
+                    "like_post",
+                    new=AsyncMock(return_value={"message": "ok"}),
+                ) as like:
+                    payload = await service.like_post(hostuin=0, fid="", latest=True)
+                feeds.assert_awaited_once_with(hostuin=123456, limit=1, scope="profile")
+                args, kwargs = like.await_args
+                self.assertEqual(args[:2], (123456, "fid-latest"))
+                self.assertEqual(kwargs["curkey"], "latest-curkey")
+                self.assertTrue(payload["verified"])
+                self.assertEqual(payload["summary"], "latest self post")
+            finally:
+                await service.close()
+
+    async def test_like_post_resolves_named_index_reference_for_specific_host(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            before = {
+                "tid": "fid-2",
+                "uin": 3112333596,
+                "content": "second friend post",
+                "like": {"isliked": "0"},
+            }
+            after = {
+                "tid": "fid-2",
+                "uin": 3112333596,
+                "content": "second friend post",
+                "like": {"isliked": "1"},
+            }
+            try:
+                with patch.object(
+                    service,
+                    "list_feeds",
+                    new=AsyncMock(
+                        return_value={
+                            "items": [
+                                {
+                                    "hostuin": 3112333596,
+                                    "fid": "fid-1",
+                                    "appid": 311,
+                                    "summary": "first friend post",
+                                    "curkey": "friend-curkey-1",
+                                },
+                                {
+                                    "hostuin": 3112333596,
+                                    "fid": "fid-2",
+                                    "appid": 311,
+                                    "summary": "second friend post",
+                                    "curkey": "friend-curkey-2",
+                                },
+                            ]
+                        }
+                    ),
+                ) as feeds, patch.object(
+                    service.client,
+                    "detail",
+                    new=AsyncMock(side_effect=[before, after]),
+                ), patch.object(
+                    service.client,
+                    "like_post",
+                    new=AsyncMock(return_value={"message": "ok"}),
+                ) as like:
+                    payload = await service.like_post(hostuin=3112333596, fid="第2条")
+                feeds.assert_awaited_once_with(hostuin=3112333596, limit=2, scope="profile")
+                args, kwargs = like.await_args
+                self.assertEqual(args[:2], (3112333596, "fid-2"))
+                self.assertEqual(kwargs["curkey"], "friend-curkey-2")
+                self.assertTrue(payload["verified"])
+                self.assertEqual(payload["summary"], "second friend post")
+            finally:
+                await service.close()
+
+
 class ControllerLifecycleTests(unittest.IsolatedAsyncioTestCase):
     async def test_close_shuts_down_daemon_and_releases_port(self):
         with TemporaryDirectory() as tmp:

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -316,7 +316,14 @@ class MainPublishTests(unittest.TestCase):
             collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1"))
         )
 
-        plugin.controller.like_post.assert_awaited_once_with(hostuin=0, fid="1", appid=311, unlike=False)
+        plugin.controller.like_post.assert_awaited_once_with(
+            hostuin=0,
+            fid="1",
+            appid=311,
+            unlike=False,
+            latest=False,
+            index=0,
+        )
         self.assertEqual(results[0], "已经帮你点赞成功。")
         plugin._context.llm_generate.assert_awaited_once()
         prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
@@ -325,6 +332,38 @@ class MainPublishTests(unittest.TestCase):
         self.assertIn("瘦了…………", prompt)
         self.assertNotIn("fid=", results[0])
         self.assertFalse(results[0].lstrip().startswith("{"))
+
+    def test_llm_like_tool_forwards_latest_and_index_reference(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin._context = types.SimpleNamespace(
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="已经帮对方第 2 条说说点赞。")),
+        )
+        plugin.controller.like_post = AsyncMock(
+            return_value={
+                "action": "like",
+                "liked": True,
+                "verified": True,
+                "already": False,
+                "summary": "hello",
+            }
+        )
+        event = Event([])
+
+        asyncio.run(
+            collect_async_generator(
+                plugin.tool_like_post(event, hostuin=3112333596, latest=True, index=2)
+            )
+        )
+
+        plugin.controller.like_post.assert_awaited_once_with(
+            hostuin=3112333596,
+            fid="",
+            appid=311,
+            unlike=False,
+            latest=True,
+            index=2,
+        )
 
     def test_llm_like_tool_ignores_preview_confirmation(self):
         module = self.load_main_module()


### PR DESCRIPTION
﻿## What changed
- Added `latest` and `index` support to `qzone_like_post` so the tool can directly target a QQ user's latest post or nth visible post without manually passing a real `fid`.
- Extended the daemon/controller like flow to resolve recent-list references and profile-feed references before sending the like request.
- Kept the newer natural-language LLM reply flow and the latest like-verification retry behavior from `main`, so stale Qzone readback is handled gracefully instead of surfacing raw tool JSON or premature failures.
- Added tests for latest/nth post resolution, stale verification handling, and LLM-facing reply behavior.

## Why
Users should be able to say things like "给你自己最新一条QQ说说点赞" or "给别人第几条QQ说说点赞" and let the LLM complete the action in one tool call. This also needs to stay compatible with the newer main-branch like reply and verification behavior.

## Validation
- `python -m py_compile main.py qzone_bridge/controller.py qzone_bridge/daemon.py tests/test_daemon_lifecycle.py tests/test_main_publish.py`
- `python -m unittest tests.test_daemon_lifecycle tests.test_main_publish`
