### PR TITLE
[codex] Fix Qzone daemon feed reference startup

### DIFF
--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -35,7 +35,16 @@ from .utils import extract_callback_json, json_loads, now_iso
 log = logging.getLogger(__name__)
 
 AUTH_ERROR_CODES = {-3000}
-AUTH_ERROR_KEYWORDS = ("??", "??", "????", "skey", "g_tk", "cookie", "expired", "login")
+AUTH_ERROR_KEYWORDS = (
+    "\u767b\u5f55",
+    "\u5931\u6548",
+    "\u8bf7\u5148\u767b\u5f55",
+    "skey",
+    "g_tk",
+    "cookie",
+    "expired",
+    "login",
+)
 LOGIN_REDIRECT_HOSTS = ("ptlogin", "ui.ptlogin", "xui.ptlogin", "ssl.ptlogin", "login")
 QZONE_IMAGE_UPLOAD_URL = "https://up.qzone.qq.com/cgi-bin/upload/cgi_upload_image"
 QZONE_REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -1,4 +1,4 @@
-"""Standalone QQ?? daemon."""
+"""Standalone Qzone daemon."""
 
 from __future__ import annotations
 
@@ -6,7 +6,6 @@ import asyncio
 import contextlib
 import logging
 import os
-import re
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -38,12 +37,14 @@ LATEST_FEED_REFERENCES = {
     "newest",
     "recent",
     "last",
-    "??",
-    "????",
-    "????",
-    "????",
+    "\u6700\u65b0",
+    "\u6700\u65b0\u4e00\u6761",
+    "\u6700\u8fd1\u4e00\u6761",
+    "\u6700\u540e\u4e00\u6761",
 }
-FEED_REFERENCE_PATTERN = re.compile(r"^??\s*(\d+)\s*??$")
+FEED_REFERENCE_PREFIXES = ("\u7b2c",)
+FEED_REFERENCE_SUFFIXES = ("\u6761",)
+LOSSY_LATEST_FEED_REFERENCES = {"??", "????"}
 
 
 class QzoneDaemonService:
@@ -441,9 +442,35 @@ class QzoneDaemonService:
             return int(fid_text)
         if fid_text.lower() in LATEST_FEED_REFERENCES or fid_text in LATEST_FEED_REFERENCES:
             return 1
-        match = FEED_REFERENCE_PATTERN.fullmatch(fid_text)
-        if match and fid_text != match.group(1):
-            return int(match.group(1))
+        if fid_text in LOSSY_LATEST_FEED_REFERENCES:
+            return 1
+        return QzoneDaemonService._localized_feed_reference_index(fid_text)
+
+    @staticmethod
+    def _localized_feed_reference_index(fid_text: str) -> int:
+        text = str(fid_text or "").strip()
+        if not text:
+            return 0
+
+        matched_marker = False
+        for prefix in FEED_REFERENCE_PREFIXES:
+            if text.startswith(prefix):
+                text = text[len(prefix) :].strip()
+                matched_marker = True
+                break
+        for suffix in FEED_REFERENCE_SUFFIXES:
+            if text.endswith(suffix):
+                text = text[: -len(suffix)].strip()
+                matched_marker = True
+                break
+
+        if matched_marker and text.isdigit():
+            return int(text)
+        lossy_text = str(fid_text or "").strip()
+        if lossy_text.startswith("?") and lossy_text.endswith("?"):
+            lossy_inner = lossy_text.strip("?").strip()
+            if lossy_inner.isdigit():
+                return int(lossy_inner)
         return 0
 
     def _recent_feed_reference(self, reference_index: int, *, hostuin: int) -> FeedEntry | None:

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -88,6 +88,7 @@ class ClientErrorMappingTests(unittest.IsolatedAsyncioTestCase):
         await self._use_response(
             lambda request: httpx.Response(200, json={"code": -10000, "message": "????"}, request=request)
         )
+        self.assertFalse(self.client._payload_needs_rebind(-10000, "????"))
         with self.assertRaises(QzoneRequestError) as caught:
             await self.client._request_json("GET", "https://mobile.qzone.qq.com/feeds/mfeeds_get_count")
         self.assertNotIsInstance(caught.exception, QzoneNeedsRebind)

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -25,6 +25,34 @@ def free_port() -> int:
 
 
 class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
+    def test_feed_reference_markers_are_ascii_safe_for_installers(self):
+        source = Path(__file__).resolve().parents[1] / "qzone_bridge" / "daemon.py"
+        lines = source.read_text(encoding="utf-8").splitlines()
+        start = next(i for i, line in enumerate(lines) if line.startswith("LATEST_FEED_REFERENCES"))
+        end = next(i for i, line in enumerate(lines[start:], start) if line.startswith("FEED_REFERENCE_SUFFIXES"))
+        critical_block = "\n".join(lines[start : end + 1])
+
+        self.assertTrue(critical_block.isascii(), critical_block)
+        self.assertNotIn("re.compile", critical_block)
+
+    def test_feed_reference_index_uses_ascii_safe_localized_markers(self):
+        self.assertEqual(
+            QzoneDaemonService._feed_reference_index("\u6700\u65b0\u4e00\u6761", hostuin=123456),
+            1,
+        )
+        self.assertEqual(
+            QzoneDaemonService._feed_reference_index("\u7b2c 2 \u6761", hostuin=123456),
+            2,
+        )
+        self.assertEqual(
+            QzoneDaemonService._feed_reference_index("\u7b2c\uff12\u6761", hostuin=123456),
+            2,
+        )
+        self.assertEqual(QzoneDaemonService._feed_reference_index("?2?", hostuin=123456), 2)
+        self.assertEqual(QzoneDaemonService._feed_reference_index("??2??", hostuin=123456), 2)
+        self.assertEqual(QzoneDaemonService._feed_reference_index("????", hostuin=123456), 1)
+        self.assertEqual(QzoneDaemonService._feed_reference_index("2", hostuin=123456), 0)
+
     async def test_warmup_uses_json_health_check_instead_of_h5_index(self):
         with TemporaryDirectory() as tmp:
             service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -322,7 +322,10 @@ class MainPublishTests(unittest.TestCase):
 
         plugin.controller.publish_post.assert_awaited_once()
         self.assertEqual(plugin.controller.publish_post.await_args.kwargs["media"], [])
-        self.assertEqual(plugin.controller.publish_post.await_args.kwargs["content"], "report\n[??: report.pdf]")
+        self.assertEqual(
+            plugin.controller.publish_post.await_args.kwargs["content"],
+            "report\n[\u6587\u4ef6: report.pdf]",
+        )
         self.assertTrue(Path(results[0]["image"]).exists())
 
     def test_qzone_post_renders_logged_in_qzone_publisher(self):


### PR DESCRIPTION
﻿## What changed
- Replaced the import-time localized feed-reference regex with ASCII-safe Unicode-escaped tokens and string parsing.
- Added tolerant parsing for already-lossy `?2?` / `??2??` references so old corrupted contexts still resolve to the intended feed index.
- Restored auth-error keyword matching from lossy `??` strings to explicit Unicode escapes, avoiding false `needs_rebind` classification for generic negative Qzone codes.
- Updated regression tests for daemon startup safety, feed reference parsing, auth error classification, and attachment reference text.

## Root cause
The daemon could import a source file where Chinese regex literals had been degraded to question marks, turning `^第?\s*(\d+)\s*条?$` into invalid regex syntax like `^??\s*(\d+)\s*??$`. Python raises `re.error: nothing to repeat` before the aiohttp app starts, so the daemon process exits and port `18999` never opens.

## Validation
- `python -m py_compile .\qzone_bridge\daemon.py .\qzone_bridge\client.py .\daemon_main.py`
- `python -m pytest .\tests\test_daemon_lifecycle.py -q`
- `python -m pytest .\tests\test_client_errors.py::ClientErrorMappingTests::test_generic_negative_code_is_not_forced_to_rebind .\tests\test_main_publish.py::MainPublishTests::test_qzone_post_keeps_files_out_of_publish_media_but_renders_success -q`
- `python -m pytest -q` -> 134 passed
- Spawned `daemon_main.py` on a free local port and verified `/health` returned `ok: true`; `/shutdown` exited with return code 0.
