### PR TITLE
[codex] Fix latest Qzone like 302 redirects

### DIFF
--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from urllib.parse import unquote, urljoin, urlparse
+from urllib.parse import parse_qsl, unquote, urlencode, urljoin, urlparse, urlunparse
 
 import httpx
 
@@ -203,7 +203,16 @@ class QzoneClient:
         if parsed.scheme.lower() not in {"http", "https"}:
             return False
         host = (parsed.hostname or "").lower()
-        return host == "qzone.qq.com" or host.endswith(".qzone.qq.com")
+        return host == "qq.com" or host.endswith(".qq.com")
+
+    @staticmethod
+    def _redirect_url_with_params(target_url: str, params: dict[str, Any] | None) -> str:
+        if not params:
+            return target_url
+        parsed = urlparse(target_url)
+        query = parse_qsl(parsed.query, keep_blank_values=True)
+        query.extend((str(key), str(value)) for key, value in params.items())
+        return urlunparse(parsed._replace(query=urlencode(query, doseq=True)))
 
     def _persist_cookie_response(self, response: httpx.Response) -> None:
         for key, value in response.cookies.items():
@@ -300,8 +309,9 @@ class QzoneClient:
                             and redirects_left > 0
                             and self._is_allowed_qzone_redirect(str(response.request.url), location)
                         ):
-                            current_url = urljoin(str(response.request.url), location)
-                            current_params = None if urlparse(current_url).query else params
+                            target_url = urljoin(str(response.request.url), location)
+                            current_url = self._redirect_url_with_params(target_url, params)
+                            current_params = None
                             redirects_left -= 1
                             continue
                         raise QzoneRequestError(
@@ -466,6 +476,7 @@ class QzoneClient:
             referer=f"https://user.qzone.qq.com/{self.login_uin}",
             hostuin=self.login_uin,
             attach_token=True,
+            follow_qzone_redirects=True,
         )
         return payload
 
@@ -483,6 +494,7 @@ class QzoneClient:
             referer=f"https://user.qzone.qq.com/{hostuin}",
             hostuin=hostuin,
             attach_token=True,
+            follow_qzone_redirects=True,
         )
         return payload
 
@@ -506,6 +518,7 @@ class QzoneClient:
             origin="https://user.qzone.qq.com",
             hostuin=hostuin,
             attach_token=False,
+            follow_qzone_redirects=True,
         )
         return payload
 
@@ -533,6 +546,7 @@ class QzoneClient:
             origin="https://user.qzone.qq.com",
             hostuin=self.login_uin,
             attach_token=False,
+            follow_qzone_redirects=True,
         )
         return payload
 
@@ -553,6 +567,7 @@ class QzoneClient:
             referer=f"https://user.qzone.qq.com/{uin}/mood/{fid}",
             hostuin=uin,
             attach_token=True,
+            follow_qzone_redirects=True,
         )
         return payload
 

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -280,7 +280,12 @@ class QzoneDaemonService:
                 feedpage = payload
             else:
                 if page_round == 0 and not next_cursor:
-                    payload = await self.client.profile(hostuin)
+                    try:
+                        payload = await self.client.profile(hostuin)
+                    except QzoneRequestError as exc:
+                        if exc.status_code not in {301, 302, 303, 307, 308}:
+                            raise
+                        payload = await self.client.legacy_feeds(hostuin, page=1, num=max(limit, 20))
                 else:
                     payload = unwrap_payload(await self.client.get_feeds(hostuin, next_cursor))
                 feedpage = payload

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -197,6 +197,38 @@ class ClientErrorMappingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(seen[1][2]["hostuin"][0], "123456")
         self.assertEqual(seen[1][2]["fid"][0], "fid-1")
 
+    async def test_legacy_feed_follows_qq_domain_redirect(self):
+        seen = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(str(request.url))
+            if len(seen) == 1:
+                return httpx.Response(
+                    302,
+                    headers={
+                        "location": (
+                            "https://taotao.qq.com/cgi-bin/emotion_cgi_msglist_v6"
+                            "?redirected=1"
+                        )
+                    },
+                    request=request,
+                )
+            return httpx.Response(
+                200,
+                text='_Callback({"msglist":[{"tid":"fid-1","uin":123456,"content":"ok"}]})',
+                request=request,
+            )
+
+        await self._use_response(handler)
+
+        payload = await self.client.legacy_feeds(123456, page=1, num=1)
+
+        self.assertEqual(payload["msglist"][0]["tid"], "fid-1")
+        self.assertEqual(len(seen), 2)
+        self.assertIn("taotao.qq.com", seen[1])
+        self.assertIn("redirected=1", seen[1])
+        self.assertIn("g_tk=", seen[1])
+
     async def test_like_login_redirect_requires_rebind(self):
         await self._use_response(
             lambda request: httpx.Response(

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -115,6 +115,37 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             finally:
                 await service.close()
 
+    async def test_profile_list_feeds_falls_back_when_h5_redirects(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            try:
+                with patch.object(
+                    service.client,
+                    "profile",
+                    new=AsyncMock(side_effect=QzoneRequestError("profile redirect", status_code=302)),
+                ) as profile, patch.object(
+                    service.client,
+                    "legacy_feeds",
+                    new=AsyncMock(
+                        return_value={
+                            "msglist": [
+                                {"tid": "fid-latest", "uin": 123456, "content": "latest"}
+                            ]
+                        }
+                    ),
+                ) as legacy:
+                    payload = await service.list_feeds(hostuin=123456, limit=1, scope="profile")
+                profile.assert_awaited_once()
+                legacy.assert_awaited_once_with(123456, page=1, num=20)
+                self.assertEqual(payload["items"][0]["fid"], "fid-latest")
+            finally:
+                await service.close()
+
     async def test_publish_post_does_not_probe_h5_index_for_token(self):
         with TemporaryDirectory() as tmp:
             service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())


### PR DESCRIPTION
## Summary
- handle the `qzone_like_post(latest=True, hostuin=0)` path by falling back from H5 profile redirects to legacy feed lookup when resolving the latest target
- allow guarded redirects across QQ-owned domains for feed/detail endpoints, not only `*.qzone.qq.com`
- preserve both QQ-provided redirect query parameters and original request params such as `g_tk` when replaying redirects
- add regression coverage for profile-list fallback and legacy feed redirects

## Root Cause
The previous fix covered the like POST endpoint itself, but `latest=True` first resolves the target feed and then verifies like state. Those feed/profile/detail requests can also receive HTTP 302 from QQ. The profile path bubbled that redirect before a target feed was selected, and redirect replay could drop either the Location query or original `g_tk`, causing repeated 302s.

## Validation
- `python -m compileall qzone_bridge tests`
- `python -m unittest tests.test_client_errors tests.test_daemon_lifecycle`
- `python -m unittest discover -s tests` (118 tests OK; asyncio slow-task debug logs printed, no failures)
- `git diff --check`