### PR TITLE
[codex] Recover degraded Qzone daemon status

### DIFF
--- a/main.py
+++ b/main.py
@@ -374,6 +374,40 @@ class QzoneStablePlugin(Star):
             "detail": exc.detail,
         }
 
+    @staticmethod
+    def _status_error_payload(exc: QzoneBridgeError) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "type": type(exc).__name__,
+            "code": exc.code,
+            "message": exc.message,
+        }
+        detail = _safe_for_llm(exc.detail)
+        if detail not in (None, {}, []):
+            payload["detail"] = detail
+        return payload
+
+    async def _status_with_recovery(self) -> dict[str, Any]:
+        status = await self.controller.get_status()
+        should_start = (
+            self.settings.auto_start_daemon
+            and status.get("daemon_state") != "ready"
+            and int(status.get("cookie_count") or 0) > 0
+            and not bool(status.get("needs_rebind"))
+        )
+        if not should_start:
+            return status
+        try:
+            return await self.controller.ensure_running()
+        except QzoneBridgeError as exc:
+            try:
+                detail_text = json.dumps(_redact_for_log(exc.detail), ensure_ascii=False, default=str)
+            except Exception:
+                detail_text = str(_redact_for_log(exc.detail))
+            logger.warning("qzone daemon status recovery failed: %s detail=%s", exc.message, detail_text)
+            fallback = await self.controller.get_status(probe_daemon=False)
+            fallback["daemon_start_error"] = self._status_error_payload(exc)
+            return fallback
+
 
     async def _maybe_await(self, value: Any) -> Any:
         if inspect.isawaitable(value):
@@ -745,7 +779,7 @@ class QzoneStablePlugin(Star):
             yield self._command_result(event, "??????????")
             return
         try:
-            payload = await self.controller.get_status()
+            payload = await self._status_with_recovery()
         except QzoneBridgeError as exc:
             yield self._command_result(event, self._error_text(exc))
             return
@@ -763,6 +797,10 @@ class QzoneStablePlugin(Star):
             yield self._command_result(event, self._error_text(exc))
             return
         self._schedule_daemon_warmup("manual bind")
+        try:
+            payload = await self._status_with_recovery()
+        except QzoneBridgeError:
+            pass
         yield self._command_result(event, format_status(payload))
 
     @qzone.command("autobind")
@@ -777,6 +815,10 @@ class QzoneStablePlugin(Star):
             yield self._command_result(event, self._error_text(exc))
             return
         self._schedule_daemon_warmup("autobind")
+        try:
+            payload = await self._status_with_recovery()
+        except QzoneBridgeError:
+            pass
         yield self._command_result(event, format_status(payload))
 
     @qzone.command("unbind")
@@ -886,7 +928,7 @@ class QzoneStablePlugin(Star):
             yield event.plain_result("???????????")
             return
         try:
-            payload = await self.controller.get_status()
+            payload = await self._status_with_recovery()
         except QzoneBridgeError as exc:
             yield event.plain_result(self._error_text(exc))
             return

--- a/qzone_bridge/controller.py
+++ b/qzone_bridge/controller.py
@@ -248,6 +248,49 @@ class QzoneDaemonController:
     def _daemon_script(self) -> Path:
         return self.plugin_root / "daemon_main.py"
 
+    def _daemon_log_path(self) -> Path:
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        return self.data_dir / "daemon.log"
+
+    @staticmethod
+    def _tail_text(path: Path, *, max_chars: int = 4000) -> str:
+        try:
+            if not path.exists():
+                return ""
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except Exception:
+            return ""
+        if len(text) <= max_chars:
+            return text
+        return text[-max_chars:]
+
+    def _daemon_start_detail(self, port: int, *, returncode: int | None = None, error: str = "") -> dict[str, Any]:
+        log_path = self._daemon_log_path()
+        detail: dict[str, Any] = {
+            "daemon_port": int(port or 0),
+            "log_path": str(log_path),
+        }
+        if returncode is not None:
+            detail["returncode"] = returncode
+        if error:
+            detail["error"] = error
+        log_tail = self._tail_text(log_path)
+        if log_tail:
+            detail["log_tail"] = log_tail
+        return detail
+
+    def _record_daemon_start_error(self, exc: DaemonUnavailableError, *, port: int) -> None:
+        self._invalidate_health_cache()
+        state = self.store.read()
+        state.runtime.daemon_pid = 0
+        state.runtime.daemon_port = int(port or state.runtime.daemon_port or self.default_port or 0)
+        state.session.last_error = {
+            "type": type(exc).__name__,
+            "message": exc.message,
+            "detail": exc.detail,
+        }
+        self.store.write(state)
+
     def _invalidate_health_cache(self) -> None:
         self._health_cache = None
 
@@ -277,7 +320,15 @@ class QzoneDaemonController:
         env = os.environ.copy()
         env["QZONE_BRIDGE_PLUGIN_ROOT"] = str(self.plugin_root)
         kwargs["env"] = env
-        return subprocess.Popen(cmd, cwd=str(self.plugin_root), **kwargs)
+        log_path = self._daemon_log_path()
+        log_file = log_path.open("a", encoding="utf-8", buffering=1)
+        try:
+            log_file.write(f"\n[{now_iso()}] starting qzone daemon on 127.0.0.1:{port}\n")
+            kwargs["stdout"] = log_file
+            kwargs["stderr"] = log_file
+            return subprocess.Popen(cmd, cwd=str(self.plugin_root), **kwargs)
+        finally:
+            log_file.close()
 
     async def _probe_health(
         self,
@@ -337,6 +388,7 @@ class QzoneDaemonController:
             "started_at": runtime.started_at,
             "last_seen_at": runtime.last_seen_at,
             "login_uin": state.session.uin,
+            "session_source": state.session.source,
             "cookie_summary": self.cookie_summary(state.session.cookies),
             "cookie_count": len(state.session.cookies),
             "needs_rebind": state.session.needs_rebind or not bool(state.session.cookies),
@@ -356,19 +408,41 @@ class QzoneDaemonController:
 
             if not _port_is_free(port):
                 candidate = port
+                found_port = 0
                 for _ in range(32):
                     candidate += 1
                     if _port_is_free(candidate):
-                        port = candidate
+                        found_port = candidate
                         break
+                if not found_port:
+                    exc = DaemonUnavailableError(
+                        "QQ?? daemon ????????????????",
+                        detail={"daemon_port": port, "checked_ports": f"{port + 1}-{port + 32}"},
+                    )
+                    self._record_daemon_start_error(exc, port=port)
+                    raise exc
+                port = found_port
                 state = self.store.read()
                 state.runtime.daemon_port = port
                 self.store.write(state)
 
             if not self._daemon_script().exists():
-                raise DaemonUnavailableError("??? daemon_main.py")
+                exc = DaemonUnavailableError(
+                    "??? daemon_main.py",
+                    detail={"path": str(self._daemon_script())},
+                )
+                self._record_daemon_start_error(exc, port=port)
+                raise exc
 
-            self._process = self._spawn_daemon(port)
+            try:
+                self._process = self._spawn_daemon(port)
+            except OSError as exc:
+                error = DaemonUnavailableError(
+                    "QQ?? daemon ????",
+                    detail=self._daemon_start_detail(port, error=str(exc)),
+                )
+                self._record_daemon_start_error(error, port=port)
+                raise error from exc
 
             deadline = asyncio.get_running_loop().time() + self.start_timeout
             while asyncio.get_running_loop().time() < deadline:
@@ -379,6 +453,8 @@ class QzoneDaemonController:
                     runtime.last_seen_at = now_iso()
                     state = self.store.read()
                     state.runtime = runtime
+                    if isinstance(state.session.last_error, dict) and state.session.last_error.get("type") == "DaemonUnavailableError":
+                        state.session.last_error = None
                     self.store.write(state)
                     self._health_cache = (
                         port,
@@ -391,7 +467,13 @@ class QzoneDaemonController:
                     break
                 await asyncio.sleep(0.5)
 
-            raise DaemonUnavailableError("QQ?? daemon ????")
+            returncode = self._process.poll() if self._process else None
+            error = DaemonUnavailableError(
+                "QQ?? daemon ????",
+                detail=self._daemon_start_detail(port, returncode=returncode),
+            )
+            self._record_daemon_start_error(error, port=port)
+            raise error
 
     async def _request(
         self,

--- a/qzone_bridge/render.py
+++ b/qzone_bridge/render.py
@@ -10,7 +10,7 @@ from .utils import to_local_time_text, truncate
 
 def cookie_summary(cookies: dict[str, str]) -> str:
     if not cookies:
-        return "未绑定"
+        return "???"
     keys = [
         "uin",
         "p_uin",
@@ -28,12 +28,12 @@ def cookie_summary(cookies: dict[str, str]) -> str:
     ]
     found = [key for key in keys if key in cookies]
     extras = len(cookies) - len(found)
-    return f"{len(cookies)}个字段: " + ", ".join(found + ([f"其他{extras}项"] if extras > 0 else []))
+    return f"{len(cookies)}???: " + ", ".join(found + ([f"??{extras}?"] if extras > 0 else []))
 
 
 def format_status(status: dict) -> str:
     lines = [
-        "QQ空间状态",
+        "QQ????",
         f"- daemon: {status.get('daemon_state', 'unknown')}",
         f"- login: {status.get('login_uin') or '-'}",
         f"- source: {status.get('session_source') or '-'}",
@@ -44,6 +44,20 @@ def format_status(status: dict) -> str:
     ]
     if status.get("daemon_port"):
         lines.append(f"- endpoint: 127.0.0.1:{status['daemon_port']}")
+    if status.get("daemon_pid"):
+        lines.append(f"- pid: {status['daemon_pid']}")
+    start_error = status.get("daemon_start_error")
+    if isinstance(start_error, dict):
+        message = start_error.get("message") or "daemon ????"
+        lines.append(f"- daemon_error: {message}")
+        detail = start_error.get("detail")
+        if isinstance(detail, dict):
+            if detail.get("returncode") is not None:
+                lines.append(f"- daemon_returncode: {detail['returncode']}")
+            if detail.get("log_path"):
+                lines.append(f"- daemon_log: {detail['log_path']}")
+            if detail.get("log_tail"):
+                lines.append(f"- daemon_log_tail: {truncate(str(detail['log_tail']), 300)}")
     return "\n".join(lines)
 
 
@@ -57,8 +71,8 @@ def format_feed_entry(entry: FeedEntry, index: int | None = None, *, include_int
             f"like={entry.like_count} comment={entry.comment_count} liked={entry.liked}"
         )
     else:
-        liked_text = "已点赞" if entry.liked else "未点赞"
-        lines.append(f"   {liked_text}，{entry.like_count} 赞，{entry.comment_count} 评论")
+        liked_text = "???" if entry.liked else "???"
+        lines.append(f"   {liked_text}?{entry.like_count} ??{entry.comment_count} ??")
     lines.append(f"   {headline}")
     return "\n".join(lines)
 
@@ -87,14 +101,14 @@ def format_feed_list(
 def format_llm_feed_list(entries: Iterable[FeedEntry]) -> str:
     entries = list(entries)
     if not entries:
-        return "没有找到可操作的说说。"
+        return "???????????"
     body = format_feed_list(entries, include_internal=False, include_pagination=False)
-    return f"{body}\n可直接让我点赞或取消点赞对应编号。"
+    return f"{body}\n?????????????????"
 
 
 def format_feed_detail(entry: FeedEntry) -> str:
     lines = [
-        "说说详情",
+        "????",
         f"- hostuin: {entry.hostuin}",
         f"- fid: {entry.fid}",
         f"- appid: {entry.appid}",
@@ -119,14 +133,14 @@ def format_action_result(title: str, payload: dict) -> str:
 
 
 def format_like_result(payload: dict) -> str:
-    action = "取消点赞" if payload.get("action") == "unlike" else "点赞"
+    action = "????" if payload.get("action") == "unlike" else "??"
     summary = truncate(str(payload.get("summary") or ""), 80)
-    suffix = f"：{summary}" if summary else ""
+    suffix = f"?{summary}" if summary else ""
     if payload.get("verified"):
         if payload.get("already"):
-            state = "已是目标状态"
+            state = "??????"
         else:
-            state = "成功"
-        liked = "当前已点赞" if payload.get("liked") else "当前未点赞"
-        return f"{action}{state}{suffix}（{liked}）。"
-    return f"{action}请求已提交，但暂未能确认 QQ 空间状态{suffix}。"
+            state = "??"
+        liked = "?????" if payload.get("liked") else "?????"
+        return f"{action}{state}{suffix}?{liked}??"
+    return f"{action}???????????? QQ ????{suffix}?"

--- a/tests/test_controller_bind.py
+++ b/tests/test_controller_bind.py
@@ -1,4 +1,5 @@
 import unittest
+import socket
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import AsyncMock, patch
@@ -7,6 +8,13 @@ import httpx
 
 from qzone_bridge.controller import QzoneDaemonController
 from qzone_bridge.errors import DaemonUnavailableError, QzoneRequestError
+from qzone_bridge.models import SessionState
+
+
+def free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
 
 
 class ControllerBindTests(unittest.IsolatedAsyncioTestCase):
@@ -58,6 +66,7 @@ class ControllerBindTests(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(state.session.cookies["p_skey"], "def")
                 self.assertGreaterEqual(payload["cookie_count"], 4)
                 self.assertEqual(payload["login_uin"], 123456)
+                self.assertEqual(payload["session_source"], "aiocqhttp")
             finally:
                 await controller.close()
 
@@ -127,6 +136,44 @@ class ControllerBindTests(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(request.await_args.kwargs["json_body"]["content"], "qzone post literal")
                 self.assertTrue(request.await_args.kwargs["json_body"]["content_sanitized"])
                 self.assertEqual(payload["fid"], "fid-1")
+            finally:
+                await controller.close()
+
+    async def test_ensure_running_records_crashed_daemon_start_detail(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "daemon_main.py").write_text(
+                "import sys\nprint('daemon boom', file=sys.stderr)\nraise SystemExit(7)\n",
+                encoding="utf-8",
+            )
+            controller = QzoneDaemonController(
+                plugin_root=root,
+                data_dir=root / "data",
+                default_port=free_port(),
+                request_timeout=0.5,
+                start_timeout=2.0,
+                keepalive_interval=30,
+                user_agent="test-agent",
+            )
+            try:
+                state = controller.store.read()
+                state.session = SessionState(
+                    uin=123456,
+                    cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+                    needs_rebind=False,
+                )
+                controller.store.write(state)
+
+                with self.assertRaises(DaemonUnavailableError) as caught:
+                    await controller.ensure_running()
+
+                detail = caught.exception.detail
+                self.assertEqual(detail["returncode"], 7)
+                self.assertIn("daemon.log", detail["log_path"])
+                self.assertIn("daemon boom", detail["log_tail"])
+                stored_error = controller.store.read().session.last_error
+                self.assertEqual(stored_error["type"], "DaemonUnavailableError")
+                self.assertIn("daemon boom", stored_error["detail"]["log_tail"])
             finally:
                 await controller.close()
 

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -187,6 +187,91 @@ class MainPublishTests(unittest.TestCase):
         self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "qzone post literal")
         self.assertTrue(plugin.controller.publish_post.await_args.kwargs["content_sanitized"])
 
+    def test_qzone_status_auto_recovers_degraded_daemon(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        degraded = {
+            "daemon_state": "degraded",
+            "login_uin": 3112333596,
+            "session_source": "aiocqhttp",
+            "cookie_count": 14,
+            "cookie_summary": "14???: uin, p_uin, skey, p_skey",
+            "needs_rebind": False,
+            "daemon_port": 18999,
+        }
+        ready = dict(degraded, daemon_state="ready", daemon_pid=1234)
+        plugin.controller = types.SimpleNamespace(
+            get_status=AsyncMock(return_value=degraded),
+            ensure_running=AsyncMock(return_value=ready),
+        )
+        event = Event([])
+
+        results = asyncio.run(collect_async_generator(plugin.qzone_status(event)))
+
+        plugin.controller.ensure_running.assert_awaited_once()
+        self.assertIn("- daemon: ready", results[0])
+        self.assertIn("- source: aiocqhttp", results[0])
+        self.assertIn("- pid: 1234", results[0])
+
+    def test_qzone_status_reports_daemon_start_failure_detail(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        degraded = {
+            "daemon_state": "degraded",
+            "login_uin": 3112333596,
+            "session_source": "aiocqhttp",
+            "cookie_count": 14,
+            "cookie_summary": "14???: uin, p_uin, skey, p_skey",
+            "needs_rebind": False,
+            "daemon_port": 18999,
+        }
+        plugin.controller = types.SimpleNamespace(
+            get_status=AsyncMock(return_value=degraded),
+            ensure_running=AsyncMock(
+                side_effect=module.DaemonUnavailableError(
+                    "QQ?? daemon ????",
+                    detail={"returncode": 7, "log_path": "D:/qzone/daemon.log", "log_tail": "daemon boom"},
+                )
+            ),
+        )
+        event = Event([])
+
+        results = asyncio.run(collect_async_generator(plugin.qzone_status(event)))
+
+        self.assertIn("- daemon: degraded", results[0])
+        self.assertIn("- daemon_error: QQ?? daemon ????", results[0])
+        self.assertIn("- daemon_returncode: 7", results[0])
+        self.assertIn("- daemon_log: D:/qzone/daemon.log", results[0])
+        self.assertIn("daemon boom", results[0])
+
+    def test_qzone_bind_returns_recovered_ready_status(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        degraded = {
+            "daemon_state": "degraded",
+            "login_uin": 3112333596,
+            "session_source": "manual",
+            "cookie_count": 4,
+            "cookie_summary": "4???: uin, p_uin, skey, p_skey",
+            "needs_rebind": False,
+            "daemon_port": 18999,
+        }
+        ready = dict(degraded, daemon_state="ready", daemon_pid=5678)
+        plugin.controller = types.SimpleNamespace(
+            bind_cookie_local=AsyncMock(return_value=degraded),
+            get_status=AsyncMock(return_value=degraded),
+            ensure_running=AsyncMock(return_value=ready),
+        )
+        plugin._schedule_daemon_warmup = lambda trigger: None
+        event = Event([])
+
+        results = asyncio.run(collect_async_generator(plugin.qzone_bind(event, "uin=o3112333596; p_skey=abc")))
+
+        plugin.controller.bind_cookie_local.assert_awaited_once()
+        plugin.controller.ensure_running.assert_awaited_once()
+        self.assertIn("- daemon: ready", results[0])
+        self.assertIn("- pid: 5678", results[0])
+
     def test_llm_publish_tool_strips_command_prefix_from_tool_content(self):
         module = self.load_main_module()
         plugin = self.make_plugin(module)


### PR DESCRIPTION
﻿## Summary
- make `/qzone status` and `qzone_get_status` actively recover a degraded daemon when cookies are still valid
- return recovered ready status after manual/auto bind instead of leaving users at a misleading degraded snapshot
- preserve `session_source` in controller-rendered status so `source` no longer appears as `-`
- capture daemon stdout/stderr into `data/qzone/daemon.log` and surface startup return code/log path/tail when startup fails

## Root Cause
A `degraded` status with `needs_rebind: False` means the cookie state exists, but the controller could not reach the local daemon health endpoint. The status command only probed and rendered the local state; it did not try to restart the daemon, and daemon startup failures were collapsed to a generic startup error without persisted details. That made the plugin look completely unavailable while hiding the actionable daemon failure reason.

## Validation
- `python -m compileall main.py qzone_bridge tests`
- `python -m unittest tests.test_controller_bind tests.test_main_publish`
- `python -m unittest discover -s tests` (132 tests)
- `git diff --check`
