### PR TITLE
[codex] Fix garbled Chinese output text

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-"""AstrBot entry point for the QQ?? bridge."""
+"""AstrBot entry point for the QQ 空间 bridge."""
 
 from __future__ import annotations
 
@@ -324,7 +324,7 @@ class QzoneStablePlugin(Star):
         *,
         profile_task: asyncio.Task | None = None,
     ):
-        text = format_action_result("????", payload)
+        text = format_action_result("发布结果", payload)
         if not self.settings.render_publish_result:
             self._stop_event(event)
             return event.plain_result(text)
@@ -352,7 +352,7 @@ class QzoneStablePlugin(Star):
             self._stop_event(event)
             return image_result(str(image_path))
         self._stop_event(event)
-        return event.plain_result(f"{text}\n???: {image_path}")
+        return event.plain_result(f"{text}\n图片路径: {image_path}")
 
     def _stop_event(self, event: AstrMessageEvent) -> None:
         stopper = getattr(event, "stop_event", None)
@@ -372,12 +372,12 @@ class QzoneStablePlugin(Star):
                 parts.append(f"HTTP {status_code}")
             location = exc.detail.get("location")
             if location:
-                parts.append(f"?? {location}")
+                parts.append(f"跳转 {location}")
             url = exc.detail.get("url")
             if url:
-                parts.append(f"?? {url}")
+                parts.append(f"地址 {url}")
             if parts:
-                return f"{exc.message}?{', '.join(parts)}?"
+                return f"{exc.message}（{', '.join(parts)}）"
         return f"{exc.message}\n{exc.detail}"
 
     def _log_tool_call_result(self, payload: dict[str, Any]) -> None:
@@ -750,7 +750,7 @@ class QzoneStablePlugin(Star):
     async def _ensure_daemon(self, *, allow_needs_rebind: bool = False) -> None:
         status = await self.controller.get_status()
         if status.get("needs_rebind") and not allow_needs_rebind:
-            raise QzoneNeedsRebind("QQ???????????? Cookie")
+            raise QzoneNeedsRebind("QQ 空间登录态已失效，需要重新绑定 Cookie")
         if allow_needs_rebind:
             if status.get("daemon_state") != "ready":
                 await self.controller.ensure_running()
@@ -759,7 +759,7 @@ class QzoneStablePlugin(Star):
             if status.get("daemon_state") != "ready":
                 await self.controller.ensure_running()
         elif status.get("daemon_state") != "ready":
-            raise DaemonUnavailableError("daemon ???")
+            raise DaemonUnavailableError("daemon 未运行")
 
     def _limit(self, limit: int | None) -> int:
         if not limit or limit <= 0:
@@ -780,7 +780,7 @@ class QzoneStablePlugin(Star):
         text = format_feed_detail(entry)
         comments = payload.get("comments") or []
         if comments:
-            lines = [text, "", "??"]
+            lines = [text, "", "评论"]
             for comment in comments[:5]:
                 nickname = comment.get("nickname") or comment.get("uin") or "-"
                 lines.append(f"- {nickname}: {truncate(str(comment.get('content') or ''), 80)}")
@@ -824,7 +824,7 @@ class QzoneStablePlugin(Star):
         return self._capture_onebot_client_from_context()
 
     def _cookie_binding_hint(self) -> str:
-        return "??? AstrBot ???? aiocqhttp(OneBot v11) ???????? /qzone bind ?? Cookie?"
+        return "没有从 AstrBot 拿到 aiocqhttp(OneBot v11) 客户端，请先用 /qzone bind 手动绑定 Cookie。"
 
     async def _auto_bind_cookie(
         self,
@@ -835,11 +835,11 @@ class QzoneStablePlugin(Star):
     ) -> dict[str, Any]:
         async with self._get_cookie_lock():
             if not self.settings.auto_bind_cookie and not force:
-                raise QzoneCookieAcquireError("???? Cookie ??????????")
+                raise QzoneCookieAcquireError("自动绑定 Cookie 未开启")
 
             bot = self._capture_onebot_client(event)
             if bot is None:
-                raise QzoneCookieAcquireError(f"???? OneBot ?????????? Cookie?{self._cookie_binding_hint()}")
+                raise QzoneCookieAcquireError(f"无法从 OneBot 获取 Cookie。{self._cookie_binding_hint()}")
 
             try:
                 status = await self.controller.get_status(probe_daemon=False)
@@ -851,7 +851,7 @@ class QzoneStablePlugin(Star):
 
             cookie_text = await fetch_cookie_text(bot, domain=self.settings.cookie_domain)
             if not cookie_text:
-                raise QzoneCookieAcquireError(f"OneBot ????? Cookie?{self._cookie_binding_hint()}")
+                raise QzoneCookieAcquireError(f"OneBot 没有返回可用 Cookie。{self._cookie_binding_hint()}")
 
             try:
                 cookie_uin = normalize_uin(parse_cookie_text(cookie_text))
@@ -932,14 +932,14 @@ class QzoneStablePlugin(Star):
     async def qzone_help(self, event: AstrMessageEvent):
         text = "\n".join(
             [
-                "QQ????",
+                "QQ 空间命令",
                 "/qzone status",
                 "/qzone bind <cookie>",
                 "/qzone autobind",
                 "/qzone unbind",
                 "/qzone feed [hostuin] [limit] [cursor]",
                 "/qzone detail <hostuin> <fid> [appid]",
-                "/qzone post <content> [??/????]",
+                "/qzone post <content> [图片/文件]",
                 "/qzone comment <hostuin> <fid> <content>",
                 "/qzone like <hostuin> <fid> [appid] [unlike]",
                 "",
@@ -957,7 +957,7 @@ class QzoneStablePlugin(Star):
     @qzone.command("status")
     async def qzone_status(self, event: AstrMessageEvent):
         if not self._is_admin(event):
-            yield self._command_result(event, "??????????")
+            yield self._command_result(event, "只有管理员可以查看状态。")
             return
         try:
             payload = await self._status_with_recovery()
@@ -969,7 +969,7 @@ class QzoneStablePlugin(Star):
     @qzone.command("bind")
     async def qzone_bind(self, event: AstrMessageEvent, cookie: str):
         if not self._is_admin(event):
-            yield self._command_result(event, "??????? Cookie?")
+            yield self._command_result(event, "只有管理员可以绑定 Cookie。")
             return
         try:
             payload = await self.controller.bind_cookie_local(cookie)
@@ -987,7 +987,7 @@ class QzoneStablePlugin(Star):
     @qzone.command("autobind")
     async def qzone_autobind(self, event: AstrMessageEvent):
         if not self._is_admin(event):
-            yield self._command_result(event, "????????? Cookie?")
+            yield self._command_result(event, "只有管理员可以自动绑定 Cookie。")
             return
         try:
             payload = await self._auto_bind_cookie(event, force=True, source="aiocqhttp")
@@ -1005,7 +1005,7 @@ class QzoneStablePlugin(Star):
     @qzone.command("unbind")
     async def qzone_unbind(self, event: AstrMessageEvent):
         if not self._is_admin(event):
-            yield self._command_result(event, "????????")
+            yield self._command_result(event, "只有管理员可以解绑。")
             return
         try:
             payload = await self.controller.unbind_local()
@@ -1046,7 +1046,7 @@ class QzoneStablePlugin(Star):
     async def qzone_post(self, event: AstrMessageEvent, content: str = ""):
         self._stop_event(event)
         if not self._is_admin(event):
-            yield self._command_result(event, "?????????")
+            yield self._command_result(event, "只有管理员可以发说说。")
             return
         post = collect_post_payload(
             event,
@@ -1073,7 +1073,7 @@ class QzoneStablePlugin(Star):
     @qzone.command("comment")
     async def qzone_comment(self, event: AstrMessageEvent, hostuin: int, fid: str, content: str):
         if not self._is_admin(event):
-            yield self._command_result(event, "????????")
+            yield self._command_result(event, "只有管理员可以评论。")
             return
         try:
             await self._ensure_cookie_ready(event)
@@ -1082,12 +1082,12 @@ class QzoneStablePlugin(Star):
         except QzoneBridgeError as exc:
             yield self._command_result(event, self._error_text(exc))
             return
-        yield self._command_result(event, format_action_result("????", payload))
+        yield self._command_result(event, format_action_result("评论结果", payload))
 
     @qzone.command("like")
     async def qzone_like(self, event: AstrMessageEvent, hostuin: int, fid: str, appid: int = 311, unlike: bool = False):
         if not self._is_admin(event):
-            yield self._command_result(event, "????????")
+            yield self._command_result(event, "只有管理员可以点赞。")
             return
         try:
             await self._ensure_cookie_ready(event)
@@ -1100,13 +1100,13 @@ class QzoneStablePlugin(Star):
 
     @filter.llm_tool(name="qzone_get_status")
     async def tool_get_status(self, event: AstrMessageEvent):
-        """?? QQ ?? daemon ???
+        """获取 QQ 空间 daemon 状态。
 
         Returns:
-            ???????
+            当前状态摘要。
         """
         if not self._is_admin(event):
-            yield event.plain_result("???????????")
+            yield event.plain_result("只有管理员可以查看 QQ 空间状态。")
             return
         try:
             payload = await self._status_with_recovery()
@@ -1117,12 +1117,12 @@ class QzoneStablePlugin(Star):
 
     @filter.llm_tool(name="qzone_list_feed")
     async def tool_list_feed(self, event: AstrMessageEvent, hostuin: int = 0, limit: int = 5, cursor: str = "", scope: str = ""):
-        """?? QQ ?????
+        """获取 QQ 空间说说列表。
 
         Args:
-            hostuin (number): ?? QQ ??0 ?????????
-            limit (number): ?????
-            cursor (string): ?????
+            hostuin (number): 目标 QQ 号，0 表示当前登录账号。
+            limit (number): 返回数量。
+            cursor (string): 翻页游标。
             scope (string): self ? profile?
         """
         try:
@@ -1142,12 +1142,12 @@ class QzoneStablePlugin(Star):
 
     @filter.llm_tool(name="qzone_detail_feed")
     async def tool_detail_feed(self, event: AstrMessageEvent, hostuin: int, fid: str, appid: int = 311):
-        """?????????
+        """获取说说详情。
 
         Args:
-            hostuin (number): ???? QQ ??
-            fid (string): ?? fid?
-            appid (number): ?? id??? 311?
+            hostuin (number): 目标 QQ 号。
+            fid (string): 说说 fid。
+            appid (number): 应用 id，默认 311。
         """
         try:
             await self._ensure_cookie_ready(event)
@@ -1167,15 +1167,15 @@ class QzoneStablePlugin(Star):
         sync_weibo: bool = False,
         media: list[str] | None = None,
     ):
-        """???? QQ ?????
+        """发布 QQ 空间说说。
 
         Args:
-            content (string): ?????
-            confirm (boolean): ???????
-            sync_weibo (boolean): ???????
+            content (string): 说说内容。
+            confirm (boolean): 是否确认发布。
+            sync_weibo (boolean): 是否同步到微博。
         """
         if not self._is_admin(event):
-            yield event.plain_result("??????????")
+            yield event.plain_result("只有管理员可以发说说。")
             return
         post = collect_post_payload(
             event,
@@ -1185,9 +1185,9 @@ class QzoneStablePlugin(Star):
             extra_media=media,
         )
         if self.settings.preview_writes and not confirm:
-            draft = truncate(post.content or "?????", 120)
-            suffix = f"??? {len(post.media)} ?" if post.media else ""
-            yield event.plain_result(f"?????: {draft}{suffix}????????")
+            draft = truncate(post.content or "空内容", 120)
+            suffix = f"，附带 {len(post.media)} 个媒体" if post.media else ""
+            yield event.plain_result(f"发布预览: {draft}{suffix}。确认后再发布。")
             return
         profile_task: asyncio.Task | None = None
         try:
@@ -1217,22 +1217,22 @@ class QzoneStablePlugin(Star):
         appid: int = 311,
         private: bool = False,
     ):
-        """???????
+        """评论一条说说。
 
         Args:
-            hostuin (number): ?? QQ ??
-            fid (string): ?? fid?
-            content (string): ?????
-            confirm (boolean): ????????????????
-            appid (number): ?? id?
-            private (boolean): ???????
+            hostuin (number): 目标 QQ 号。
+            fid (string): 说说 fid。
+            content (string): 评论内容。
+            confirm (boolean): 是否确认评论。
+            appid (number): 应用 id。
+            private (boolean): 是否私密评论。
         """
         if not self._is_admin(event):
-            yield event.plain_result("????????")
+            yield event.plain_result("只有管理员可以评论。")
             return
         if self.settings.preview_writes and not confirm:
             yield event.plain_result(
-                f"?????: hostuin={hostuin}, fid={fid}, content={truncate(content, 120)}????????"
+                f"评论预览: hostuin={hostuin}, fid={fid}, content={truncate(content, 120)}。确认后再发布。"
             )
             return
         try:
@@ -1248,7 +1248,7 @@ class QzoneStablePlugin(Star):
         except QzoneBridgeError as exc:
             yield event.plain_result(self._error_text(exc))
             return
-        yield event.plain_result(format_action_result("????", payload))
+        yield event.plain_result(format_action_result("评论结果", payload))
 
     @filter.llm_tool(name="qzone_like_post")
     async def tool_like_post(
@@ -1262,16 +1262,16 @@ class QzoneStablePlugin(Star):
         latest: bool = False,
         index: int = 0,
     ):
-        """????????????
+        """点赞或取消点赞一条说说。
 
         Args:
-            hostuin (number): ?? QQ ??`0` ?????? QQ?????????????????????
-            fid (string): ????? fid???????????? N ????????? `latest` / `index`???? `latest`?`?3?` ???????
-            confirm (boolean): ???????????????
-            appid (number): ?? appid???? `311`?
-            unlike (boolean): ? `true` ?????????????
-            latest (boolean): ? `true` ??????? QQ ????????
-            index (number): ?????? QQ ?? N ????`1` ???????
+            hostuin (number): 目标 QQ 号，`0` 表示当前登录账号。
+            fid (string): 说说 fid，也可以用最近列表的序号。
+            confirm (boolean): 兼容旧参数，目前不会拦截执行。
+            appid (number): 说说 appid，默认 `311`。
+            unlike (boolean): 为 `true` 时取消点赞。
+            latest (boolean): 为 `true` 时操作最新一条说说。
+            index (number): 操作最近列表第 N 条，`1` 表示第一条。
         """
         arguments = {
             "hostuin": hostuin,
@@ -1289,19 +1289,19 @@ class QzoneStablePlugin(Star):
                 "error": {
                     "type": "PermissionError",
                     "code": "QZONE_PERMISSION",
-                    "message": "????????",
+                    "message": "没有权限",
                 },
             }
             self._log_tool_call_result({**log_payload, "arguments": arguments})
             llm_payload = {
                 "ok": False,
-                "public_reason": "????????",
+                "public_reason": "没有权限",
                 "reply_guidance": "Use a short natural reply in the active persona. Do not expose error details.",
             }
             text = await self._ask_llm_tool_reply(
                 event,
                 llm_payload,
-                self._llm_error_fallback_text("????????"),
+                self._llm_error_fallback_text("没有权限"),
             )
             yield event.plain_result(text)
             return

--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -1,4 +1,4 @@
-"""Low-level QQ?? HTTP client."""
+"""Low-level QQ 空间 HTTP client."""
 
 from __future__ import annotations
 
@@ -175,9 +175,9 @@ class QzoneClient:
                     code = 0
                 message = str(payload.get("msg") or payload.get("message") or payload.get("text") or "")
                 if self._payload_needs_rebind(code, message):
-                    raise QzoneNeedsRebind(message or "QQ????????", detail=payload)
+                    raise QzoneNeedsRebind(message or "QQ 空间登录态已失效", detail=payload)
                 code_text = raw_code if raw_code not in (None, "") else code
-                raise QzoneRequestError(message or f"QQ??????? {code_text}", status_code=response.status_code, detail=payload)
+                raise QzoneRequestError(message or f"QQ 空间接口返回错误 {code_text}", status_code=response.status_code, detail=payload)
 
     @staticmethod
     def _response_detail(response: httpx.Response) -> dict[str, Any]:
@@ -299,7 +299,7 @@ class QzoneClient:
         if login_required and not self.session.cookies:
             raise QzoneNeedsRebind()
         if login_required and self.gtk == 0:
-            raise QzoneNeedsRebind("Cookie ??? p_skey ? skey????? g_tk")
+            raise QzoneNeedsRebind("Cookie 缺少 p_skey 或 skey，无法计算 g_tk")
 
         params = self._merge_params(params, hostuin=hostuin, attach_token=attach_token)
         attempts = self.max_retries if max_attempts is None else max(1, int(max_attempts))
@@ -324,7 +324,7 @@ class QzoneClient:
                         if accept_qzone_redirects and self._is_allowed_qzone_redirect(str(response.request.url), location):
                             return response
                         raise QzoneRequestError(
-                            "QQ?? H5 ?????????????????",
+                            "QQ 空间 H5 页面跳转到主页，接口数据不可用",
                             status_code=response.status_code,
                             detail=self._response_detail(response),
                         )
@@ -332,7 +332,7 @@ class QzoneClient:
                         response.status_code in QZONE_REDIRECT_STATUS_CODES and self._is_login_redirect(location)
                     ):
                         raise QzoneNeedsRebind(
-                            "QQ???????????? Cookie",
+                            "QQ 空间登录态已失效，需要重新绑定 Cookie",
                             detail=self._response_detail(response),
                         )
                     if response.status_code in QZONE_REDIRECT_STATUS_CODES:
@@ -354,32 +354,32 @@ class QzoneClient:
                         if accept_qzone_redirects and allowed_redirect:
                             return response
                         raise QzoneRequestError(
-                            f"QQ????????? {response.status_code}",
+                            f"QQ 空间接口跳转异常 {response.status_code}",
                             status_code=response.status_code,
                             detail=self._response_detail(response),
                         )
                     break
                 if response.status_code == 403:
                     raise QzoneRequestError(
-                        "QQ???????????",
+                        "QQ 空间拒绝访问，可能没有权限",
                         status_code=response.status_code,
                         detail=self._response_detail(response),
                     )
                 if response.status_code == 429:
                     raise QzoneRequestError(
-                        "QQ?????????????",
+                        "QQ 空间请求过于频繁，请稍后再试",
                         status_code=response.status_code,
                         detail=self._response_detail(response),
                     )
                 if response.status_code >= 500:
                     raise QzoneRequestError(
-                        f"QQ?????????? ({response.status_code})",
+                        f"QQ 空间服务暂时不可用 ({response.status_code})",
                         status_code=response.status_code,
                         detail=self._response_detail(response),
                     )
                 if response.status_code >= 400:
                     raise QzoneRequestError(
-                        f"QQ???? HTTP {response.status_code}",
+                        f"QQ 空间接口 HTTP {response.status_code}",
                         status_code=response.status_code,
                         detail=self._response_detail(response),
                     )
@@ -416,7 +416,7 @@ class QzoneClient:
             if not json_like:
                 detail = {"text": text[:500], "url": str(response.request.url)}
                 raise QzoneParseError(
-                    "QQ ???????? JSON ??",
+                    "QQ 空间接口返回的内容不是 JSON",
                     detail=detail,
                 ) from (callback_error or json_exc)
             try:
@@ -424,7 +424,7 @@ class QzoneClient:
             except Exception as js_exc:
                 detail = {"text": text[:500], "url": str(response.request.url)}
                 raise QzoneParseError(
-                    "???? QQ ?? JSON ??",
+                    "无法解析 QQ 空间 JSON 内容",
                     detail=detail,
                 ) from (js_exc or json_exc)
 
@@ -473,7 +473,7 @@ class QzoneClient:
         try:
             payload = parse_profile_html(response_text) if profile else parse_index_html(response_text)
         except Exception as exc:
-            raise QzoneParseError("QQ ????????", detail={"text": response_text[:500]}) from exc
+            raise QzoneParseError("QQ 空间页面解析失败", detail={"text": response_text[:500]}) from exc
         return payload
 
     def _store_token(self, hostuin: int, token: str) -> None:
@@ -650,7 +650,7 @@ class QzoneClient:
     async def _load_image_source(self, media: dict[str, Any]) -> tuple[bytes, str, str]:
         item = normalize_media_item(media, default_kind="image")
         if item is None or not item.source:
-            raise QzoneParseError("???????????")
+            raise QzoneParseError("图片来源为空或无效")
 
         source = item.source.strip()
         filename = item.name or source_name(source) or "image.jpg"
@@ -664,19 +664,19 @@ class QzoneClient:
             try:
                 return base64.b64decode(source[len("base64://") :], validate=False), filename, mime_type
             except Exception as exc:
-                raise QzoneParseError("???? base64 ????") from exc
+                raise QzoneParseError("图片 base64 解码失败") from exc
         if source.startswith("data:"):
             try:
                 header, encoded = source.split(",", 1)
             except ValueError as exc:
-                raise QzoneParseError("???? data URI ????") from exc
+                raise QzoneParseError("图片 data URI 格式错误") from exc
             header_mime = header[5:].split(";", 1)[0]
             if ";base64" not in header:
-                raise QzoneParseError("data URI ?????? base64 ??")
+                raise QzoneParseError("data URI 必须使用 base64 编码")
             try:
                 data = base64.b64decode(encoded, validate=False)
             except Exception as exc:
-                raise QzoneParseError("???? data URI ????") from exc
+                raise QzoneParseError("图片 data URI 解码失败") from exc
             return data, filename, mime_type or header_mime
 
         if parsed.scheme.lower() in {"http", "https"}:
@@ -691,14 +691,14 @@ class QzoneClient:
                     if response.status_code >= 400:
                         text = (await response.aread()).decode("utf-8", errors="ignore")
                         raise QzoneRequestError(
-                            f"?????? HTTP {response.status_code}",
+                            f"图片下载失败 HTTP {response.status_code}",
                             status_code=response.status_code,
                             detail={"url": source, "text": text[:500]},
                         )
                     length = response.headers.get("content-length")
                     try:
                         if length and int(length) > MAX_UPLOAD_IMAGE_BYTES:
-                            raise QzoneParseError("?????????????", detail={"url": source})
+                            raise QzoneParseError("图片大小超过限制", detail={"url": source})
                     except ValueError:
                         pass
                     chunks: list[bytes] = []
@@ -708,10 +708,10 @@ class QzoneClient:
                             continue
                         total += len(chunk)
                         if total > MAX_UPLOAD_IMAGE_BYTES:
-                            raise QzoneParseError("?????????????", detail={"url": source})
+                            raise QzoneParseError("图片大小超过限制", detail={"url": source})
                         chunks.append(chunk)
             except httpx.HTTPError as exc:
-                raise QzoneRequestError("??????", detail={"url": source}) from exc
+                raise QzoneRequestError("图片下载失败", detail={"url": source}) from exc
             content_type = response.headers.get("content-type", "").split(";", 1)[0]
             data = b"".join(chunks)
             self._store_image_source_cache(source, data, content_type)
@@ -720,10 +720,10 @@ class QzoneClient:
         path = Path(source)
         def read_local_image() -> bytes:
             if not path.exists() or not path.is_file():
-                raise QzoneParseError("???????", detail={"path": source})
+                raise QzoneParseError("图片文件不存在", detail={"path": source})
             stat = path.stat()
             if stat.st_size > MAX_UPLOAD_IMAGE_BYTES:
-                raise QzoneParseError("?????????????", detail={"path": source})
+                raise QzoneParseError("图片大小超过限制", detail={"path": source})
             return path.read_bytes()
 
         data = await asyncio.to_thread(read_local_image)
@@ -733,7 +733,7 @@ class QzoneClient:
     def _photo_payload_from_upload(payload: dict[str, Any], *, filename: str = "", mime_type: str = "") -> dict[str, Any]:
         data = unwrap_payload(payload)
         if not isinstance(data, dict):
-            raise QzoneParseError("??????????", detail=payload)
+            raise QzoneParseError("图片上传返回格式异常", detail=payload)
         albumid = str(data.get("albumid") or data.get("albumId") or "")
         lloc = str(data.get("lloc") or data.get("LLoc") or "")
         sloc = str(data.get("sloc") or data.get("SLoc") or "")
@@ -741,7 +741,7 @@ class QzoneClient:
         height = str(data.get("height") or data.get("h") or 0)
         width = str(data.get("width") or data.get("w") or 0)
         if not albumid or not lloc or not sloc:
-            raise QzoneParseError("???????? richval ??", detail=data)
+            raise QzoneParseError("图片上传返回缺少 richval 字段", detail=data)
         url = str(data.get("url") or data.get("origin_url") or data.get("originUrl") or data.get("pre") or "")
         pic_bo = str(data.get("pic_bo") or data.get("picBo") or QzoneClient._extract_pic_bo(url) or "")
         richval = f",{albumid},{lloc},{sloc},{photo_type},{height},{width},,{height},{width}"
@@ -760,10 +760,10 @@ class QzoneClient:
     async def upload_photo(self, media: dict[str, Any]) -> dict[str, Any]:
         item = normalize_media_item(media, default_kind="image")
         if item is None or not is_supported_image(item):
-            raise QzoneParseError("QQ?????????????", detail=media)
+            raise QzoneParseError("QQ 空间只支持上传图片文件", detail=media)
         data, filename, mime_type = await self._load_image_source(item.to_dict())
         if not data:
-            raise QzoneParseError("???????????", detail={"name": filename})
+            raise QzoneParseError("图片内容为空或无法读取", detail={"name": filename})
 
         encoded_bytes = await asyncio.to_thread(base64.b64encode, data)
         encoded = encoded_bytes.decode("ascii")
@@ -810,7 +810,7 @@ class QzoneClient:
 
     async def _prepare_publish_photos(self, photos: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
         if photos and len(photos) > QZONE_MAX_IMAGES:
-            raise QzoneParseError(f"QQ???????? {QZONE_MAX_IMAGES} ???")
+            raise QzoneParseError(f"QQ 空间一次最多只能上传 {QZONE_MAX_IMAGES} 张图片")
         source_photos = list(photos or [])
         prepared: list[dict[str, Any] | None] = [None] * len(source_photos)
         pending: list[tuple[int, dict[str, Any]]] = []
@@ -850,7 +850,7 @@ class QzoneClient:
 
         final = [photo for photo in prepared if photo is not None]
         if len(final) > QZONE_MAX_IMAGES:
-            raise QzoneParseError(f"QQ???????? {QZONE_MAX_IMAGES} ???")
+            raise QzoneParseError(f"QQ 空间一次最多只能上传 {QZONE_MAX_IMAGES} 张图片")
         return final
 
     async def publish_mood(self, content: str, *, sync_weibo: bool = False, photos: list[dict[str, Any]] | None = None) -> dict[str, Any]:
@@ -1020,13 +1020,13 @@ class QzoneClient:
 
         if isinstance(last_exc, QzoneRequestError):
             status_code = last_exc.status_code
-            message = f"{last_exc.message}??????????"
+            message = f"{last_exc.message}；所有点赞入口都尝试失败"
         elif last_exc is not None:
             status_code = None
-            message = f"{getattr(last_exc, 'message', str(last_exc))}??????????"
+            message = f"{getattr(last_exc, 'message', str(last_exc))}；所有点赞入口都尝试失败"
         else:
             status_code = None
-            message = "QQ???????????????????"
+            message = "QQ 空间点赞入口不可用，请稍后再试"
         raise QzoneRequestError(message, status_code=status_code, detail={"attempts": attempts}) from last_exc
 
     async def detail(self, hostuin: int, fid: str, *, appid: int = 311, busi_param: str = "") -> dict[str, Any]:

--- a/qzone_bridge/controller.py
+++ b/qzone_bridge/controller.py
@@ -416,7 +416,7 @@ class QzoneDaemonController:
                         break
                 if not found_port:
                     exc = DaemonUnavailableError(
-                        "QQ?? daemon ????????????????",
+                        "QQ 空间 daemon 端口被占用，未找到可用备用端口",
                         detail={"daemon_port": port, "checked_ports": f"{port + 1}-{port + 32}"},
                     )
                     self._record_daemon_start_error(exc, port=port)
@@ -428,7 +428,7 @@ class QzoneDaemonController:
 
             if not self._daemon_script().exists():
                 exc = DaemonUnavailableError(
-                    "??? daemon_main.py",
+                    "找不到 daemon_main.py",
                     detail={"path": str(self._daemon_script())},
                 )
                 self._record_daemon_start_error(exc, port=port)
@@ -438,7 +438,7 @@ class QzoneDaemonController:
                 self._process = self._spawn_daemon(port)
             except OSError as exc:
                 error = DaemonUnavailableError(
-                    "QQ?? daemon ????",
+                    "QQ 空间 daemon 启动失败",
                     detail=self._daemon_start_detail(port, error=str(exc)),
                 )
                 self._record_daemon_start_error(error, port=port)
@@ -469,7 +469,7 @@ class QzoneDaemonController:
 
             returncode = self._process.poll() if self._process else None
             error = DaemonUnavailableError(
-                "QQ?? daemon ????",
+                "QQ 空间 daemon 启动超时",
                 detail=self._daemon_start_detail(port, returncode=returncode),
             )
             self._record_daemon_start_error(error, port=port)
@@ -491,7 +491,7 @@ class QzoneDaemonController:
                 await self.ensure_running()
                 runtime = self._runtime()
             elif not await self._probe_health(runtime.daemon_port):
-                raise DaemonUnavailableError("daemon ???")
+                raise DaemonUnavailableError("daemon 未运行")
             try:
                 response = await self._client.request(
                     method,
@@ -506,18 +506,18 @@ class QzoneDaemonController:
                 last_exc = exc
                 if not self.auto_start_daemon or attempt > 0:
                     raise DaemonUnavailableError(
-                        "daemon ????",
+                        "daemon 请求失败",
                         detail={"error": str(exc), "path": path},
                     ) from exc
         if response is None:
             raise DaemonUnavailableError(
-                "daemon ????",
+                "daemon 请求失败",
                 detail={"error": str(last_exc), "path": path},
             )
         try:
             payload = response.json()
         except Exception as exc:
-            raise DaemonUnavailableError("daemon ???? JSON ??", detail={"text": response.text[:500]}) from exc
+            raise DaemonUnavailableError("daemon 返回的 JSON 无法解析", detail={"text": response.text[:500]}) from exc
         if not payload.get("ok", False):
             error = payload.get("error") or {}
             code = str(error.get("code") or "DAEMON_ERROR")
@@ -552,10 +552,10 @@ class QzoneDaemonController:
     @staticmethod
     def cookie_summary(cookies: dict[str, str]) -> str:
         if not cookies:
-            return "???"
+            return "无 Cookie"
         keys = ["uin", "p_uin", "skey", "p_skey", "pt4_token", "pt_key"]
         found = [key for key in keys if key in cookies]
-        return f"{len(cookies)}???: " + ", ".join(found or ["????"])
+        return f"{len(cookies)} 个 Cookie: " + ", ".join(found or ["未识别关键字段"])
 
     async def bind_cookie(self, cookie_text: str, *, uin: int = 0, source: str = "manual") -> dict[str, Any]:
         return await self._request("POST", "/bind", json_body={"cookie_text": cookie_text, "uin": uin, "source": source})
@@ -568,10 +568,10 @@ class QzoneDaemonController:
         except DaemonUnavailableError:
             cookies = parse_cookie_text(cookie_text)
             if not cookies:
-                raise QzoneParseError("Cookie ???????")
+                raise QzoneParseError("Cookie 内容为空或无法解析")
             resolved_uin = normalize_uin(cookies, override=uin)
             if not resolved_uin:
-                raise QzoneParseError("Cookie ???? uin / p_uin???????")
+                raise QzoneParseError("Cookie 缺少 uin / p_uin，无法识别登录 QQ")
 
             state = self.store.read()
             runtime = self._runtime()

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -44,7 +44,7 @@ LATEST_FEED_REFERENCES = {
 }
 FEED_REFERENCE_PREFIXES = ("\u7b2c",)
 FEED_REFERENCE_SUFFIXES = ("\u6761",)
-LOSSY_LATEST_FEED_REFERENCES = {"??", "????"}
+LOSSY_LATEST_FEED_REFERENCES = {"最新", "最近"}
 
 
 class QzoneDaemonService:
@@ -222,10 +222,10 @@ class QzoneDaemonService:
     async def bind_cookie(self, cookie_text: str, *, uin: int = 0, source: str = "manual") -> dict[str, Any]:
         cookies = parse_cookie_text(cookie_text)
         if not cookies:
-            raise QzoneParseError("Cookie ???????")
+            raise QzoneParseError("Cookie 内容为空或无法解析")
         resolved_uin = normalize_uin(cookies, override=uin)
         if not resolved_uin:
-            raise QzoneParseError("Cookie ???? uin / p_uin???????")
+            raise QzoneParseError("Cookie 缺少 uin / p_uin，无法识别登录 QQ")
         self.state.session = SessionState(
             uin=resolved_uin,
             cookies=cookies,
@@ -344,7 +344,7 @@ class QzoneDaemonService:
         await self.ensure_token(hostuin)
         payload = unwrap_payload(await self.client.detail(hostuin, fid, appid=appid, busi_param=busi_param))
         if not isinstance(payload, dict):
-            raise QzoneParseError("??????????")
+            raise QzoneParseError("说说详情返回格式异常")
         entry = self.client.feed_entry_from_payload(payload, default_hostuin=hostuin)
         self.client.cache_feed_page(hostuin, [entry])
         comments = []
@@ -381,12 +381,12 @@ class QzoneDaemonService:
         normalized_media = normalize_media_list(media)
         photos, fallback_media = split_publishable_images(normalized_media)
         if len(photos) > QZONE_MAX_IMAGES:
-            raise QzoneParseError(f"QQ???????? {QZONE_MAX_IMAGES} ???")
+            raise QzoneParseError(f"QQ 空间一次最多只能上传 {QZONE_MAX_IMAGES} 张图片")
         if fallback_media:
             refs = "\n".join(media_reference_text(item) for item in fallback_media)
             content = "\n".join(part for part in (content.strip(), refs) if part)
         if not content.strip() and not photos:
-            raise QzoneParseError("????????")
+            raise QzoneParseError("说说内容或图片不能为空")
         self._ensure_session_ready()
         payload = unwrap_payload(
             await self.client.publish_mood(
@@ -396,7 +396,7 @@ class QzoneDaemonService:
             )
         )
         if not isinstance(payload, dict):
-            raise QzoneParseError("??????????")
+            raise QzoneParseError("说说发布返回格式异常")
         self._set_success(defer_save=True)
         return {
             "fid": payload.get("fid") or payload.get("tid") or "",
@@ -416,11 +416,11 @@ class QzoneDaemonService:
         private: bool = False,
     ) -> dict[str, Any]:
         if not content.strip():
-            raise QzoneParseError("????????")
+            raise QzoneParseError("评论内容不能为空")
         self._ensure_session_ready()
         payload = unwrap_payload(await self.client.add_comment(hostuin, fid, content, appid=appid, private=private))
         if not isinstance(payload, dict):
-            raise QzoneParseError("????????")
+            raise QzoneParseError("评论发布返回格式异常")
         self._set_success(defer_save=True)
         return {
             "commentid": payload.get("commentid") or payload.get("commentId") or 0,
@@ -513,7 +513,7 @@ class QzoneDaemonService:
             feed_payload = await self.list_feeds(hostuin=target_hostuin, limit=reference_index, scope="profile")
             items = feed_payload.get("items") or []
             if reference_index > len(items):
-                raise QzoneParseError(f"???? {reference_index} ???????")
+                raise QzoneParseError(f"第 {reference_index} 条说说不存在")
             entry = FeedEntry(**items[reference_index - 1])
             return entry.hostuin, entry.fid, entry.appid or appid, curkey or entry.curkey
         return target_hostuin, fid_text, int(appid or 311), curkey
@@ -599,7 +599,7 @@ class QzoneDaemonService:
             index=index,
         )
         if not hostuin or not fid:
-            raise QzoneParseError("????????????????")
+            raise QzoneParseError("没有指定要点赞的说说")
 
         target_liked = not unlike
         before_entry = await self._refresh_like_entry(hostuin, fid, appid)
@@ -740,7 +740,7 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
     async def auth_middleware(request: web.Request, handler):
         secret = request.headers.get(SECRET_HEADER) or request.query.get("secret") or ""
         if secret != service.state.runtime.secret:
-            return fail("UNAUTHORIZED", "secret ???", status=401)
+            return fail("UNAUTHORIZED", "secret 不正确", status=401)
         return await handler(request)
 
     app.middlewares.append(auth_middleware)

--- a/qzone_bridge/render.py
+++ b/qzone_bridge/render.py
@@ -10,7 +10,7 @@ from .utils import to_local_time_text, truncate
 
 def cookie_summary(cookies: dict[str, str]) -> str:
     if not cookies:
-        return "???"
+        return "无 Cookie"
     keys = [
         "uin",
         "p_uin",
@@ -28,12 +28,12 @@ def cookie_summary(cookies: dict[str, str]) -> str:
     ]
     found = [key for key in keys if key in cookies]
     extras = len(cookies) - len(found)
-    return f"{len(cookies)}???: " + ", ".join(found + ([f"??{extras}?"] if extras > 0 else []))
+    return f"{len(cookies)} 个 Cookie: " + ", ".join(found + ([f"另 {extras} 个"] if extras > 0 else []))
 
 
 def format_status(status: dict) -> str:
     lines = [
-        "QQ????",
+        "QQ 空间状态",
         f"- daemon: {status.get('daemon_state', 'unknown')}",
         f"- login: {status.get('login_uin') or '-'}",
         f"- source: {status.get('session_source') or '-'}",
@@ -48,7 +48,7 @@ def format_status(status: dict) -> str:
         lines.append(f"- pid: {status['daemon_pid']}")
     start_error = status.get("daemon_start_error")
     if isinstance(start_error, dict):
-        message = start_error.get("message") or "daemon ????"
+        message = start_error.get("message") or "daemon 启动失败"
         lines.append(f"- daemon_error: {message}")
         detail = start_error.get("detail")
         if isinstance(detail, dict):
@@ -71,8 +71,8 @@ def format_feed_entry(entry: FeedEntry, index: int | None = None, *, include_int
             f"like={entry.like_count} comment={entry.comment_count} liked={entry.liked}"
         )
     else:
-        liked_text = "???" if entry.liked else "???"
-        lines.append(f"   {liked_text}?{entry.like_count} ??{entry.comment_count} ??")
+        liked_text = "已赞" if entry.liked else "未赞"
+        lines.append(f"   {liked_text} | {entry.like_count} 赞 | {entry.comment_count} 评论")
     lines.append(f"   {headline}")
     return "\n".join(lines)
 
@@ -101,14 +101,14 @@ def format_feed_list(
 def format_llm_feed_list(entries: Iterable[FeedEntry]) -> str:
     entries = list(entries)
     if not entries:
-        return "???????????"
+        return "没有找到可展示的说说。"
     body = format_feed_list(entries, include_internal=False, include_pagination=False)
-    return f"{body}\n?????????????????"
+    return f"{body}\n可以用上面的序号继续指定要查看或操作的说说。"
 
 
 def format_feed_detail(entry: FeedEntry) -> str:
     lines = [
-        "????",
+        "说说详情",
         f"- hostuin: {entry.hostuin}",
         f"- fid: {entry.fid}",
         f"- appid: {entry.appid}",
@@ -133,14 +133,14 @@ def format_action_result(title: str, payload: dict) -> str:
 
 
 def format_like_result(payload: dict) -> str:
-    action = "????" if payload.get("action") == "unlike" else "??"
+    action = "取消点赞" if payload.get("action") == "unlike" else "点赞"
     summary = truncate(str(payload.get("summary") or ""), 80)
-    suffix = f"?{summary}" if summary else ""
+    suffix = f"「{summary}」" if summary else ""
     if payload.get("verified"):
         if payload.get("already"):
-            state = "??????"
+            state = "已经是目标状态"
         else:
-            state = "??"
-        liked = "?????" if payload.get("liked") else "?????"
-        return f"{action}{state}{suffix}?{liked}??"
-    return f"{action}???????????? QQ ????{suffix}?"
+            state = "已完成"
+        liked = "当前已点赞" if payload.get("liked") else "当前未点赞"
+        return f"{action}{state}{suffix}，{liked}。"
+    return f"{action}已受理，QQ 空间可能还在同步{suffix}。"

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -68,27 +68,27 @@ class ClientErrorMappingTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(QzoneRequestError) as caught:
             await self.client._request_text("GET", "https://h5.qzone.qq.com/mqzone/profile")
         self.assertEqual(caught.exception.status_code, 403)
-        self.assertIn("??", caught.exception.message)
+        self.assertIn("权限", caught.exception.message)
 
     async def test_payload_login_code_requires_rebind(self):
         await self._use_response(
-            lambda request: httpx.Response(200, json={"code": -3000, "message": "?????"}, request=request)
+            lambda request: httpx.Response(200, json={"code": -3000, "message": "登录态失效"}, request=request)
         )
         with self.assertRaises(QzoneNeedsRebind):
             await self.client._request_json("GET", "https://mobile.qzone.qq.com/feeds/mfeeds_get_count")
 
     async def test_payload_login_code_inside_data_requires_rebind(self):
         await self._use_response(
-            lambda request: httpx.Response(200, json={"data": {"code": -3000, "message": "?????"}}, request=request)
+            lambda request: httpx.Response(200, json={"data": {"code": -3000, "message": "登录态失效"}}, request=request)
         )
         with self.assertRaises(QzoneNeedsRebind):
             await self.client._request_json("GET", "https://mobile.qzone.qq.com/feeds/mfeeds_get_count")
 
     async def test_generic_negative_code_is_not_forced_to_rebind(self):
         await self._use_response(
-            lambda request: httpx.Response(200, json={"code": -10000, "message": "????"}, request=request)
+            lambda request: httpx.Response(200, json={"code": -10000, "message": "普通错误"}, request=request)
         )
-        self.assertFalse(self.client._payload_needs_rebind(-10000, "????"))
+        self.assertFalse(self.client._payload_needs_rebind(-10000, "普通错误"))
         with self.assertRaises(QzoneRequestError) as caught:
             await self.client._request_json("GET", "https://mobile.qzone.qq.com/feeds/mfeeds_get_count")
         self.assertNotIsInstance(caught.exception, QzoneNeedsRebind)
@@ -199,7 +199,7 @@ class ClientErrorMappingTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(QzoneRequestError) as caught:
             await self.client.like_post(123456, "fid-1")
 
-        self.assertIn("?????????", caught.exception.message)
+        self.assertIn("所有点赞入口", caught.exception.message)
         self.assertEqual(caught.exception.status_code, 503)
         attempts = caught.exception.detail["attempts"]
         self.assertEqual(len(attempts), 2)

--- a/tests/test_controller_bind.py
+++ b/tests/test_controller_bind.py
@@ -197,7 +197,7 @@ class ControllerBindTests(unittest.IsolatedAsyncioTestCase):
                         "ok": False,
                         "error": {
                             "code": "QZONE_REQUEST",
-                            "message": "QQ?????????? (503)",
+                            "message": "QQ 空间服务暂时不可用 (503)",
                             "detail": {
                                 "status_code": 503,
                                 "url": "https://w.qzone.qq.com/cgi-bin/likes/internal_dolike_app",

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -48,9 +48,8 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             QzoneDaemonService._feed_reference_index("\u7b2c\uff12\u6761", hostuin=123456),
             2,
         )
-        self.assertEqual(QzoneDaemonService._feed_reference_index("?2?", hostuin=123456), 2)
-        self.assertEqual(QzoneDaemonService._feed_reference_index("??2??", hostuin=123456), 2)
-        self.assertEqual(QzoneDaemonService._feed_reference_index("????", hostuin=123456), 1)
+        self.assertEqual(QzoneDaemonService._feed_reference_index("第2条", hostuin=123456), 2)
+        self.assertEqual(QzoneDaemonService._feed_reference_index("最新", hostuin=123456), 1)
         self.assertEqual(QzoneDaemonService._feed_reference_index("2", hostuin=123456), 0)
 
     async def test_warmup_uses_json_health_check_instead_of_h5_index(self):
@@ -81,7 +80,7 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             service.client.update_session(service.state.session)
             service.health_state = "ready"
 
-            service._set_error(QzoneRequestError("?????", status_code=403))
+            service._set_error(QzoneRequestError("禁止访问", status_code=403))
 
             self.assertEqual(service.health_state, "ready")
             self.assertFalse(service.state.session.needs_rebind)
@@ -595,7 +594,7 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
                     hostuin=3112333596,
                     fid="1c7182b96589046ad3380900",
                     appid=311,
-                    summary="??????",
+                    summary="甜酷风怎么样",
                     liked=False,
                     curkey="cached-curkey",
                 )
@@ -603,13 +602,13 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             before = {
                 "tid": "1c7182b96589046ad3380900",
                 "uin": 3112333596,
-                "content": "??????",
+                "content": "甜酷风怎么样",
                 "like": {"isliked": "0"},
             }
             after = {
                 "tid": "1c7182b96589046ad3380900",
                 "uin": 3112333596,
-                "content": "??????",
+                "content": "甜酷风怎么样",
                 "like": {"isliked": "1"},
             }
             try:
@@ -623,7 +622,7 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(args[:2], (3112333596, "1c7182b96589046ad3380900"))
                 self.assertEqual(kwargs["curkey"], "cached-curkey")
                 self.assertTrue(payload["verified"])
-                self.assertEqual(payload["summary"], "??????")
+                self.assertEqual(payload["summary"], "甜酷风怎么样")
             finally:
                 await service.close()
 

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -195,7 +195,7 @@ class MainPublishTests(unittest.TestCase):
             "login_uin": 3112333596,
             "session_source": "aiocqhttp",
             "cookie_count": 14,
-            "cookie_summary": "14???: uin, p_uin, skey, p_skey",
+            "cookie_summary": "14 个 Cookie: uin, p_uin, skey, p_skey",
             "needs_rebind": False,
             "daemon_port": 18999,
         }
@@ -221,7 +221,7 @@ class MainPublishTests(unittest.TestCase):
             "login_uin": 3112333596,
             "session_source": "aiocqhttp",
             "cookie_count": 14,
-            "cookie_summary": "14???: uin, p_uin, skey, p_skey",
+            "cookie_summary": "14 个 Cookie: uin, p_uin, skey, p_skey",
             "needs_rebind": False,
             "daemon_port": 18999,
         }
@@ -229,7 +229,7 @@ class MainPublishTests(unittest.TestCase):
             get_status=AsyncMock(return_value=degraded),
             ensure_running=AsyncMock(
                 side_effect=module.DaemonUnavailableError(
-                    "QQ?? daemon ????",
+                    "QQ 空间 daemon 启动失败",
                     detail={"returncode": 7, "log_path": "D:/qzone/daemon.log", "log_tail": "daemon boom"},
                 )
             ),
@@ -239,7 +239,7 @@ class MainPublishTests(unittest.TestCase):
         results = asyncio.run(collect_async_generator(plugin.qzone_status(event)))
 
         self.assertIn("- daemon: degraded", results[0])
-        self.assertIn("- daemon_error: QQ?? daemon ????", results[0])
+        self.assertIn("- daemon_error: QQ 空间 daemon 启动失败", results[0])
         self.assertIn("- daemon_returncode: 7", results[0])
         self.assertIn("- daemon_log: D:/qzone/daemon.log", results[0])
         self.assertIn("daemon boom", results[0])
@@ -252,7 +252,7 @@ class MainPublishTests(unittest.TestCase):
             "login_uin": 3112333596,
             "session_source": "manual",
             "cookie_count": 4,
-            "cookie_summary": "4???: uin, p_uin, skey, p_skey",
+            "cookie_summary": "4 个 Cookie: uin, p_uin, skey, p_skey",
             "needs_rebind": False,
             "daemon_port": 18999,
         }
@@ -362,7 +362,7 @@ class MainPublishTests(unittest.TestCase):
             hostuin=3112333596,
             fid="1c7182b96589046ad3380900",
             appid=311,
-            summary="??????",
+            summary="甜酷风怎么样",
             liked=False,
         )
         plugin.controller.list_feeds = AsyncMock(
@@ -377,8 +377,12 @@ class MainPublishTests(unittest.TestCase):
         results = asyncio.run(collect_async_generator(plugin.tool_list_feed(event, limit=1)))
 
         self.assertEqual(len(results), 1)
-        self.assertIn("??", results[0])
-        self.assertIn("???", results[0])
+        self.assertIn("未赞", results[0])
+        self.assertIn("0 赞", results[0])
+        self.assertIn("0 评论", results[0])
+        self.assertIn("甜酷风怎么样", results[0])
+        self.assertIn("可以用上面的序号", results[0])
+        self.assertNotIn("?" * 3, results[0])
         self.assertNotIn("cursor=", results[0])
         self.assertNotIn("has_more", results[0])
         self.assertNotIn("fid=", results[0])
@@ -388,7 +392,7 @@ class MainPublishTests(unittest.TestCase):
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
             get_current_chat_provider_id=AsyncMock(return_value="provider-1"),
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="?????????")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="这条已经点好了。")),
         )
         plugin.controller.like_post = AsyncMock(
             return_value={
@@ -396,7 +400,7 @@ class MainPublishTests(unittest.TestCase):
                 "liked": True,
                 "verified": True,
                 "already": False,
-                "summary": "??????",
+                "summary": "甜酷风怎么样",
             }
         )
         event = Event([])
@@ -413,12 +417,12 @@ class MainPublishTests(unittest.TestCase):
             latest=False,
             index=0,
         )
-        self.assertEqual(results[0], "?????????")
+        self.assertEqual(results[0], "这条已经点好了。")
         plugin._context.llm_generate.assert_awaited_once()
         prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
         self.assertIn("不要照抄", prompt)
         self.assertIn("当前聊天里的人设", prompt)
-        self.assertIn("??????", prompt)
+        self.assertIn("甜酷风怎么样", prompt)
         self.assertNotIn('"ok"', prompt)
         self.assertNotIn('"verified"', prompt)
         self.assertNotIn("fid=", results[0])
@@ -428,7 +432,7 @@ class MainPublishTests(unittest.TestCase):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="????")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="好了")),
         )
         plugin.controller.like_post = AsyncMock(
             return_value={
@@ -460,7 +464,7 @@ class MainPublishTests(unittest.TestCase):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="?????? 2 ??????")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="第 2 条已经点好了。")),
         )
         plugin.controller.like_post = AsyncMock(
             return_value={
@@ -492,7 +496,7 @@ class MainPublishTests(unittest.TestCase):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="???????????????????")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="先帮你点上了，显示可能慢一点。")),
         )
         plugin.settings.preview_writes = True
         plugin.controller.like_post = AsyncMock(
@@ -511,7 +515,7 @@ class MainPublishTests(unittest.TestCase):
         )
 
         plugin.controller.like_post.assert_awaited_once()
-        self.assertEqual(results[0], "???????????????????")
+        self.assertEqual(results[0], "先帮你点上了，显示可能慢一点。")
         prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
         self.assertIn("QQ 空间显示可能会慢一点", prompt)
         self.assertIn("不要说成失败", prompt)
@@ -560,19 +564,19 @@ class MainPublishTests(unittest.TestCase):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="?????QQ ??????????")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="这会儿 QQ 空间还动不了。")),
         )
-        plugin.controller.like_post = AsyncMock(side_effect=module.QzoneBridgeError("????"))
+        plugin.controller.like_post = AsyncMock(side_effect=module.QzoneBridgeError("点赞失败"))
         event = Event([])
 
         results = asyncio.run(
             collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
         )
 
-        self.assertEqual(results[0], "?????QQ ??????????")
+        self.assertEqual(results[0], "这会儿 QQ 空间还动不了。")
         prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
         self.assertIn("\u73b0\u5728\u8fd8\u6ca1\u529e\u6cd5\u7ee7\u7eed", prompt)
-        self.assertIn("????", prompt)
+        self.assertIn("点赞失败", prompt)
         self.assertNotIn('"ok"', prompt)
         self.assertNotIn("QZONE_ERROR", prompt)
         self.assertFalse(results[0].lstrip().startswith("{"))
@@ -581,10 +585,10 @@ class MainPublishTests(unittest.TestCase):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="?????QQ ??????????")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="这会儿 QQ 空间还动不了。")),
         )
         exc = module.QzoneBridgeError(
-            "QQ?????????? (503)",
+            "QQ 空间服务暂时不可用 (503)",
             detail={
                 "status_code": 503,
                 "url": "https://w.qzone.qq.com/cgi-bin/likes/internal_dolike_app?g_tk=123",
@@ -600,7 +604,7 @@ class MainPublishTests(unittest.TestCase):
                 collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
             )
 
-        self.assertEqual(results[0], "?????QQ ??????????")
+        self.assertEqual(results[0], "这会儿 QQ 空间还动不了。")
         prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
         self.assertNotIn('"diagnostic"', prompt)
         self.assertNotIn("status_code", prompt)
@@ -644,7 +648,7 @@ class MainPublishTests(unittest.TestCase):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin.controller.like_post = AsyncMock(
-            side_effect=module.QzoneBridgeError("????", detail={"fid": "secret-fid", "raw": {"code": 1}})
+            side_effect=module.QzoneBridgeError("点赞失败", detail={"fid": "secret-fid", "raw": {"code": 1}})
         )
         event = Event([])
 


### PR DESCRIPTION
## What changed
- Replaced garbled Chinese user-facing strings across Qzone command replies, daemon/client/controller errors, and LLM feed/list renderers with readable Chinese.
- Updated feed/list/detail/like output formatting so Chinese status text such as like/comment counts no longer appears as question marks.
- Added and adjusted regression assertions to catch unreadable `???` output in the affected command, daemon, and client paths.

## Why
Some hardcoded Chinese literals had already been corrupted in source files, so normal Unicode output paths could still return strings like `????1 ??0 ??` even when runtime encoding was fine. This fixes the source text itself and covers the affected render/error surfaces.

## Validation
- `git diff --check origin/main..HEAD`
- `Get-ChildItem -Recurse -Include *.py,*.md,*.yaml,*.json -File | Select-String -SimpleMatch '??'`
- `python -m py_compile main.py daemon_main.py qzone_bridge\client.py qzone_bridge\controller.py qzone_bridge\daemon.py qzone_bridge\render.py qzone_bridge\settings.py`
- `python -m unittest discover -s tests -v` (136 tests)