### PR TITLE
[codex] Improve Qzone like diagnostics and fallback

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-"""AstrBot entry point for the QQ空间 bridge."""
+"""AstrBot entry point for the QQ?? bridge."""
 
 from __future__ import annotations
 
@@ -10,12 +10,95 @@ import sys
 import time
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, filter
 from astrbot.api.star import Context, Star
 
 PLUGIN_ROOT = Path(__file__).resolve().parent
+
+SENSITIVE_LOG_KEYS = {
+    "cookie",
+    "cookies",
+    "p_skey",
+    "skey",
+    "pt4_token",
+    "pt_key",
+    "qzonetoken",
+    "secret",
+    "token",
+}
+SENSITIVE_URL_QUERY_KEYS = {"g_tk", "gtk", "p_skey", "skey", "pt4_token", "pt_key", "qzonetoken", "token", "secret"}
+LLM_INTERNAL_KEYS = SENSITIVE_LOG_KEYS | {"raw", "cursor", "fid", "curkey", "unikey", "busi_param"}
+
+
+def _redact_url(value: str) -> str:
+    try:
+        parsed = urlparse(value)
+    except Exception:
+        return value
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.netloc:
+        return value
+    query = []
+    changed = False
+    for key, item_value in parse_qsl(parsed.query, keep_blank_values=True):
+        lowered = key.lower()
+        if lowered in SENSITIVE_URL_QUERY_KEYS or "token" in lowered or "skey" in lowered:
+            query.append((key, "***"))
+            changed = True
+        else:
+            query.append((key, item_value))
+    if not changed:
+        return value
+    return urlunparse(parsed._replace(query=urlencode(query, doseq=True)))
+
+
+def _redact_for_log(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            lowered = key_text.lower()
+            if lowered in SENSITIVE_LOG_KEYS or "cookie" in lowered or "skey" in lowered or "secret" in lowered:
+                redacted[key_text] = "***"
+            else:
+                redacted[key_text] = _redact_for_log(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_for_log(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_for_log(item) for item in value]
+    if isinstance(value, str):
+        return _redact_url(value)
+    return value
+
+
+def _safe_for_llm(value: Any) -> Any:
+    if isinstance(value, dict):
+        visible: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            lowered = key_text.lower()
+            if (
+                lowered in LLM_INTERNAL_KEYS
+                or "cookie" in lowered
+                or "skey" in lowered
+                or "secret" in lowered
+                or "token" in lowered
+            ):
+                continue
+            visible[key_text] = _safe_for_llm(item)
+        return visible
+    if isinstance(value, list):
+        return [_safe_for_llm(item) for item in value]
+    if isinstance(value, tuple):
+        return [_safe_for_llm(item) for item in value]
+    if isinstance(value, str):
+        return truncate(_redact_url(value), 500)
+    if isinstance(value, (bool, int, float)) or value is None:
+        return value
+    return truncate(str(value), 500)
 
 
 def _prepare_local_qzone_bridge_imports() -> None:
@@ -202,7 +285,7 @@ class QzoneStablePlugin(Star):
         *,
         profile_task: asyncio.Task | None = None,
     ):
-        text = format_action_result("发布成功", payload)
+        text = format_action_result("????", payload)
         if not self.settings.render_publish_result:
             self._stop_event(event)
             return event.plain_result(text)
@@ -230,7 +313,7 @@ class QzoneStablePlugin(Star):
             self._stop_event(event)
             return image_result(str(image_path))
         self._stop_event(event)
-        return event.plain_result(f"{text}\n渲染图: {image_path}")
+        return event.plain_result(f"{text}\n???: {image_path}")
 
     def _stop_event(self, event: AstrMessageEvent) -> None:
         stopper = getattr(event, "stop_event", None)
@@ -250,13 +333,46 @@ class QzoneStablePlugin(Star):
                 parts.append(f"HTTP {status_code}")
             location = exc.detail.get("location")
             if location:
-                parts.append(f"跳转 {location}")
+                parts.append(f"?? {location}")
             url = exc.detail.get("url")
             if url:
-                parts.append(f"来源 {url}")
+                parts.append(f"?? {url}")
             if parts:
-                return f"{exc.message}（{', '.join(parts)}）"
+                return f"{exc.message}?{', '.join(parts)}?"
         return f"{exc.message}\n{exc.detail}"
+
+    def _log_tool_call_result(self, payload: dict[str, Any]) -> None:
+        try:
+            data = json.dumps(
+                _redact_for_log(payload),
+                ensure_ascii=False,
+                sort_keys=True,
+                default=str,
+            )
+        except Exception:
+            data = str(_redact_for_log(payload))
+        if payload.get("ok"):
+            logger.info("qzone llm tool result: %s", data)
+        else:
+            logger.warning("qzone llm tool result: %s", data)
+
+    @staticmethod
+    def _bridge_error_log_payload(tool: str, exc: QzoneBridgeError, arguments: dict[str, Any]) -> dict[str, Any]:
+        error: dict[str, Any] = {
+            "type": type(exc).__name__,
+            "code": exc.code,
+            "message": exc.message,
+        }
+        status_code = getattr(exc, "status_code", None)
+        if status_code is not None:
+            error["status_code"] = status_code
+        return {
+            "ok": False,
+            "tool": tool,
+            "arguments": arguments,
+            "error": error,
+            "detail": exc.detail,
+        }
 
 
     async def _maybe_await(self, value: Any) -> Any:
@@ -307,13 +423,13 @@ class QzoneStablePlugin(Star):
     async def _ask_llm_tool_reply(self, event: AstrMessageEvent, payload: dict[str, Any], fallback: str) -> str:
         data = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
         prompt = (
-            "下面是 QQ 空间工具执行结果 JSON，只用于你组织给用户的回复，不要原样输出。"
+            "??? QQ ???????? JSON?????????????????????"
             f"\n{data}\n"
-            "请直接用简短中文回复用户，不要输出 JSON，不要暴露字段名、tool、code、fid、cursor、raw、detail 等内部信息。"
-            "如果 ok 为 true，按已完成或已提交处理；verified 为 false 时说明 QQ 空间状态可能稍后刷新，不要说成失败。"
-            "如果 ok 为 false，只说明失败原因即可。"
+            "????????????????? JSON?????????tool?code?fid?cursor?raw?detail?diagnostic ??????"
+            "?? ok ? true????????????verified ? false ??? QQ ??????????????????"
+            "?? ok ? false????? diagnostic/status_code/text ???????????????????????????"
         )
-        system_prompt = "你是 AstrBot 的 QQ 空间助手，负责把工具执行结果改写成自然、简短、对用户友好的中文回复。"
+        system_prompt = "?? AstrBot ? QQ ??????????????????????????????????"
         context = getattr(self, "_context", None) or getattr(self, "context", None)
 
         generator = getattr(context, "llm_generate", None)
@@ -383,39 +499,43 @@ class QzoneStablePlugin(Star):
         return fallback
 
     def _llm_like_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
-        visible_payload = {
-            key: value
-            for key, value in payload.items()
-            if key not in {"raw", "detail"} and not isinstance(value, (dict, list))
-        }
+        visible_payload = _safe_for_llm(payload)
         return {
             "ok": True,
             "tool": "qzone_like_post",
             "result": visible_payload,
             "reply_guidance": (
-                "请根据 result 用自然语言回复用户。"
-                "如果 verified 为 true，说明 QQ 空间状态已确认；"
-                "如果 verified 为 false，请说明请求已提交但状态暂未确认。"
-                "不要暴露 fid、cursor、raw 或内部字段。"
+                "??? result ??????????"
+                "?? verified ? true??? QQ ????????"
+                "?? verified ? false?????????????????"
+                "???? fid?cursor?raw ??????"
             ),
         }
 
     def _llm_error_payload(self, tool: str, exc: QzoneBridgeError) -> dict[str, Any]:
-        return {
+        error: dict[str, Any] = {
+            "type": type(exc).__name__,
+            "code": exc.code,
+            "message": exc.message,
+        }
+        status_code = getattr(exc, "status_code", None)
+        if status_code is not None:
+            error["status_code"] = status_code
+        result: dict[str, Any] = {
             "ok": False,
             "tool": tool,
-            "error": {
-                "type": type(exc).__name__,
-                "code": exc.code,
-                "message": exc.message,
-            },
-            "reply_guidance": "请根据 error 用自然语言简短告知用户失败原因，不要暴露内部字段。",
+            "error": error,
+            "reply_guidance": "??? error ? diagnostic ?????????????????????????",
         }
+        diagnostic = _safe_for_llm(exc.detail)
+        if diagnostic not in (None, {}, []):
+            result["diagnostic"] = diagnostic
+        return result
 
     async def _ensure_daemon(self, *, allow_needs_rebind: bool = False) -> None:
         status = await self.controller.get_status()
         if status.get("needs_rebind") and not allow_needs_rebind:
-            raise QzoneNeedsRebind("QQ空间登录失效，请重新绑定 Cookie")
+            raise QzoneNeedsRebind("QQ???????????? Cookie")
         if allow_needs_rebind:
             if status.get("daemon_state") != "ready":
                 await self.controller.ensure_running()
@@ -424,7 +544,7 @@ class QzoneStablePlugin(Star):
             if status.get("daemon_state") != "ready":
                 await self.controller.ensure_running()
         elif status.get("daemon_state") != "ready":
-            raise DaemonUnavailableError("daemon 未运行")
+            raise DaemonUnavailableError("daemon ???")
 
     def _limit(self, limit: int | None) -> int:
         if not limit or limit <= 0:
@@ -445,7 +565,7 @@ class QzoneStablePlugin(Star):
         text = format_feed_detail(entry)
         comments = payload.get("comments") or []
         if comments:
-            lines = [text, "", "评论"]
+            lines = [text, "", "??"]
             for comment in comments[:5]:
                 nickname = comment.get("nickname") or comment.get("uin") or "-"
                 lines.append(f"- {nickname}: {truncate(str(comment.get('content') or ''), 80)}")
@@ -489,7 +609,7 @@ class QzoneStablePlugin(Star):
         return self._capture_onebot_client_from_context()
 
     def _cookie_binding_hint(self) -> str:
-        return "请确认 AstrBot 正在使用 aiocqhttp(OneBot v11) 平台，或手动使用 /qzone bind 绑定 Cookie。"
+        return "??? AstrBot ???? aiocqhttp(OneBot v11) ???????? /qzone bind ?? Cookie?"
 
     async def _auto_bind_cookie(
         self,
@@ -500,11 +620,11 @@ class QzoneStablePlugin(Star):
     ) -> dict[str, Any]:
         async with self._get_cookie_lock():
             if not self.settings.auto_bind_cookie and not force:
-                raise QzoneCookieAcquireError("自动获取 Cookie 已关闭。请手动绑定。")
+                raise QzoneCookieAcquireError("???? Cookie ??????????")
 
             bot = self._capture_onebot_client(event)
             if bot is None:
-                raise QzoneCookieAcquireError(f"未捕获到 OneBot 客户端，无法自动获取 Cookie。{self._cookie_binding_hint()}")
+                raise QzoneCookieAcquireError(f"???? OneBot ?????????? Cookie?{self._cookie_binding_hint()}")
 
             try:
                 status = await self.controller.get_status(probe_daemon=False)
@@ -516,7 +636,7 @@ class QzoneStablePlugin(Star):
 
             cookie_text = await fetch_cookie_text(bot, domain=self.settings.cookie_domain)
             if not cookie_text:
-                raise QzoneCookieAcquireError(f"OneBot 未返回可用 Cookie。{self._cookie_binding_hint()}")
+                raise QzoneCookieAcquireError(f"OneBot ????? Cookie?{self._cookie_binding_hint()}")
 
             try:
                 cookie_uin = normalize_uin(parse_cookie_text(cookie_text))
@@ -597,14 +717,14 @@ class QzoneStablePlugin(Star):
     async def qzone_help(self, event: AstrMessageEvent):
         text = "\n".join(
             [
-                "QQ空间插件",
+                "QQ????",
                 "/qzone status",
                 "/qzone bind <cookie>",
                 "/qzone autobind",
                 "/qzone unbind",
                 "/qzone feed [hostuin] [limit] [cursor]",
                 "/qzone detail <hostuin> <fid> [appid]",
-                "/qzone post <content> [图片/图片文件]",
+                "/qzone post <content> [??/????]",
                 "/qzone comment <hostuin> <fid> <content>",
                 "/qzone like <hostuin> <fid> [appid] [unlike]",
                 "",
@@ -622,7 +742,7 @@ class QzoneStablePlugin(Star):
     @qzone.command("status")
     async def qzone_status(self, event: AstrMessageEvent):
         if not self._is_admin(event):
-            yield self._command_result(event, "仅管理员可查看状态。")
+            yield self._command_result(event, "??????????")
             return
         try:
             payload = await self.controller.get_status()
@@ -634,7 +754,7 @@ class QzoneStablePlugin(Star):
     @qzone.command("bind")
     async def qzone_bind(self, event: AstrMessageEvent, cookie: str):
         if not self._is_admin(event):
-            yield self._command_result(event, "仅管理员可绑定 Cookie。")
+            yield self._command_result(event, "??????? Cookie?")
             return
         try:
             payload = await self.controller.bind_cookie_local(cookie)
@@ -648,7 +768,7 @@ class QzoneStablePlugin(Star):
     @qzone.command("autobind")
     async def qzone_autobind(self, event: AstrMessageEvent):
         if not self._is_admin(event):
-            yield self._command_result(event, "仅管理员可自动绑定 Cookie。")
+            yield self._command_result(event, "????????? Cookie?")
             return
         try:
             payload = await self._auto_bind_cookie(event, force=True, source="aiocqhttp")
@@ -662,7 +782,7 @@ class QzoneStablePlugin(Star):
     @qzone.command("unbind")
     async def qzone_unbind(self, event: AstrMessageEvent):
         if not self._is_admin(event):
-            yield self._command_result(event, "仅管理员可解绑。")
+            yield self._command_result(event, "????????")
             return
         try:
             payload = await self.controller.unbind_local()
@@ -703,7 +823,7 @@ class QzoneStablePlugin(Star):
     async def qzone_post(self, event: AstrMessageEvent, content: str = ""):
         self._stop_event(event)
         if not self._is_admin(event):
-            yield self._command_result(event, "仅管理员可发说说。")
+            yield self._command_result(event, "?????????")
             return
         post = collect_post_payload(
             event,
@@ -730,7 +850,7 @@ class QzoneStablePlugin(Star):
     @qzone.command("comment")
     async def qzone_comment(self, event: AstrMessageEvent, hostuin: int, fid: str, content: str):
         if not self._is_admin(event):
-            yield self._command_result(event, "仅管理员可评论。")
+            yield self._command_result(event, "????????")
             return
         try:
             await self._ensure_cookie_ready(event)
@@ -739,12 +859,12 @@ class QzoneStablePlugin(Star):
         except QzoneBridgeError as exc:
             yield self._command_result(event, self._error_text(exc))
             return
-        yield self._command_result(event, format_action_result("评论成功", payload))
+        yield self._command_result(event, format_action_result("????", payload))
 
     @qzone.command("like")
     async def qzone_like(self, event: AstrMessageEvent, hostuin: int, fid: str, appid: int = 311, unlike: bool = False):
         if not self._is_admin(event):
-            yield self._command_result(event, "仅管理员可点赞。")
+            yield self._command_result(event, "????????")
             return
         try:
             await self._ensure_cookie_ready(event)
@@ -757,13 +877,13 @@ class QzoneStablePlugin(Star):
 
     @filter.llm_tool(name="qzone_get_status")
     async def tool_get_status(self, event: AstrMessageEvent):
-        """获取 QQ 空间 daemon 状态。
+        """?? QQ ?? daemon ???
 
         Returns:
-            文本状态摘要。
+            ???????
         """
         if not self._is_admin(event):
-            yield event.plain_result("仅管理员可以查看状态。")
+            yield event.plain_result("???????????")
             return
         try:
             payload = await self.controller.get_status()
@@ -774,13 +894,13 @@ class QzoneStablePlugin(Star):
 
     @filter.llm_tool(name="qzone_list_feed")
     async def tool_list_feed(self, event: AstrMessageEvent, hostuin: int = 0, limit: int = 5, cursor: str = "", scope: str = ""):
-        """列出 QQ 空间说说。
+        """?? QQ ?????
 
         Args:
-            hostuin (number): 目标 QQ 号。0 表示当前登录账号。
-            limit (number): 返回条数。
-            cursor (string): 翻页游标。
-            scope (string): self 或 profile。
+            hostuin (number): ?? QQ ??0 ?????????
+            limit (number): ?????
+            cursor (string): ?????
+            scope (string): self ? profile?
         """
         try:
             await self._ensure_cookie_ready(event)
@@ -799,12 +919,12 @@ class QzoneStablePlugin(Star):
 
     @filter.llm_tool(name="qzone_detail_feed")
     async def tool_detail_feed(self, event: AstrMessageEvent, hostuin: int, fid: str, appid: int = 311):
-        """获取单条说说详情。
+        """?????????
 
         Args:
-            hostuin (number): 说说所属 QQ 号。
-            fid (string): 说说 fid。
-            appid (number): 应用 id，默认 311。
+            hostuin (number): ???? QQ ??
+            fid (string): ?? fid?
+            appid (number): ?? id??? 311?
         """
         try:
             await self._ensure_cookie_ready(event)
@@ -824,15 +944,15 @@ class QzoneStablePlugin(Star):
         sync_weibo: bool = False,
         media: list[str] | None = None,
     ):
-        """发布一条 QQ 空间说说。
+        """???? QQ ?????
 
         Args:
-            content (string): 说说内容。
-            confirm (boolean): 是否确认执行。
-            sync_weibo (boolean): 是否同步微博。
+            content (string): ?????
+            confirm (boolean): ???????
+            sync_weibo (boolean): ???????
         """
         if not self._is_admin(event):
-            yield event.plain_result("仅管理员可发布说说。")
+            yield event.plain_result("??????????")
             return
         post = collect_post_payload(
             event,
@@ -842,9 +962,9 @@ class QzoneStablePlugin(Star):
             extra_media=media,
         )
         if self.settings.preview_writes and not confirm:
-            draft = truncate(post.content or "（仅附件）", 120)
-            suffix = f"；附件 {len(post.media)} 个" if post.media else ""
-            yield event.plain_result(f"待发布草稿: {draft}{suffix}。确认后将执行。")
+            draft = truncate(post.content or "?????", 120)
+            suffix = f"??? {len(post.media)} ?" if post.media else ""
+            yield event.plain_result(f"?????: {draft}{suffix}????????")
             return
         profile_task: asyncio.Task | None = None
         try:
@@ -874,22 +994,22 @@ class QzoneStablePlugin(Star):
         appid: int = 311,
         private: bool = False,
     ):
-        """评论一条说说。
+        """???????
 
         Args:
-            hostuin (number): 目标 QQ 号。
-            fid (string): 说说 fid。
-            content (string): 评论内容。
-            confirm (boolean): 兼容旧参数；点赞工具会直接执行。
-            appid (number): 应用 id。
-            private (boolean): 是否私密评论。
+            hostuin (number): ?? QQ ??
+            fid (string): ?? fid?
+            content (string): ?????
+            confirm (boolean): ????????????????
+            appid (number): ?? id?
+            private (boolean): ???????
         """
         if not self._is_admin(event):
-            yield event.plain_result("仅管理员可评论。")
+            yield event.plain_result("????????")
             return
         if self.settings.preview_writes and not confirm:
             yield event.plain_result(
-                f"待评论草稿: hostuin={hostuin}, fid={fid}, content={truncate(content, 120)}。确认后将执行。"
+                f"?????: hostuin={hostuin}, fid={fid}, content={truncate(content, 120)}????????"
             )
             return
         try:
@@ -905,7 +1025,7 @@ class QzoneStablePlugin(Star):
         except QzoneBridgeError as exc:
             yield event.plain_result(self._error_text(exc))
             return
-        yield event.plain_result(format_action_result("评论成功", payload))
+        yield event.plain_result(format_action_result("????", payload))
 
     @filter.llm_tool(name="qzone_like_post")
     async def tool_like_post(
@@ -919,17 +1039,26 @@ class QzoneStablePlugin(Star):
         latest: bool = False,
         index: int = 0,
     ):
-        """点赞或取消点赞一条说说。
+        """????????????
 
         Args:
-            hostuin (number): 目标 QQ 号。`0` 表示当前登录 QQ，也可以复用最近一次列出的说说列表上下文。
-            fid (string): 精确的说说 fid。若按“最新一条”或“第 N 条”操作，优先使用 `latest` / `index`，也兼容 `latest`、`第3条` 这类文本引用。
-            confirm (boolean): 兼容旧参数；该工具会直接执行。
-            appid (number): 说说 appid，通常为 `311`。
-            unlike (boolean): 为 `true` 时取消点赞，否则执行点赞。
-            latest (boolean): 为 `true` 时自动定位目标 QQ 的最新一条说说。
-            index (number): 自动定位目标 QQ 的第 N 条说说；`1` 表示最新一条。
+            hostuin (number): ?? QQ ??`0` ?????? QQ?????????????????????
+            fid (string): ????? fid???????????? N ????????? `latest` / `index`???? `latest`?`?3?` ???????
+            confirm (boolean): ???????????????
+            appid (number): ?? appid???? `311`?
+            unlike (boolean): ? `true` ?????????????
+            latest (boolean): ? `true` ??????? QQ ????????
+            index (number): ?????? QQ ?? N ????`1` ???????
         """
+        arguments = {
+            "hostuin": hostuin,
+            "fid": fid,
+            "confirm": confirm,
+            "appid": appid,
+            "unlike": unlike,
+            "latest": latest,
+            "index": index,
+        }
         if not self._is_admin(event):
             payload = {
                 "ok": False,
@@ -937,11 +1066,12 @@ class QzoneStablePlugin(Star):
                 "error": {
                     "type": "PermissionError",
                     "code": "QZONE_PERMISSION",
-                    "message": "仅管理员可点赞。",
+                    "message": "????????",
                 },
-                "reply_guidance": "请用自然语言告诉用户没有权限执行点赞。",
+                "reply_guidance": "???????????????????",
             }
-            text = await self._ask_llm_tool_reply(event, payload, "仅管理员可点赞。")
+            self._log_tool_call_result({**payload, "arguments": arguments})
+            text = await self._ask_llm_tool_reply(event, payload, "????????")
             yield event.plain_result(text)
             return
         try:
@@ -956,13 +1086,24 @@ class QzoneStablePlugin(Star):
                 index=index,
             )
         except QzoneBridgeError as exc:
+            log_payload = self._bridge_error_log_payload("qzone_like_post", exc, arguments)
+            self._log_tool_call_result(log_payload)
+            llm_payload = self._llm_error_payload("qzone_like_post", exc)
             text = await self._ask_llm_tool_reply(
                 event,
-                self._llm_error_payload("qzone_like_post", exc),
+                llm_payload,
                 exc.message,
             )
             yield event.plain_result(text)
             return
+        self._log_tool_call_result(
+            {
+                "ok": True,
+                "tool": "qzone_like_post",
+                "arguments": arguments,
+                "result": payload,
+            }
+        )
         text = await self._ask_llm_tool_reply(
             event,
             self._llm_like_payload(payload),

--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -1,4 +1,4 @@
-"""Low-level QQ空间 HTTP client."""
+"""Low-level QQ?? HTTP client."""
 
 from __future__ import annotations
 
@@ -35,12 +35,16 @@ from .utils import extract_callback_json, json_loads, now_iso
 log = logging.getLogger(__name__)
 
 AUTH_ERROR_CODES = {-3000}
-AUTH_ERROR_KEYWORDS = ("登录", "失效", "请先登录", "skey", "g_tk", "cookie", "expired", "login")
+AUTH_ERROR_KEYWORDS = ("??", "??", "????", "skey", "g_tk", "cookie", "expired", "login")
 LOGIN_REDIRECT_HOSTS = ("ptlogin", "ui.ptlogin", "xui.ptlogin", "ssl.ptlogin", "login")
 QZONE_IMAGE_UPLOAD_URL = "https://up.qzone.qq.com/cgi-bin/upload/cgi_upload_image"
 QZONE_REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
-QZONE_LIKE_URL = "https://w.qzone.qq.com/cgi-bin/likes/internal_dolike_app"
-QZONE_UNLIKE_URL = "https://w.qzone.qq.com/cgi-bin/likes/internal_unlike_app"
+QZONE_LIKE_DIRECT_URL = "https://w.qzone.qq.com/cgi-bin/likes/internal_dolike_app"
+QZONE_UNLIKE_DIRECT_URL = "https://w.qzone.qq.com/cgi-bin/likes/internal_unlike_app"
+QZONE_LIKE_PROXY_URL = "https://user.qzone.qq.com/proxy/domain/w.qzone.qq.com/cgi-bin/likes/internal_dolike_app"
+QZONE_UNLIKE_PROXY_URL = "https://user.qzone.qq.com/proxy/domain/w.qzone.qq.com/cgi-bin/likes/internal_unlike_app"
+QZONE_LIKE_URL = QZONE_LIKE_DIRECT_URL
+QZONE_UNLIKE_URL = QZONE_UNLIKE_DIRECT_URL
 MAX_UPLOAD_IMAGE_BYTES = 32 * 1024 * 1024
 IMAGE_SOURCE_CACHE_TTL_SECONDS = 10 * 60
 IMAGE_SOURCE_CACHE_MAX_ITEMS = 16
@@ -162,9 +166,9 @@ class QzoneClient:
                     code = 0
                 message = str(payload.get("msg") or payload.get("message") or payload.get("text") or "")
                 if self._payload_needs_rebind(code, message):
-                    raise QzoneNeedsRebind(message or "QQ空间登录态已失效", detail=payload)
+                    raise QzoneNeedsRebind(message or "QQ????????", detail=payload)
                 code_text = raw_code if raw_code not in (None, "") else code
-                raise QzoneRequestError(message or f"QQ空间返回错误码 {code_text}", status_code=response.status_code, detail=payload)
+                raise QzoneRequestError(message or f"QQ??????? {code_text}", status_code=response.status_code, detail=payload)
 
     @staticmethod
     def _response_detail(response: httpx.Response) -> dict[str, Any]:
@@ -175,6 +179,12 @@ class QzoneClient:
         location = response.headers.get("location") or response.headers.get("Location")
         if location:
             detail["location"] = location
+        try:
+            text = response.text
+        except Exception:
+            text = ""
+        if text:
+            detail["text"] = text[:500]
         return detail
 
     @staticmethod
@@ -204,6 +214,14 @@ class QzoneClient:
             return False
         host = (parsed.hostname or "").lower()
         return host == "qq.com" or host.endswith(".qq.com")
+
+    @staticmethod
+    def _is_like_action_redirect(current_url: str, location: str) -> bool:
+        if not location:
+            return False
+        target = urljoin(current_url, location)
+        parsed = urlparse(target)
+        return "/cgi-bin/likes/internal_" in parsed.path
 
     @staticmethod
     def _redirect_url_with_params(target_url: str, params: dict[str, Any] | None) -> str:
@@ -266,15 +284,18 @@ class QzoneClient:
         attach_token: bool = False,
         login_required: bool = True,
         follow_qzone_redirects: bool = False,
+        accept_qzone_redirects: bool = False,
+        max_attempts: int | None = None,
     ) -> httpx.Response:
         if login_required and not self.session.cookies:
             raise QzoneNeedsRebind()
         if login_required and self.gtk == 0:
-            raise QzoneNeedsRebind("Cookie 中缺少 p_skey 或 skey，无法计算 g_tk")
+            raise QzoneNeedsRebind("Cookie ??? p_skey ? skey????? g_tk")
 
         params = self._merge_params(params, hostuin=hostuin, attach_token=attach_token)
+        attempts = self.max_retries if max_attempts is None else max(1, int(max_attempts))
         last_exc: Exception | None = None
-        for attempt in range(1, self.max_retries + 1):
+        for attempt in range(1, attempts + 1):
             try:
                 current_url = url
                 current_params = params
@@ -291,8 +312,10 @@ class QzoneClient:
                     self._persist_cookie_response(response)
                     location = response.headers.get("location") or response.headers.get("Location") or ""
                     if response.status_code in QZONE_REDIRECT_STATUS_CODES and self._is_qzone_home_redirect(response):
+                        if accept_qzone_redirects and self._is_allowed_qzone_redirect(str(response.request.url), location):
+                            return response
                         raise QzoneRequestError(
-                            "QQ空间 H5 入口跳转到个人主页，已切换备用接口",
+                            "QQ?? H5 ?????????????????",
                             status_code=response.status_code,
                             detail=self._response_detail(response),
                         )
@@ -300,56 +323,63 @@ class QzoneClient:
                         response.status_code in QZONE_REDIRECT_STATUS_CODES and self._is_login_redirect(location)
                     ):
                         raise QzoneNeedsRebind(
-                            "QQ空间登录失效，请重新绑定 Cookie",
+                            "QQ???????????? Cookie",
                             detail=self._response_detail(response),
                         )
                     if response.status_code in QZONE_REDIRECT_STATUS_CODES:
+                        allowed_redirect = self._is_allowed_qzone_redirect(str(response.request.url), location)
                         if (
                             follow_qzone_redirects
                             and redirects_left > 0
-                            and self._is_allowed_qzone_redirect(str(response.request.url), location)
+                            and allowed_redirect
+                            and (
+                                not accept_qzone_redirects
+                                or self._is_like_action_redirect(str(response.request.url), location)
+                            )
                         ):
                             target_url = urljoin(str(response.request.url), location)
                             current_url = self._redirect_url_with_params(target_url, params)
                             current_params = None
                             redirects_left -= 1
                             continue
+                        if accept_qzone_redirects and allowed_redirect:
+                            return response
                         raise QzoneRequestError(
-                            f"QQ空间返回跳转状态码 {response.status_code}",
+                            f"QQ????????? {response.status_code}",
                             status_code=response.status_code,
                             detail=self._response_detail(response),
                         )
                     break
                 if response.status_code == 403:
                     raise QzoneRequestError(
-                        "QQ空间访问受限或权限不足",
+                        "QQ???????????",
                         status_code=response.status_code,
                         detail=self._response_detail(response),
                     )
                 if response.status_code == 429:
                     raise QzoneRequestError(
-                        "QQ空间请求过于频繁，已被限流",
+                        "QQ?????????????",
                         status_code=response.status_code,
-                        detail={"url": url, "text": response.text[:500]},
+                        detail=self._response_detail(response),
                     )
                 if response.status_code >= 500:
                     raise QzoneRequestError(
-                        f"QQ空间服务器暂时不可用 ({response.status_code})",
+                        f"QQ?????????? ({response.status_code})",
                         status_code=response.status_code,
-                        detail={"url": url, "text": response.text[:500]},
+                        detail=self._response_detail(response),
                     )
                 if response.status_code >= 400:
                     raise QzoneRequestError(
-                        f"QQ空间返回 HTTP {response.status_code}",
+                        f"QQ???? HTTP {response.status_code}",
                         status_code=response.status_code,
-                        detail={"url": url, "text": response.text[:500]},
+                        detail=self._response_detail(response),
                     )
                 return response
             except (httpx.TimeoutException, httpx.NetworkError, httpx.HTTPError, QzoneRequestError) as exc:
                 last_exc = exc
                 if isinstance(exc, QzoneRequestError) and exc.status_code is not None and exc.status_code < 500:
                     raise
-                if attempt >= self.max_retries:
+                if attempt >= attempts:
                     raise
                 await asyncio.sleep(min(2.0 * attempt, 6.0))
         assert last_exc is not None
@@ -377,7 +407,7 @@ class QzoneClient:
             if not json_like:
                 detail = {"text": text[:500], "url": str(response.request.url)}
                 raise QzoneParseError(
-                    "QQ 空间接口返回了非 JSON 响应",
+                    "QQ ???????? JSON ??",
                     detail=detail,
                 ) from (callback_error or json_exc)
             try:
@@ -385,7 +415,7 @@ class QzoneClient:
             except Exception as js_exc:
                 detail = {"text": text[:500], "url": str(response.request.url)}
                 raise QzoneParseError(
-                    "无法解析 QQ 空间 JSON 响应",
+                    "???? QQ ?? JSON ??",
                     detail=detail,
                 ) from (js_exc or json_exc)
 
@@ -403,6 +433,8 @@ class QzoneClient:
         attach_token: bool = False,
         login_required: bool = True,
         follow_qzone_redirects: bool = False,
+        accept_qzone_redirects: bool = False,
+        max_attempts: int | None = None,
     ) -> dict[str, Any]:
         response = await self._request_text(
             method,
@@ -416,7 +448,11 @@ class QzoneClient:
             attach_token=attach_token,
             login_required=login_required,
             follow_qzone_redirects=follow_qzone_redirects,
+            accept_qzone_redirects=accept_qzone_redirects,
+            max_attempts=max_attempts,
         )
+        if accept_qzone_redirects and response.status_code in QZONE_REDIRECT_STATUS_CODES:
+            return {"message": "accepted redirect", "redirect": self._response_detail(response)}
         text = response.text.strip()
         payload = self._parse_response_payload(text, response)
         self._raise_payload_error(payload, response)
@@ -428,7 +464,7 @@ class QzoneClient:
         try:
             payload = parse_profile_html(response_text) if profile else parse_index_html(response_text)
         except Exception as exc:
-            raise QzoneParseError("QQ 空间页面解析失败", detail={"text": response_text[:500]}) from exc
+            raise QzoneParseError("QQ ????????", detail={"text": response_text[:500]}) from exc
         return payload
 
     def _store_token(self, hostuin: int, token: str) -> None:
@@ -605,7 +641,7 @@ class QzoneClient:
     async def _load_image_source(self, media: dict[str, Any]) -> tuple[bytes, str, str]:
         item = normalize_media_item(media, default_kind="image")
         if item is None or not item.source:
-            raise QzoneParseError("图片来源为空，无法上传")
+            raise QzoneParseError("???????????")
 
         source = item.source.strip()
         filename = item.name or source_name(source) or "image.jpg"
@@ -619,19 +655,19 @@ class QzoneClient:
             try:
                 return base64.b64decode(source[len("base64://") :], validate=False), filename, mime_type
             except Exception as exc:
-                raise QzoneParseError("无法解析 base64 图片数据") from exc
+                raise QzoneParseError("???? base64 ????") from exc
         if source.startswith("data:"):
             try:
                 header, encoded = source.split(",", 1)
             except ValueError as exc:
-                raise QzoneParseError("无法解析 data URI 图片数据") from exc
+                raise QzoneParseError("???? data URI ????") from exc
             header_mime = header[5:].split(";", 1)[0]
             if ";base64" not in header:
-                raise QzoneParseError("data URI 图片必须使用 base64 编码")
+                raise QzoneParseError("data URI ?????? base64 ??")
             try:
                 data = base64.b64decode(encoded, validate=False)
             except Exception as exc:
-                raise QzoneParseError("无法解析 data URI 图片数据") from exc
+                raise QzoneParseError("???? data URI ????") from exc
             return data, filename, mime_type or header_mime
 
         if parsed.scheme.lower() in {"http", "https"}:
@@ -646,14 +682,14 @@ class QzoneClient:
                     if response.status_code >= 400:
                         text = (await response.aread()).decode("utf-8", errors="ignore")
                         raise QzoneRequestError(
-                            f"下载图片返回 HTTP {response.status_code}",
+                            f"?????? HTTP {response.status_code}",
                             status_code=response.status_code,
                             detail={"url": source, "text": text[:500]},
                         )
                     length = response.headers.get("content-length")
                     try:
                         if length and int(length) > MAX_UPLOAD_IMAGE_BYTES:
-                            raise QzoneParseError("图片文件过大，无法快速上传", detail={"url": source})
+                            raise QzoneParseError("?????????????", detail={"url": source})
                     except ValueError:
                         pass
                     chunks: list[bytes] = []
@@ -663,10 +699,10 @@ class QzoneClient:
                             continue
                         total += len(chunk)
                         if total > MAX_UPLOAD_IMAGE_BYTES:
-                            raise QzoneParseError("图片文件过大，无法快速上传", detail={"url": source})
+                            raise QzoneParseError("?????????????", detail={"url": source})
                         chunks.append(chunk)
             except httpx.HTTPError as exc:
-                raise QzoneRequestError("下载图片失败", detail={"url": source}) from exc
+                raise QzoneRequestError("??????", detail={"url": source}) from exc
             content_type = response.headers.get("content-type", "").split(";", 1)[0]
             data = b"".join(chunks)
             self._store_image_source_cache(source, data, content_type)
@@ -675,10 +711,10 @@ class QzoneClient:
         path = Path(source)
         def read_local_image() -> bytes:
             if not path.exists() or not path.is_file():
-                raise QzoneParseError("图片文件不存在", detail={"path": source})
+                raise QzoneParseError("???????", detail={"path": source})
             stat = path.stat()
             if stat.st_size > MAX_UPLOAD_IMAGE_BYTES:
-                raise QzoneParseError("图片文件过大，无法快速上传", detail={"path": source})
+                raise QzoneParseError("?????????????", detail={"path": source})
             return path.read_bytes()
 
         data = await asyncio.to_thread(read_local_image)
@@ -688,7 +724,7 @@ class QzoneClient:
     def _photo_payload_from_upload(payload: dict[str, Any], *, filename: str = "", mime_type: str = "") -> dict[str, Any]:
         data = unwrap_payload(payload)
         if not isinstance(data, dict):
-            raise QzoneParseError("图片上传返回结构异常", detail=payload)
+            raise QzoneParseError("??????????", detail=payload)
         albumid = str(data.get("albumid") or data.get("albumId") or "")
         lloc = str(data.get("lloc") or data.get("LLoc") or "")
         sloc = str(data.get("sloc") or data.get("SLoc") or "")
@@ -696,7 +732,7 @@ class QzoneClient:
         height = str(data.get("height") or data.get("h") or 0)
         width = str(data.get("width") or data.get("w") or 0)
         if not albumid or not lloc or not sloc:
-            raise QzoneParseError("图片上传返回缺少 richval 字段", detail=data)
+            raise QzoneParseError("???????? richval ??", detail=data)
         url = str(data.get("url") or data.get("origin_url") or data.get("originUrl") or data.get("pre") or "")
         pic_bo = str(data.get("pic_bo") or data.get("picBo") or QzoneClient._extract_pic_bo(url) or "")
         richval = f",{albumid},{lloc},{sloc},{photo_type},{height},{width},,{height},{width}"
@@ -715,10 +751,10 @@ class QzoneClient:
     async def upload_photo(self, media: dict[str, Any]) -> dict[str, Any]:
         item = normalize_media_item(media, default_kind="image")
         if item is None or not is_supported_image(item):
-            raise QzoneParseError("QQ空间说说仅支持上传图片附件", detail=media)
+            raise QzoneParseError("QQ?????????????", detail=media)
         data, filename, mime_type = await self._load_image_source(item.to_dict())
         if not data:
-            raise QzoneParseError("图片内容为空，无法上传", detail={"name": filename})
+            raise QzoneParseError("???????????", detail={"name": filename})
 
         encoded_bytes = await asyncio.to_thread(base64.b64encode, data)
         encoded = encoded_bytes.decode("ascii")
@@ -765,7 +801,7 @@ class QzoneClient:
 
     async def _prepare_publish_photos(self, photos: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
         if photos and len(photos) > QZONE_MAX_IMAGES:
-            raise QzoneParseError(f"QQ空间说说最多支持 {QZONE_MAX_IMAGES} 张图片")
+            raise QzoneParseError(f"QQ???????? {QZONE_MAX_IMAGES} ???")
         source_photos = list(photos or [])
         prepared: list[dict[str, Any] | None] = [None] * len(source_photos)
         pending: list[tuple[int, dict[str, Any]]] = []
@@ -805,7 +841,7 @@ class QzoneClient:
 
         final = [photo for photo in prepared if photo is not None]
         if len(final) > QZONE_MAX_IMAGES:
-            raise QzoneParseError(f"QQ空间说说最多支持 {QZONE_MAX_IMAGES} 张图片")
+            raise QzoneParseError(f"QQ???????? {QZONE_MAX_IMAGES} ???")
         return final
 
     async def publish_mood(self, content: str, *, sync_weibo: bool = False, photos: list[dict[str, Any]] | None = None) -> dict[str, Any]:
@@ -885,6 +921,27 @@ class QzoneClient:
         )
         return payload
 
+    @staticmethod
+    def _like_endpoint_candidates(like: bool) -> tuple[str, ...]:
+        if like:
+            return (QZONE_LIKE_PROXY_URL, QZONE_LIKE_DIRECT_URL)
+        return (QZONE_UNLIKE_PROXY_URL, QZONE_UNLIKE_DIRECT_URL)
+
+    @staticmethod
+    def _like_attempt_detail(endpoint: str, exc: Exception) -> dict[str, Any]:
+        detail: dict[str, Any] = {
+            "endpoint": endpoint,
+            "type": type(exc).__name__,
+            "message": getattr(exc, "message", str(exc)),
+        }
+        status_code = getattr(exc, "status_code", None)
+        if status_code is not None:
+            detail["status_code"] = status_code
+        exc_detail = getattr(exc, "detail", None)
+        if exc_detail is not None:
+            detail["detail"] = exc_detail
+        return detail
+
     async def like_post(
         self,
         hostuin: int,
@@ -908,34 +965,60 @@ class QzoneClient:
             else compute_unikey(appid, hostuin, fid)
         )
         created_at = cached.created_at if cached else 0
-        path = QZONE_LIKE_URL if like else QZONE_UNLIKE_URL
-        payload = await self._request_json(
-            "POST",
-            path,
-            data={
-                "unikey": unikey,
-                "curkey": curkey,
-                "appid": appid,
-                "opuin": self.login_uin,
-                "uin": self.login_uin,
-                "hostuin": hostuin,
-                "fid": fid,
-                "from": 1,
-                "typeid": 0,
-                "abstime": created_at,
-                "active": 0,
-                "fupdate": 1,
-                "opr_type": "like" if like else "unlike",
-                "format": "purejson",
-                "qzreferrer": f"https://user.qzone.qq.com/{hostuin}/mood/{fid}",
-            },
-            referer=f"https://user.qzone.qq.com/{hostuin}/mood/{fid}",
-            origin="https://user.qzone.qq.com",
-            hostuin=hostuin,
-            attach_token=False,
-            follow_qzone_redirects=True,
-        )
-        return payload
+        data = {
+            "unikey": unikey,
+            "curkey": curkey,
+            "appid": appid,
+            "opuin": self.login_uin,
+            "uin": self.login_uin,
+            "hostuin": hostuin,
+            "fid": fid,
+            "from": 1,
+            "typeid": 0,
+            "abstime": created_at,
+            "active": 0,
+            "fupdate": 1,
+            "opr_type": "like" if like else "unlike",
+            "format": "purejson",
+            "qzreferrer": f"https://user.qzone.qq.com/{hostuin}/mood/{fid}",
+        }
+        attempts: list[dict[str, Any]] = []
+        last_exc: Exception | None = None
+        for path in self._like_endpoint_candidates(like):
+            try:
+                return await self._request_json(
+                    "POST",
+                    path,
+                    data=data,
+                    referer=f"https://user.qzone.qq.com/{hostuin}/mood/{fid}",
+                    origin="https://user.qzone.qq.com",
+                    hostuin=hostuin,
+                    attach_token=False,
+                    follow_qzone_redirects=True,
+                    accept_qzone_redirects=True,
+                    max_attempts=1,
+                )
+            except (QzoneRequestError, QzoneParseError) as exc:
+                last_exc = exc
+                attempts.append(self._like_attempt_detail(path, exc))
+                log.warning(
+                    "qzone like endpoint failed endpoint=%s status=%s message=%s",
+                    path,
+                    getattr(exc, "status_code", None),
+                    getattr(exc, "message", str(exc)),
+                )
+                continue
+
+        if isinstance(last_exc, QzoneRequestError):
+            status_code = last_exc.status_code
+            message = f"{last_exc.message}??????????"
+        elif last_exc is not None:
+            status_code = None
+            message = f"{getattr(last_exc, 'message', str(last_exc))}??????????"
+        else:
+            status_code = None
+            message = "QQ???????????????????"
+        raise QzoneRequestError(message, status_code=status_code, detail={"attempts": attempts}) from last_exc
 
     async def detail(self, hostuin: int, fid: str, *, appid: int = 311, busi_param: str = "") -> dict[str, Any]:
         payload = await self.shuoshuo(fid=fid, uin=hostuin, appid=appid, busi_param=busi_param)

--- a/qzone_bridge/controller.py
+++ b/qzone_bridge/controller.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import httpx
 
@@ -25,6 +26,8 @@ from .utils import now_iso
 
 
 log = logging.getLogger(__name__)
+SENSITIVE_DETAIL_KEYS = {"cookie", "cookies", "p_skey", "skey", "pt4_token", "pt_key", "qzonetoken", "secret", "token"}
+SENSITIVE_URL_QUERY_KEYS = {"g_tk", "gtk", "p_skey", "skey", "pt4_token", "pt_key", "qzonetoken", "token", "secret"}
 
 
 def _port_is_free(port: int) -> bool:
@@ -115,6 +118,64 @@ def _is_plugin_daemon_pid(pid: int, plugin_root: Path) -> bool:
         return False
     root = str(plugin_root).lower()
     return "daemon_main.py" in command_line and root in command_line
+
+
+def _detail_status_code(detail: Any) -> int | None:
+    if not isinstance(detail, dict):
+        return None
+    raw_status = detail.get("status_code")
+    if raw_status is None:
+        attempts = detail.get("attempts")
+        if isinstance(attempts, list):
+            for attempt in reversed(attempts):
+                if isinstance(attempt, dict) and attempt.get("status_code") is not None:
+                    raw_status = attempt.get("status_code")
+                    break
+    try:
+        return int(raw_status) if raw_status is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _redact_url(value: str) -> str:
+    try:
+        parsed = urlparse(value)
+    except Exception:
+        return value
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.netloc:
+        return value
+    query = []
+    changed = False
+    for key, item_value in parse_qsl(parsed.query, keep_blank_values=True):
+        lowered = key.lower()
+        if lowered in SENSITIVE_URL_QUERY_KEYS or "token" in lowered or "skey" in lowered:
+            query.append((key, "***"))
+            changed = True
+        else:
+            query.append((key, item_value))
+    if not changed:
+        return value
+    return urlunparse(parsed._replace(query=urlencode(query, doseq=True)))
+
+
+def _redact_detail_for_log(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            lowered = key_text.lower()
+            if lowered in SENSITIVE_DETAIL_KEYS or "cookie" in lowered or "skey" in lowered or "secret" in lowered:
+                redacted[key_text] = "***"
+            else:
+                redacted[key_text] = _redact_detail_for_log(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_detail_for_log(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_detail_for_log(item) for item in value]
+    if isinstance(value, str):
+        return _redact_url(value)
+    return value
 
 
 def _terminate_pid_tree(pid: int, *, force: bool = False) -> None:
@@ -305,7 +366,7 @@ class QzoneDaemonController:
                 self.store.write(state)
 
             if not self._daemon_script().exists():
-                raise DaemonUnavailableError("找不到 daemon_main.py")
+                raise DaemonUnavailableError("??? daemon_main.py")
 
             self._process = self._spawn_daemon(port)
 
@@ -330,7 +391,7 @@ class QzoneDaemonController:
                     break
                 await asyncio.sleep(0.5)
 
-            raise DaemonUnavailableError("QQ空间 daemon 启动失败")
+            raise DaemonUnavailableError("QQ?? daemon ????")
 
     async def _request(
         self,
@@ -348,7 +409,7 @@ class QzoneDaemonController:
                 await self.ensure_running()
                 runtime = self._runtime()
             elif not await self._probe_health(runtime.daemon_port):
-                raise DaemonUnavailableError("daemon 未运行")
+                raise DaemonUnavailableError("daemon ???")
             try:
                 response = await self._client.request(
                     method,
@@ -363,29 +424,36 @@ class QzoneDaemonController:
                 last_exc = exc
                 if not self.auto_start_daemon or attempt > 0:
                     raise DaemonUnavailableError(
-                        "daemon 请求失败",
+                        "daemon ????",
                         detail={"error": str(exc), "path": path},
                     ) from exc
         if response is None:
             raise DaemonUnavailableError(
-                "daemon 请求失败",
+                "daemon ????",
                 detail={"error": str(last_exc), "path": path},
             )
         try:
             payload = response.json()
         except Exception as exc:
-            raise DaemonUnavailableError("daemon 返回了非 JSON 响应", detail={"text": response.text[:500]}) from exc
+            raise DaemonUnavailableError("daemon ???? JSON ??", detail={"text": response.text[:500]}) from exc
         if not payload.get("ok", False):
             error = payload.get("error") or {}
             code = str(error.get("code") or "DAEMON_ERROR")
             message = str(error.get("message") or "daemon error")
             detail = error.get("detail")
+            log.warning(
+                "qzone daemon request failed path=%s code=%s message=%s detail=%s",
+                path,
+                code,
+                message,
+                _redact_detail_for_log(detail),
+            )
             if code == "QZONE_AUTH":
                 raise QzoneNeedsRebind(message, detail=detail)
             if code == "QZONE_PARSE":
                 raise QzoneParseError(message, detail=detail)
             if code == "QZONE_REQUEST":
-                raise QzoneRequestError(message, detail=detail)
+                raise QzoneRequestError(message, status_code=_detail_status_code(detail), detail=detail)
             raise DaemonUnavailableError(message, detail=detail)
         return payload.get("data")
 
@@ -402,10 +470,10 @@ class QzoneDaemonController:
     @staticmethod
     def cookie_summary(cookies: dict[str, str]) -> str:
         if not cookies:
-            return "未绑定"
+            return "???"
         keys = ["uin", "p_uin", "skey", "p_skey", "pt4_token", "pt_key"]
         found = [key for key in keys if key in cookies]
-        return f"{len(cookies)}个字段: " + ", ".join(found or ["未知字段"])
+        return f"{len(cookies)}???: " + ", ".join(found or ["????"])
 
     async def bind_cookie(self, cookie_text: str, *, uin: int = 0, source: str = "manual") -> dict[str, Any]:
         return await self._request("POST", "/bind", json_body={"cookie_text": cookie_text, "uin": uin, "source": source})
@@ -418,10 +486,10 @@ class QzoneDaemonController:
         except DaemonUnavailableError:
             cookies = parse_cookie_text(cookie_text)
             if not cookies:
-                raise QzoneParseError("Cookie 为空，无法绑定")
+                raise QzoneParseError("Cookie ???????")
             resolved_uin = normalize_uin(cookies, override=uin)
             if not resolved_uin:
-                raise QzoneParseError("Cookie 中未找到 uin / p_uin，请补齐后重试")
+                raise QzoneParseError("Cookie ???? uin / p_uin???????")
 
             state = self.store.read()
             runtime = self._runtime()

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -1,4 +1,4 @@
-"""Standalone QQ空间 daemon."""
+"""Standalone QQ?? daemon."""
 
 from __future__ import annotations
 
@@ -38,12 +38,12 @@ LATEST_FEED_REFERENCES = {
     "newest",
     "recent",
     "last",
-    "最新",
-    "最新一条",
-    "最近一条",
-    "最后一条",
+    "??",
+    "????",
+    "????",
+    "????",
 }
-FEED_REFERENCE_PATTERN = re.compile(r"^第?\s*(\d+)\s*条?$")
+FEED_REFERENCE_PATTERN = re.compile(r"^??\s*(\d+)\s*??$")
 
 
 class QzoneDaemonService:
@@ -221,10 +221,10 @@ class QzoneDaemonService:
     async def bind_cookie(self, cookie_text: str, *, uin: int = 0, source: str = "manual") -> dict[str, Any]:
         cookies = parse_cookie_text(cookie_text)
         if not cookies:
-            raise QzoneParseError("Cookie 为空，无法绑定")
+            raise QzoneParseError("Cookie ???????")
         resolved_uin = normalize_uin(cookies, override=uin)
         if not resolved_uin:
-            raise QzoneParseError("Cookie 中未找到 uin / p_uin，请补齐后重试")
+            raise QzoneParseError("Cookie ???? uin / p_uin???????")
         self.state.session = SessionState(
             uin=resolved_uin,
             cookies=cookies,
@@ -266,6 +266,16 @@ class QzoneDaemonService:
         self.health_state = "needs_rebind"
         return self.snapshot()
 
+    @staticmethod
+    def _should_fallback_feed_fetch(exc: Exception) -> bool:
+        if isinstance(exc, QzoneParseError):
+            return True
+        if not isinstance(exc, QzoneRequestError):
+            return False
+        if exc.status_code in {301, 302, 303, 307, 308, 403, 429}:
+            return True
+        return exc.status_code is not None and exc.status_code >= 500
+
     async def list_feeds(self, *, hostuin: int = 0, limit: int = 5, cursor: str = "", scope: str = "") -> dict[str, Any]:
         self._ensure_session_ready()
         if limit <= 0:
@@ -283,9 +293,10 @@ class QzoneDaemonService:
                 if page_round == 0 and not next_cursor:
                     try:
                         payload = unwrap_payload(await self.client.index())
-                    except QzoneRequestError as exc:
-                        if exc.status_code not in {301, 302, 303, 307, 308}:
+                    except (QzoneRequestError, QzoneParseError) as exc:
+                        if not self._should_fallback_feed_fetch(exc):
                             raise
+                        log.warning("qzone self feed primary fetch failed, using legacy fallback: %s", exc)
                         payload = await self.client.legacy_recent_feeds()
                 else:
                     payload = unwrap_payload(await self.client.get_active_feeds(next_cursor))
@@ -294,9 +305,10 @@ class QzoneDaemonService:
                 if page_round == 0 and not next_cursor:
                     try:
                         payload = await self.client.profile(hostuin)
-                    except QzoneRequestError as exc:
-                        if exc.status_code not in {301, 302, 303, 307, 308}:
+                    except (QzoneRequestError, QzoneParseError) as exc:
+                        if not self._should_fallback_feed_fetch(exc):
                             raise
+                        log.warning("qzone profile feed primary fetch failed, using legacy fallback: %s", exc)
                         payload = await self.client.legacy_feeds(hostuin, page=1, num=max(limit, 20))
                 else:
                     payload = unwrap_payload(await self.client.get_feeds(hostuin, next_cursor))
@@ -331,7 +343,7 @@ class QzoneDaemonService:
         await self.ensure_token(hostuin)
         payload = unwrap_payload(await self.client.detail(hostuin, fid, appid=appid, busi_param=busi_param))
         if not isinstance(payload, dict):
-            raise QzoneParseError("说说详情返回结构异常")
+            raise QzoneParseError("??????????")
         entry = self.client.feed_entry_from_payload(payload, default_hostuin=hostuin)
         self.client.cache_feed_page(hostuin, [entry])
         comments = []
@@ -368,12 +380,12 @@ class QzoneDaemonService:
         normalized_media = normalize_media_list(media)
         photos, fallback_media = split_publishable_images(normalized_media)
         if len(photos) > QZONE_MAX_IMAGES:
-            raise QzoneParseError(f"QQ空间说说最多支持 {QZONE_MAX_IMAGES} 张图片")
+            raise QzoneParseError(f"QQ???????? {QZONE_MAX_IMAGES} ???")
         if fallback_media:
             refs = "\n".join(media_reference_text(item) for item in fallback_media)
             content = "\n".join(part for part in (content.strip(), refs) if part)
         if not content.strip() and not photos:
-            raise QzoneParseError("发布内容不能为空")
+            raise QzoneParseError("????????")
         self._ensure_session_ready()
         payload = unwrap_payload(
             await self.client.publish_mood(
@@ -383,7 +395,7 @@ class QzoneDaemonService:
             )
         )
         if not isinstance(payload, dict):
-            raise QzoneParseError("发布说说返回结构异常")
+            raise QzoneParseError("??????????")
         self._set_success(defer_save=True)
         return {
             "fid": payload.get("fid") or payload.get("tid") or "",
@@ -403,11 +415,11 @@ class QzoneDaemonService:
         private: bool = False,
     ) -> dict[str, Any]:
         if not content.strip():
-            raise QzoneParseError("评论内容不能为空")
+            raise QzoneParseError("????????")
         self._ensure_session_ready()
         payload = unwrap_payload(await self.client.add_comment(hostuin, fid, content, appid=appid, private=private))
         if not isinstance(payload, dict):
-            raise QzoneParseError("评论返回结构异常")
+            raise QzoneParseError("????????")
         self._set_success(defer_save=True)
         return {
             "commentid": payload.get("commentid") or payload.get("commentId") or 0,
@@ -474,7 +486,7 @@ class QzoneDaemonService:
             feed_payload = await self.list_feeds(hostuin=target_hostuin, limit=reference_index, scope="profile")
             items = feed_payload.get("items") or []
             if reference_index > len(items):
-                raise QzoneParseError(f"未找到第 {reference_index} 条可点赞的说说")
+                raise QzoneParseError(f"???? {reference_index} ???????")
             entry = FeedEntry(**items[reference_index - 1])
             return entry.hostuin, entry.fid, entry.appid or appid, curkey or entry.curkey
         return target_hostuin, fid_text, int(appid or 311), curkey
@@ -560,7 +572,7 @@ class QzoneDaemonService:
             index=index,
         )
         if not hostuin or not fid:
-            raise QzoneParseError("点赞目标不完整，请先选择一条说说")
+            raise QzoneParseError("????????????????")
 
         target_liked = not unlike
         before_entry = await self._refresh_like_entry(hostuin, fid, appid)
@@ -677,6 +689,20 @@ async def _json_body(request: web.Request) -> dict[str, Any]:
     return payload
 
 
+def _error_detail(exc: QzoneBridgeError):
+    detail = exc.detail
+    status_code = getattr(exc, "status_code", None)
+    if status_code is None:
+        return detail
+    if isinstance(detail, dict):
+        merged = dict(detail)
+        merged.setdefault("status_code", status_code)
+        return merged
+    if detail is None:
+        return {"status_code": status_code}
+    return {"status_code": status_code, "detail": detail}
+
+
 def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None = None) -> web.Application:
     app = web.Application(client_max_size=32 * 1024 * 1024)
     app["service"] = service
@@ -687,7 +713,7 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
     async def auth_middleware(request: web.Request, handler):
         secret = request.headers.get(SECRET_HEADER) or request.query.get("secret") or ""
         if secret != service.state.runtime.secret:
-            return fail("UNAUTHORIZED", "secret 不匹配", status=401)
+            return fail("UNAUTHORIZED", "secret ???", status=401)
         return await handler(request)
 
     app.middlewares.append(auth_middleware)
@@ -710,7 +736,7 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
             payload = await service.bind_cookie(cookie_text, uin=uin, source=source)
         except QzoneBridgeError as exc:
             service._set_error(exc)
-            return fail(exc.code, exc.message, detail=exc.detail)
+            return fail(exc.code, exc.message, detail=_error_detail(exc))
         return ok(payload)
 
     async def unbind(request: web.Request) -> web.Response:
@@ -726,7 +752,7 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
             payload = await service.list_feeds(hostuin=hostuin, limit=limit, cursor=cursor, scope=scope)
         except QzoneBridgeError as exc:
             service._set_error(exc)
-            return fail(exc.code, exc.message, detail=exc.detail)
+            return fail(exc.code, exc.message, detail=_error_detail(exc))
         return ok(payload)
 
     async def detail(request: web.Request) -> web.Response:
@@ -738,7 +764,7 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
             payload = await service.detail_feed(hostuin=hostuin, fid=fid, appid=appid, busi_param=busi_param)
         except QzoneBridgeError as exc:
             service._set_error(exc)
-            return fail(exc.code, exc.message, detail=exc.detail)
+            return fail(exc.code, exc.message, detail=_error_detail(exc))
         return ok(payload)
 
     async def post(request: web.Request) -> web.Response:
@@ -756,7 +782,7 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
             )
         except QzoneBridgeError as exc:
             service._set_error(exc)
-            return fail(exc.code, exc.message, detail=exc.detail)
+            return fail(exc.code, exc.message, detail=_error_detail(exc))
         return ok(payload)
 
     async def comment(request: web.Request) -> web.Response:
@@ -771,7 +797,7 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
             )
         except QzoneBridgeError as exc:
             service._set_error(exc)
-            return fail(exc.code, exc.message, detail=exc.detail)
+            return fail(exc.code, exc.message, detail=_error_detail(exc))
         return ok(payload)
 
     async def like(request: web.Request) -> web.Response:
@@ -788,7 +814,7 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
             )
         except QzoneBridgeError as exc:
             service._set_error(exc)
-            return fail(exc.code, exc.message, detail=exc.detail)
+            return fail(exc.code, exc.message, detail=_error_detail(exc))
         return ok(payload)
 
     async def shutdown(request: web.Request) -> web.Response:

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -68,25 +68,25 @@ class ClientErrorMappingTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(QzoneRequestError) as caught:
             await self.client._request_text("GET", "https://h5.qzone.qq.com/mqzone/profile")
         self.assertEqual(caught.exception.status_code, 403)
-        self.assertIn("权限", caught.exception.message)
+        self.assertIn("??", caught.exception.message)
 
     async def test_payload_login_code_requires_rebind(self):
         await self._use_response(
-            lambda request: httpx.Response(200, json={"code": -3000, "message": "登录态失效"}, request=request)
+            lambda request: httpx.Response(200, json={"code": -3000, "message": "?????"}, request=request)
         )
         with self.assertRaises(QzoneNeedsRebind):
             await self.client._request_json("GET", "https://mobile.qzone.qq.com/feeds/mfeeds_get_count")
 
     async def test_payload_login_code_inside_data_requires_rebind(self):
         await self._use_response(
-            lambda request: httpx.Response(200, json={"data": {"code": -3000, "message": "登录态失效"}}, request=request)
+            lambda request: httpx.Response(200, json={"data": {"code": -3000, "message": "?????"}}, request=request)
         )
         with self.assertRaises(QzoneNeedsRebind):
             await self.client._request_json("GET", "https://mobile.qzone.qq.com/feeds/mfeeds_get_count")
 
     async def test_generic_negative_code_is_not_forced_to_rebind(self):
         await self._use_response(
-            lambda request: httpx.Response(200, json={"code": -10000, "message": "系统繁忙"}, request=request)
+            lambda request: httpx.Response(200, json={"code": -10000, "message": "????"}, request=request)
         )
         with self.assertRaises(QzoneRequestError) as caught:
             await self.client._request_json("GET", "https://mobile.qzone.qq.com/feeds/mfeeds_get_count")
@@ -154,7 +154,7 @@ class ClientErrorMappingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(seen_form["from"][0], "1")
         self.assertEqual(seen_form["fupdate"][0], "1")
 
-    async def test_like_uses_direct_w_qzone_endpoint(self):
+    async def test_like_tries_proxy_endpoint_first(self):
         seen_requests = []
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -167,8 +167,63 @@ class ClientErrorMappingTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(payload["message"], "ok")
         self.assertEqual(len(seen_requests), 1)
-        self.assertEqual(seen_requests[0].url.host, "w.qzone.qq.com")
-        self.assertEqual(seen_requests[0].url.path, "/cgi-bin/likes/internal_dolike_app")
+        self.assertEqual(seen_requests[0].url.host, "user.qzone.qq.com")
+        self.assertEqual(
+            seen_requests[0].url.path,
+            "/proxy/domain/w.qzone.qq.com/cgi-bin/likes/internal_dolike_app",
+        )
+
+    async def test_like_falls_back_to_direct_when_proxy_is_unavailable(self):
+        seen_hosts = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_hosts.append(request.url.host)
+            if request.url.host == "user.qzone.qq.com":
+                return httpx.Response(503, text="proxy unavailable", request=request)
+            return httpx.Response(200, json={"code": 0, "message": "ok"}, request=request)
+
+        await self._use_response(handler)
+
+        payload = await self.client.like_post(123456, "fid-1")
+
+        self.assertEqual(payload["message"], "ok")
+        self.assertEqual(seen_hosts, ["user.qzone.qq.com", "w.qzone.qq.com"])
+
+    async def test_like_reports_all_endpoint_attempts_when_both_fail(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, text=f"{request.url.host} unavailable", request=request)
+
+        await self._use_response(handler)
+
+        with self.assertRaises(QzoneRequestError) as caught:
+            await self.client.like_post(123456, "fid-1")
+
+        self.assertIn("?????????", caught.exception.message)
+        self.assertEqual(caught.exception.status_code, 503)
+        attempts = caught.exception.detail["attempts"]
+        self.assertEqual(len(attempts), 2)
+        self.assertEqual(attempts[0]["status_code"], 503)
+        self.assertEqual(attempts[0]["detail"]["text"], "user.qzone.qq.com unavailable")
+        self.assertEqual(attempts[1]["detail"]["text"], "w.qzone.qq.com unavailable")
+
+    async def test_like_accepts_post_action_redirect_without_following_page(self):
+        seen = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(str(request.url))
+            return httpx.Response(
+                302,
+                headers={"location": "https://user.qzone.qq.com/123456/mood/fid-1"},
+                request=request,
+            )
+
+        await self._use_response(handler)
+
+        payload = await self.client.like_post(123456, "fid-1")
+
+        self.assertEqual(payload["message"], "accepted redirect")
+        self.assertEqual(payload["redirect"]["status_code"], 302)
+        self.assertEqual(len(seen), 1)
 
     async def test_like_follows_qzone_redirect_preserving_post_body(self):
         seen = []

--- a/tests/test_controller_bind.py
+++ b/tests/test_controller_bind.py
@@ -3,8 +3,10 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import AsyncMock, patch
 
+import httpx
+
 from qzone_bridge.controller import QzoneDaemonController
-from qzone_bridge.errors import DaemonUnavailableError
+from qzone_bridge.errors import DaemonUnavailableError, QzoneRequestError
 
 
 class ControllerBindTests(unittest.IsolatedAsyncioTestCase):
@@ -125,6 +127,47 @@ class ControllerBindTests(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(request.await_args.kwargs["json_body"]["content"], "qzone post literal")
                 self.assertTrue(request.await_args.kwargs["json_body"]["content_sanitized"])
                 self.assertEqual(payload["fid"], "fid-1")
+            finally:
+                await controller.close()
+
+    async def test_daemon_request_error_preserves_status_code_from_detail(self):
+        with TemporaryDirectory() as tmp:
+            controller = QzoneDaemonController(
+                plugin_root=Path(tmp),
+                data_dir=Path(tmp) / "data",
+                default_port=19009,
+                request_timeout=1.0,
+                start_timeout=1.0,
+                keepalive_interval=30,
+                user_agent="test-agent",
+                auto_start_daemon=False,
+            )
+            try:
+                controller._runtime()
+                response = httpx.Response(
+                    400,
+                    json={
+                        "ok": False,
+                        "error": {
+                            "code": "QZONE_REQUEST",
+                            "message": "QQ?????????? (503)",
+                            "detail": {
+                                "status_code": 503,
+                                "url": "https://w.qzone.qq.com/cgi-bin/likes/internal_dolike_app",
+                                "text": "service unavailable",
+                            },
+                        },
+                    },
+                )
+                with patch.object(controller, "_probe_health", new=AsyncMock(return_value=True)), patch.object(
+                    controller._client,
+                    "request",
+                    new=AsyncMock(return_value=response),
+                ):
+                    with self.assertRaises(QzoneRequestError) as caught:
+                        await controller.like_post(hostuin=123456, fid="fid-1")
+                self.assertEqual(caught.exception.status_code, 503)
+                self.assertEqual(caught.exception.detail["text"], "service unavailable")
             finally:
                 await controller.close()
 

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -53,7 +53,7 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             service.client.update_session(service.state.session)
             service.health_state = "ready"
 
-            service._set_error(QzoneRequestError("无权限访问", status_code=403))
+            service._set_error(QzoneRequestError("?????", status_code=403))
 
             self.assertEqual(service.health_state, "ready")
             self.assertFalse(service.state.session.needs_rebind)
@@ -567,7 +567,7 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
                     hostuin=3112333596,
                     fid="1c7182b96589046ad3380900",
                     appid=311,
-                    summary="瘦了…………",
+                    summary="??????",
                     liked=False,
                     curkey="cached-curkey",
                 )
@@ -575,13 +575,13 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             before = {
                 "tid": "1c7182b96589046ad3380900",
                 "uin": 3112333596,
-                "content": "瘦了…………",
+                "content": "??????",
                 "like": {"isliked": "0"},
             }
             after = {
                 "tid": "1c7182b96589046ad3380900",
                 "uin": 3112333596,
-                "content": "瘦了…………",
+                "content": "??????",
                 "like": {"isliked": "1"},
             }
             try:
@@ -595,7 +595,7 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(args[:2], (3112333596, "1c7182b96589046ad3380900"))
                 self.assertEqual(kwargs["curkey"], "cached-curkey")
                 self.assertTrue(payload["verified"])
-                self.assertEqual(payload["summary"], "瘦了…………")
+                self.assertEqual(payload["summary"], "??????")
             finally:
                 await service.close()
 
@@ -656,6 +656,64 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             finally:
                 await service.close()
 
+    async def test_like_post_resolves_latest_reference_from_legacy_when_profile_5xx(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            legacy = {
+                "msglist": [
+                    {
+                        "tid": "fid-latest",
+                        "uin": 123456,
+                        "content": "legacy latest post",
+                        "isliked": "0",
+                    }
+                ]
+            }
+            before = {
+                "tid": "fid-latest",
+                "uin": 123456,
+                "content": "legacy latest post",
+                "like": {"isliked": "0"},
+            }
+            after = {
+                "tid": "fid-latest",
+                "uin": 123456,
+                "content": "legacy latest post",
+                "like": {"isliked": "1"},
+            }
+            try:
+                with patch.object(
+                    service.client,
+                    "profile",
+                    new=AsyncMock(side_effect=QzoneRequestError("profile unavailable", status_code=503)),
+                ) as profile, patch.object(
+                    service.client,
+                    "legacy_feeds",
+                    new=AsyncMock(return_value=legacy),
+                ) as legacy_feeds, patch.object(
+                    service.client,
+                    "detail",
+                    new=AsyncMock(side_effect=[before, after]),
+                ), patch.object(
+                    service.client,
+                    "like_post",
+                    new=AsyncMock(return_value={"message": "ok"}),
+                ) as like:
+                    payload = await service.like_post(hostuin=0, fid="", latest=True)
+                profile.assert_awaited_once_with(123456)
+                legacy_feeds.assert_awaited_once_with(123456, page=1, num=20)
+                args, _ = like.await_args
+                self.assertEqual(args[:2], (123456, "fid-latest"))
+                self.assertTrue(payload["verified"])
+                self.assertEqual(payload["summary"], "legacy latest post")
+            finally:
+                await service.close()
+
     async def test_like_post_resolves_named_index_reference_for_specific_host(self):
         with TemporaryDirectory() as tmp:
             service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
@@ -709,7 +767,7 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
                     "like_post",
                     new=AsyncMock(return_value={"message": "ok"}),
                 ) as like:
-                    payload = await service.like_post(hostuin=3112333596, fid="第2条")
+                    payload = await service.like_post(hostuin=3112333596, fid="?2?")
                 feeds.assert_awaited_once_with(hostuin=3112333596, limit=2, scope="profile")
                 args, kwargs = like.await_args
                 self.assertEqual(args[:2], (3112333596, "fid-2"))

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.util
+import json
 import sys
 import tempfile
 import types
@@ -236,7 +237,7 @@ class MainPublishTests(unittest.TestCase):
 
         plugin.controller.publish_post.assert_awaited_once()
         self.assertEqual(plugin.controller.publish_post.await_args.kwargs["media"], [])
-        self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "report\n[文件: report.pdf]")
+        self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "report\n[??: report.pdf]")
         self.assertTrue(Path(results[0]["image"]).exists())
 
     def test_qzone_post_renders_logged_in_qzone_publisher(self):
@@ -273,7 +274,7 @@ class MainPublishTests(unittest.TestCase):
             hostuin=3112333596,
             fid="1c7182b96589046ad3380900",
             appid=311,
-            summary="瘦了…………",
+            summary="??????",
             liked=False,
         )
         plugin.controller.list_feeds = AsyncMock(
@@ -288,8 +289,8 @@ class MainPublishTests(unittest.TestCase):
         results = asyncio.run(collect_async_generator(plugin.tool_list_feed(event, limit=1)))
 
         self.assertEqual(len(results), 1)
-        self.assertIn("瘦了", results[0])
-        self.assertIn("未点赞", results[0])
+        self.assertIn("??", results[0])
+        self.assertIn("???", results[0])
         self.assertNotIn("cursor=", results[0])
         self.assertNotIn("has_more", results[0])
         self.assertNotIn("fid=", results[0])
@@ -299,7 +300,7 @@ class MainPublishTests(unittest.TestCase):
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
             get_current_chat_provider_id=AsyncMock(return_value="provider-1"),
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="已经帮你点赞成功。")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="?????????")),
         )
         plugin.controller.like_post = AsyncMock(
             return_value={
@@ -307,7 +308,7 @@ class MainPublishTests(unittest.TestCase):
                 "liked": True,
                 "verified": True,
                 "already": False,
-                "summary": "瘦了…………",
+                "summary": "??????",
             }
         )
         event = Event([])
@@ -324,20 +325,52 @@ class MainPublishTests(unittest.TestCase):
             latest=False,
             index=0,
         )
-        self.assertEqual(results[0], "已经帮你点赞成功。")
+        self.assertEqual(results[0], "?????????")
         plugin._context.llm_generate.assert_awaited_once()
         prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
         self.assertIn('"ok":true', prompt)
         self.assertIn('"verified":true', prompt)
-        self.assertIn("瘦了…………", prompt)
+        self.assertIn("??????", prompt)
         self.assertNotIn("fid=", results[0])
         self.assertFalse(results[0].lstrip().startswith("{"))
+
+    def test_llm_like_tool_logs_success_payload_to_astrbot_logger(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin._context = types.SimpleNamespace(
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="????")),
+        )
+        plugin.controller.like_post = AsyncMock(
+            return_value={
+                "action": "like",
+                "liked": True,
+                "verified": True,
+                "already": False,
+                "summary": "hello",
+                "raw": {"message": "ok"},
+            }
+        )
+        event = Event([])
+
+        with patch.object(module.logger, "info") as log_info:
+            asyncio.run(collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1")))
+
+        log_line = next(
+            call.args[1]
+            for call in log_info.call_args_list
+            if call.args and call.args[0] == "qzone llm tool result: %s"
+        )
+        logged = json.loads(log_line)
+        self.assertTrue(logged["ok"])
+        self.assertEqual(logged["tool"], "qzone_like_post")
+        self.assertEqual(logged["arguments"]["fid"], "1")
+        self.assertEqual(logged["result"]["raw"]["message"], "ok")
 
     def test_llm_like_tool_forwards_latest_and_index_reference(self):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="已经帮对方第 2 条说说点赞。")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="?????? 2 ??????")),
         )
         plugin.controller.like_post = AsyncMock(
             return_value={
@@ -369,7 +402,7 @@ class MainPublishTests(unittest.TestCase):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="点赞请求已提交，空间状态可能稍后刷新。")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="???????????????????")),
         )
         plugin.settings.preview_writes = True
         plugin.controller.like_post = AsyncMock(
@@ -388,7 +421,7 @@ class MainPublishTests(unittest.TestCase):
         )
 
         plugin.controller.like_post.assert_awaited_once()
-        self.assertEqual(results[0], "点赞请求已提交，空间状态可能稍后刷新。")
+        self.assertEqual(results[0], "???????????????????")
         prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
         self.assertIn('"verified":false', prompt)
         self.assertFalse(results[0].lstrip().startswith("{"))
@@ -397,20 +430,59 @@ class MainPublishTests(unittest.TestCase):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="点赞失败：QQ 空间暂时拒绝了请求。")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="?????QQ ??????????")),
         )
-        plugin.controller.like_post = AsyncMock(side_effect=module.QzoneBridgeError("点赞失败"))
+        plugin.controller.like_post = AsyncMock(side_effect=module.QzoneBridgeError("????"))
         event = Event([])
 
         results = asyncio.run(
             collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
         )
 
-        self.assertEqual(results[0], "点赞失败：QQ 空间暂时拒绝了请求。")
+        self.assertEqual(results[0], "?????QQ ??????????")
         prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
         self.assertIn('"ok":false', prompt)
-        self.assertIn("点赞失败", prompt)
+        self.assertIn("????", prompt)
         self.assertFalse(results[0].lstrip().startswith("{"))
+
+    def test_llm_like_tool_logs_error_and_sends_diagnostic_to_llm(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin._context = types.SimpleNamespace(
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="?????QQ ??????????")),
+        )
+        exc = module.QzoneBridgeError(
+            "QQ?????????? (503)",
+            detail={
+                "status_code": 503,
+                "url": "https://w.qzone.qq.com/cgi-bin/likes/internal_dolike_app?g_tk=123",
+                "text": "service unavailable",
+            },
+        )
+        exc.status_code = 503
+        plugin.controller.like_post = AsyncMock(side_effect=exc)
+        event = Event([])
+
+        with patch.object(module.logger, "warning") as log_warning:
+            results = asyncio.run(
+                collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
+            )
+
+        self.assertEqual(results[0], "?????QQ ??????????")
+        prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
+        self.assertIn('"diagnostic"', prompt)
+        self.assertIn('"status_code":503', prompt)
+        self.assertIn("service unavailable", prompt)
+        log_line = next(
+            call.args[1]
+            for call in log_warning.call_args_list
+            if call.args and call.args[0] == "qzone llm tool result: %s"
+        )
+        logged = json.loads(log_line)
+        self.assertFalse(logged["ok"])
+        self.assertEqual(logged["error"]["status_code"], 503)
+        self.assertEqual(logged["detail"]["text"], "service unavailable")
+        self.assertIn("g_tk=%2A%2A%2A", logged["detail"]["url"])
 
     def test_llm_like_tool_falls_back_to_natural_text_without_llm_provider(self):
         module = self.load_main_module()
@@ -430,14 +502,14 @@ class MainPublishTests(unittest.TestCase):
             collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
         )
 
-        self.assertIn("点赞请求已提交", results[0])
+        self.assertIn("???????", results[0])
         self.assertFalse(results[0].lstrip().startswith("{"))
 
     def test_llm_like_tool_error_fallback_does_not_expose_detail(self):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin.controller.like_post = AsyncMock(
-            side_effect=module.QzoneBridgeError("点赞失败", detail={"fid": "secret-fid", "raw": {"code": 1}})
+            side_effect=module.QzoneBridgeError("????", detail={"fid": "secret-fid", "raw": {"code": 1}})
         )
         event = Event([])
 
@@ -445,7 +517,7 @@ class MainPublishTests(unittest.TestCase):
             collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
         )
 
-        self.assertEqual(results[0], "点赞失败")
+        self.assertEqual(results[0], "????")
         self.assertNotIn("secret-fid", results[0])
         self.assertFalse(results[0].lstrip().startswith("{"))
 


### PR DESCRIPTION
﻿## Summary
- add proxy-first plus direct fallback for Qzone like/unlike requests
- accept safe post-action QQ redirects instead of following them into page-level 5xx failures
- preserve daemon request status/detail through controller, log qzone_like_post results in AstrBot logs, and feed diagnostics back into the LLM reply path
- make latest/index like resolution fall back to legacy feeds when H5 profile/index fetches fail with redirects, 403/429, 5xx, or parse errors

## Root Cause
The previous like flow depended on one direct `w.qzone.qq.com` action endpoint and followed QQ redirects as if the redirected page had to render successfully. When QQ returned a post-action redirect or a transient 5xx, the action could be reported as `QQ空间服务暂不可用`. The daemon/controller/main stack also dropped `status_code` and `detail`, so AstrBot logs and the LLM reply did not contain enough diagnostic context.

## Validation
- `python -m compileall main.py qzone_bridge tests`
- `python -m unittest tests.test_daemon_lifecycle tests.test_client_errors tests.test_controller_bind tests.test_main_publish`
- `python -m unittest discover -s tests` (128 tests)
- `git diff --check`
