### PR TITLE
[codex] Align Qzone commands with Zhalslar plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,54 @@
 # QQ空间Ultra（QzoneUltra）
 
-QQ空间Ultra 是面向 AstrBot 的 QQ 空间插件方案。
+面向 AstrBot 的 QQ 空间插件。当前版本在本地 daemon、Cookie 持久化、图片/文件发布、自然语言 LLM 回复和点赞校验安全性的基础上，对标 `Zhalslar/astrbot_plugin_qzone` 的中文命令体验。
 
-## 插件信息
+## 功能
 
-- 插件名：QQ空间Ultra（QzoneUltra）
-- 作者：雪碧bir
-- GitHub：https://github.com/diaomin66/astrbot_plugin_qzone_stable
+- 查看 QQ 空间说说、详情、评论、访客。
+- 点赞、评论、回复评论、发布和删除自己的说说。
+- AI 写说说、AI 评论、AI 回评。
+- 表白墙投稿、匿名投稿、撤稿、看稿、过稿、拒稿。
+- 定时自动发说说、自动评论好友说说，可配置随机时间偏移，并持久记录已自动评论的说说，避免重复打扰。
+- 可选 pillowmd 样式渲染，看说说、访客、稿件和审核通知会优先渲染成图，失败时回退文本。
+- 保留本地 daemon 管理、自动/手动 Cookie 绑定和旧 LLM tools 兼容能力。
 
-## 特点
+## 中文命令
 
-- 本地 daemon 承担登录态、请求、保活和重试
-- AstrBot 负责命令、LLM tools 和展示
-- Cookie 持久化，断线后可自动恢复
-- 支持从 OneBot v11 平台自动获取 Cookie
-- 发布说说支持文字、图片、图片文件以及文件+文字组合
+序号从 `0` 开始，`0` 表示最新一条，`-1` 表示当前页最后一条，支持范围语法如 `2~5`。`@用户` 或 QQ 号表示查看指定用户空间；不指定时默认查看好友动态流。
 
-## 使用
+| 命令 | 别名 | 权限 | 参数 | 功能 |
+| --- | --- | --- | --- | --- |
+| 查看访客 | - | ADMIN | - | 查看最近访客 |
+| 看说说 | 查看说说 | ALL | `[@用户/QQ] [序号/范围]` | 查看说说详情 |
+| 评说说 | 评论说说、读说说 | ALL | `[@用户/QQ] [序号/范围]` | AI 评论说说，可配置评论后点赞 |
+| 赞说说 | - | ALL | `[@用户/QQ] [序号/范围]` | 点赞说说 |
+| 发说说 | - | ADMIN | `<文本> [图片]` | 立即发布说说 |
+| 写说说 | 写稿 | ADMIN | `<主题> [图片]` | AI 生成待审核稿件 |
+| 删说说 | - | ADMIN | `<序号>` | 删除自己发布的说说 |
+| 回评 | 回复评论 | ALL | `<稿件ID> [评论序号]` | 回复已查看/已发布稿件下的评论 |
+| 投稿 | - | ALL | `<文本> [图片]` | 投稿到表白墙 |
+| 匿名投稿 | - | ALL | `<文本> [图片]` | 匿名投稿到表白墙 |
+| 撤稿 | - | ALL | `<稿件ID>` | 撤回自己的待审核投稿 |
+| 看稿 | 查看稿件 | ADMIN | `[稿件ID]` | 查看待审核稿件 |
+| 过稿 | 通过稿件、通过投稿 | ADMIN | `<稿件ID>` | 审核并发布稿件 |
+| 拒稿 | 拒绝稿件、拒绝投稿 | ADMIN | `<稿件ID> [原因]` | 拒绝稿件 |
 
-1. 把插件放进 AstrBot 的 `data/plugins/` 目录。
-2. 在面板里填好配置。
-3. 用 `/qzone bind <cookie>` 绑定 Cookie。
-4. 常用命令：
-   - `/qzone status`
-   - `/qzone autobind`
-   - `/qzone feed`
-   - `/qzone detail <hostuin> <fid>`
-   - `/qzone post <content>`（可同消息携带图片/图片文件，普通文件会写入可读引用）
-   - `/qzone comment <hostuin> <fid> <content>`
-   - `/qzone like <hostuin> <fid>`
+保留的管理命令：
 
-## Cookie 格式
-
-支持两种输入：
-
-- `p_skey=...; p_uin=o123456789; uin=o123456789; skey=...`
-- `{"p_skey":"...","p_uin":"o123456789","uin":"o123456789"}`
+- `/qzone help`
+- `/qzone status`
+- `/qzone bind <cookie>`
+- `/qzone autobind`
+- `/qzone unbind`
 
 ## LLM tools
+
+对标工具：
+
+- `llm_view_feed`
+- `llm_publish_feed`
+
+兼容工具：
 
 - `qzone_get_status`
 - `qzone_list_feed`
@@ -46,6 +57,41 @@ QQ空间Ultra 是面向 AstrBot 的 QQ 空间插件方案。
 - `qzone_comment_post`
 - `qzone_like_post`
 
-## 自动 Cookie 获取
+`qzone_like_post` 会继续区分“请求已被 QQ 空间接受”和“读回校验暂未同步”，不会因为 QQ 空间显示滞后把成功操作误报成失败；用户可见回复会交给 LLM 组织成自然语言，避免泄露 raw JSON、fid、cursor、status_code 等内部字段。
 
-当 AstrBot 使用 `aiocqhttp`(OneBot v11) 平台时，插件会优先尝试从平台适配器自动获取 Cookie，并写入 daemon 持久化状态。若平台不支持 `get_cookies` / `get_credentials`，仍可使用 `/qzone bind <cookie>` 手动绑定。
+## 配置
+
+除了原有 daemon 配置外，新增/兼容以下配置段：
+
+- `manage_group`：投稿审核通知群；为空时尝试私发管理员。
+- `pillowmd_style_dir`：可选的 pillowmd 样式目录；配置后会优先把说说/稿件展示渲染成图片。
+- `llm.post_provider_id` / `llm.comment_provider_id` / `llm.reply_provider_id`：分别指定写稿、评论、回评的 LLM provider。
+- `llm.post_prompt` / `llm.comment_prompt` / `llm.reply_prompt`：提示词。
+- `source.ignore_groups` / `source.ignore_users` / `source.post_max_msg`：自动写稿/读说说来源控制，AI 写稿会尽量抽取群聊文本作为参考上下文。
+- `trigger.publish_cron` / `trigger.publish_offset`：自动发说说基准时间和随机偏移秒数。
+- `trigger.comment_cron` / `trigger.comment_offset`：自动评论基准时间和随机偏移秒数。
+- `trigger.read_prob`：收到消息时概率触发读说说/评论。
+- `trigger.send_admin` / `trigger.like_when_comment`：自动评论反馈和评论时点赞。
+- `cookies_str`：可选，从配置直接绑定 Cookie。
+- `show_name`：过稿发布时在正文头部展示投稿者昵称；匿名投稿显示为“匿名者”。
+
+## 稿件和回评
+
+`看说说`、`评说说`、`赞说说` 查询到的说说会缓存成目标插件风格的稿件 ID，展示文本中会出现 `稿件 #ID`。之后可以用：
+
+```text
+回评 ID
+回评 ID 0
+```
+
+默认回复最后一条非自己评论；指定评论序号时从 `0` 开始。表白墙投稿通过后也会保存发布后的 fid，继续支持同一套 `回评` 流程。
+
+## Cookie
+
+仍支持手动绑定：
+
+```text
+/qzone bind p_skey=...; p_uin=o123456789; uin=o123456789; skey=...
+```
+
+当 AstrBot 使用 `aiocqhttp` / OneBot v11 时，插件也会尝试通过 `/qzone autobind` 或自动绑定从平台获取 Cookie。

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1,15 +1,177 @@
 {
+  "manage_group": {
+    "description": "管理群",
+    "type": "string",
+    "default": "",
+    "hint": "投稿审核通知群；不填则尝试私发管理员。"
+  },
+  "pillowmd_style_dir": {
+    "description": "Pillowmd 样式目录路径",
+    "type": "string",
+    "default": "",
+    "hint": "例如 C:\\styles\\my-style；留空则使用普通文本/内置发布结果渲染。"
+  },
+  "llm": {
+    "description": "LLM 模块配置",
+    "type": "object",
+    "items": {
+      "post_provider_id": {
+        "description": "写说说用的 LLM 提供商",
+        "type": "string",
+        "default": "",
+        "_special": "select_provider",
+        "hint": "留空时使用当前会话默认提供商。"
+      },
+      "post_prompt": {
+        "description": "写说说提示词",
+        "type": "text",
+        "default": "找出一个你感兴趣的主题来写一段适合 QQ 空间的说说，简短、有个性、不要解释。",
+        "hint": "用于 写说说/写稿 和定时自动发说说。"
+      },
+      "comment_provider_id": {
+        "description": "评论说说用的 LLM 提供商",
+        "type": "string",
+        "default": "",
+        "_special": "select_provider",
+        "hint": "留空时使用当前会话默认提供商。"
+      },
+      "comment_prompt": {
+        "description": "评论说说提示词",
+        "type": "text",
+        "default": "生成一句简短、直接、贴题的评论，不要解释。",
+        "hint": "用于 评说说/评论说说/读说说 和自动评论。"
+      },
+      "reply_provider_id": {
+        "description": "回复评论用的 LLM 提供商",
+        "type": "string",
+        "default": "",
+        "_special": "select_provider",
+        "hint": "留空时使用当前会话默认提供商。"
+      },
+      "reply_prompt": {
+        "description": "回复评论提示词",
+        "type": "text",
+        "default": "这条帖子收到了一条评论，请自然回复此条评论，不要解释。",
+        "hint": "用于 回评/回复评论。"
+      }
+    }
+  },
+  "source": {
+    "description": "数据来源配置",
+    "type": "object",
+    "items": {
+      "ignore_groups": {
+        "description": "忽略的群聊列表",
+        "type": "list",
+        "default": [],
+        "hint": "概率触发读说说/评论时会跳过这些群。"
+      },
+      "ignore_users": {
+        "description": "忽略的用户列表",
+        "type": "list",
+        "default": [],
+        "hint": "概率触发读说说/评论时会跳过这些用户。"
+      },
+      "post_max_msg": {
+        "description": "用于写说说的聊天记录最大条数",
+        "type": "int",
+        "default": 500,
+        "slider": {
+          "min": 100,
+          "max": 1000,
+          "step": 10
+        },
+        "hint": "预留给后续聊天记录上下文聚合。"
+      }
+    }
+  },
+  "trigger": {
+    "description": "触发配置",
+    "type": "object",
+    "items": {
+      "publish_cron": {
+        "description": "自动发说说的基准触发时间",
+        "type": "string",
+        "default": "",
+        "hint": "Cron 表达式：分 时 日 月 周。留空表示禁用。"
+      },
+      "publish_offset": {
+        "description": "自动发说说的随机偏移秒数",
+        "type": "int",
+        "default": 0,
+        "slider": {
+          "min": 0,
+          "max": 3600,
+          "step": 1
+        },
+        "hint": "围绕基准时间随机前后浮动；0 表示严格按基准时间。"
+      },
+      "comment_cron": {
+        "description": "自动评论的基准触发时间",
+        "type": "string",
+        "default": "",
+        "hint": "Cron 表达式：分 时 日 月 周。留空表示禁用。"
+      },
+      "comment_offset": {
+        "description": "自动评论的随机偏移秒数",
+        "type": "int",
+        "default": 0,
+        "slider": {
+          "min": 0,
+          "max": 3600,
+          "step": 1
+        },
+        "hint": "围绕基准时间随机前后浮动；0 表示严格按基准时间。"
+      },
+      "read_prob": {
+        "description": "消息触发读说说概率",
+        "type": "float",
+        "default": 0.0,
+        "hint": "收到 OneBot 消息时，按概率查看发送者空间并自动评论；0 表示关闭。"
+      },
+      "send_admin": {
+        "description": "自动评论后反馈管理员",
+        "type": "bool",
+        "default": false,
+        "hint": "预留兼容项。"
+      },
+      "like_when_comment": {
+        "description": "评论时同时点赞",
+        "type": "bool",
+        "default": false,
+        "hint": "评说说和自动评论成功后是否顺手点赞。"
+      }
+    }
+  },
+  "cookies_str": {
+    "description": "Cookie 字符串",
+    "type": "text",
+    "default": "",
+    "hint": "可选；填写后插件初始化时会尝试直接绑定 Cookie。也可以继续使用 /qzone bind。"
+  },
+  "timeout": {
+    "description": "QQ 空间请求超时",
+    "type": "float",
+    "default": 15.0,
+    "hint": "兼容目标插件 timeout 配置；会映射到 request_timeout。"
+  },
+  "show_name": {
+    "description": "展示投稿者昵称",
+    "type": "bool",
+    "default": true,
+    "hint": "匿名投稿仍会隐藏投稿者。"
+  },
   "daemon_port": {
     "description": "Local daemon port",
     "type": "int",
     "default": 18999,
-    "hint": "守护进程监听的本地端口，默认 18999。"
+    "hint": "本地 daemon 监听端口。"
   },
   "keepalive_interval": {
     "description": "Keepalive interval",
     "type": "int",
     "default": 120,
-    "hint": "守护进程的保活间隔，单位秒。"
+    "hint": "daemon 保活间隔，单位秒。"
   },
   "request_timeout": {
     "description": "Request timeout",
@@ -27,7 +189,7 @@
     "description": "Default feed limit",
     "type": "int",
     "default": 5,
-    "hint": "未指定条数时，默认返回的说说数量。"
+    "hint": "未指定条数时默认拉取的说说数量。"
   },
   "max_feed_limit": {
     "description": "Max feed limit",
@@ -39,54 +201,54 @@
     "description": "Auto start daemon",
     "type": "bool",
     "default": true,
-    "hint": "是否在第一次使用时自动启动本地 daemon。"
+    "hint": "第一次使用时自动启动本地 daemon。"
   },
   "auto_bind_cookie": {
     "description": "Auto bind cookie",
     "type": "bool",
     "default": true,
-    "hint": "是否在检测到登录态失效时自动从 OneBot 适配器获取 Cookie。"
+    "hint": "检测到登录态缺失时，尝试从 OneBot 自动获取 Cookie。"
   },
   "cookie_domain": {
     "description": "OneBot cookie domain",
     "type": "text",
     "default": "user.qzone.qq.com",
-    "hint": "向 OneBot 请求 Cookie 时使用的域名，默认 user.qzone.qq.com。"
+    "hint": "向 OneBot 请求 Cookie 时使用的域名。"
   },
   "admin_uins": {
     "description": "Admin QQ numbers",
     "type": "text",
     "default": "",
-    "hint": "可选，多个 QQ 号用英文逗号分隔；这些账号将被当作管理员。"
+    "hint": "多个 QQ 号用英文逗号分隔。"
   },
   "user_agent": {
     "description": "Custom user-agent",
     "type": "text",
     "default": "",
-    "hint": "可选，自定义 QQ 空间请求头里的 User-Agent。"
+    "hint": "自定义 QQ 空间请求头里的 User-Agent。"
   },
   "preview_writes": {
     "description": "Preview write tools",
     "type": "bool",
     "default": true,
-    "hint": "LLM 工具写操作是否默认先输出草稿预览。"
+    "hint": "兼容 LLM 写操作预览开关。"
   },
   "render_publish_result": {
     "description": "Render publish result image",
     "type": "bool",
     "default": true,
-    "hint": "发布说说成功后是否返回 QQ 空间样式的实时渲染图。"
+    "hint": "发布说说成功后返回 QQ 空间风格渲染图。"
   },
   "render_result_width": {
     "description": "Publish result image width",
     "type": "int",
     "default": 900,
-    "hint": "发布结果渲染图宽度，默认 900。"
+    "hint": "发布结果渲染图宽度。"
   },
   "render_remote_timeout": {
     "description": "Publish result remote image timeout",
     "type": "float",
     "default": 0.35,
-    "hint": "发布结果图渲染远程头像或图片预览的单个资源超时，越小越快。"
+    "hint": "发布结果图远程头像或图片预览的单资源超时。"
   }
 }

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-"""AstrBot entry point for the QQ?? bridge."""
+"""AstrBot entry point for the QQ 空间 bridge."""
 
 from __future__ import annotations
 
@@ -6,8 +6,11 @@ import asyncio
 import inspect
 import importlib
 import json
+import random
+import re
 import sys
 import time
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
@@ -31,6 +34,33 @@ SENSITIVE_LOG_KEYS = {
 }
 SENSITIVE_URL_QUERY_KEYS = {"g_tk", "gtk", "p_skey", "skey", "pt4_token", "pt_key", "qzonetoken", "token", "secret"}
 LLM_INTERNAL_KEYS = SENSITIVE_LOG_KEYS | {"raw", "cursor", "fid", "curkey", "unikey", "busi_param"}
+LLM_REPLY_FORBIDDEN_TERMS = (
+    "Result:",
+    "result:",
+    "[TOOL_",
+    "TOOL_",
+    "qzone_like_post",
+    "status_code",
+    "diagnostic",
+    "API",
+    "api",
+    "工具",
+    "系统",
+    "后台",
+    "参数",
+    "指令",
+    "命令",
+    "内部",
+    "错误代码",
+    "状态码",
+    "生成",
+    "绘制",
+    "绘图",
+    "渲染",
+    "处理完成",
+    "任务完成",
+    "已发送",
+)
 
 
 def _redact_url(value: str) -> str:
@@ -101,6 +131,17 @@ def _safe_for_llm(value: Any) -> Any:
     return truncate(str(value), 500)
 
 
+def _public_error_reason(message: Any) -> str:
+    text = str(message or "").strip()
+    text = re.sub(r"^\s*(?:Result|结果)\s*[:：]\s*", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"^\s*\[[A-Z0-9_:-]+\]\s*", "", text)
+    text = re.split(r"(?:\n|【对话要求】|请用|严格禁止|不要提)", text, maxsplit=1)[0].strip()
+    text = text.strip(" \t\r\n:：-—")
+    if not text:
+        return "现在还没办法继续"
+    return truncate(text, 80)
+
+
 def _prepare_local_qzone_bridge_imports() -> None:
     """Force bundled qzone_bridge modules to reload from this plugin directory."""
 
@@ -121,11 +162,13 @@ def _prepare_local_qzone_bridge_imports() -> None:
 _prepare_local_qzone_bridge_imports()
 
 from qzone_bridge.controller import QzoneDaemonController
+from qzone_bridge.drafts import DraftPost, DraftStore
 from qzone_bridge.errors import DaemonUnavailableError, QzoneBridgeError, QzoneCookieAcquireError, QzoneNeedsRebind
-from qzone_bridge.media import PostPayload, collect_post_payload
+from qzone_bridge.media import PostPayload, collect_post_payload, normalize_media_list
 from qzone_bridge.models import FeedEntry
 from qzone_bridge.onebot_cookie import fetch_cookie_text
 from qzone_bridge.parser import normalize_uin, parse_cookie_text
+from qzone_bridge.posts import PostStore
 from qzone_bridge.publish_renderer import RenderProfile, profile_from_event, render_publish_result_image
 from qzone_bridge.render import (
     format_action_result,
@@ -136,7 +179,23 @@ from qzone_bridge.render import (
     format_status,
 )
 from qzone_bridge.settings import PluginSettings
+from qzone_bridge.social import QzoneComment, QzonePost, post_from_entry
 from qzone_bridge.utils import truncate
+
+
+def _identity_filter_decorator(*args: Any, **kwargs: Any):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+if not hasattr(filter, "command"):
+    setattr(filter, "command", _identity_filter_decorator)
+if not hasattr(filter, "permission_type"):
+    setattr(filter, "permission_type", _identity_filter_decorator)
+if not hasattr(filter, "PermissionType"):
+    setattr(filter, "PermissionType", type("PermissionType", (), {"ADMIN": "admin"}))
 
 
 class QzoneStablePlugin(Star):
@@ -161,7 +220,12 @@ class QzoneStablePlugin(Star):
         )
         self._capture_onebot_client_from_context()
         self._daemon_warmup_task: asyncio.Task | None = None
+        self._scheduled_tasks: list[asyncio.Task] = []
         self._publisher_profile_cache: tuple[int, float, Any] | None = None
+        self.drafts = DraftStore(self.data_dir / "drafts.json")
+        self.posts = PostStore(self.data_dir / "posts.json")
+        self._pillowmd_style: Any | None = None
+        self._pillowmd_style_dir = ""
 
     def _sender_id(self, event: AstrMessageEvent) -> int:
         try:
@@ -186,6 +250,42 @@ class QzoneStablePlugin(Star):
     def _command_result(self, event: AstrMessageEvent, text: str):
         self._stop_event(event)
         return event.plain_result(text)
+
+    def _post_store(self) -> PostStore:
+        expected = self.data_dir / "posts.json"
+        if getattr(self.posts, "path", None) != expected:
+            self.posts = PostStore(expected)
+        return self.posts
+
+    @staticmethod
+    def _onebot_file_uri(path: Path) -> str:
+        return "file:///" + path.resolve().as_posix().lstrip("/")
+
+    async def _render_markdown_image(self, text: str, subdir: str = "markdown") -> Path | None:
+        style_dir = str(self.settings.pillowmd_style_dir or "").strip()
+        if not style_dir:
+            return None
+        try:
+            import pillowmd  # type: ignore
+
+            if self._pillowmd_style is None or self._pillowmd_style_dir != style_dir:
+                self._pillowmd_style = pillowmd.LoadMarkdownStyles(style_dir)
+                self._pillowmd_style_dir = style_dir
+            output_dir = self.data_dir / "pillowmd" / subdir
+            output_dir.mkdir(parents=True, exist_ok=True)
+            rendered = await self._pillowmd_style.AioRender(text=text, useImageUrl=True)
+            return Path(rendered.Save(output_dir))
+        except Exception as exc:
+            logger.debug("qzone pillowmd render failed: %s", exc)
+            return None
+
+    async def _markdown_result(self, event: AstrMessageEvent, text: str, subdir: str = "markdown"):
+        image_path = await self._render_markdown_image(text, subdir=subdir)
+        image_result = getattr(event, "image_result", None)
+        if image_path is not None and callable(image_result):
+            self._stop_event(event)
+            return image_result(str(image_path))
+        return self._command_result(event, text)
 
     async def _publisher_render_profile(self, event: AstrMessageEvent) -> Any:
         profile = profile_from_event(event)
@@ -285,7 +385,7 @@ class QzoneStablePlugin(Star):
         *,
         profile_task: asyncio.Task | None = None,
     ):
-        text = format_action_result("????", payload)
+        text = format_action_result("发布结果", payload)
         if not self.settings.render_publish_result:
             self._stop_event(event)
             return event.plain_result(text)
@@ -313,7 +413,7 @@ class QzoneStablePlugin(Star):
             self._stop_event(event)
             return image_result(str(image_path))
         self._stop_event(event)
-        return event.plain_result(f"{text}\n???: {image_path}")
+        return event.plain_result(f"{text}\n图片路径: {image_path}")
 
     def _stop_event(self, event: AstrMessageEvent) -> None:
         stopper = getattr(event, "stop_event", None)
@@ -333,12 +433,12 @@ class QzoneStablePlugin(Star):
                 parts.append(f"HTTP {status_code}")
             location = exc.detail.get("location")
             if location:
-                parts.append(f"?? {location}")
+                parts.append(f"跳转 {location}")
             url = exc.detail.get("url")
             if url:
-                parts.append(f"?? {url}")
+                parts.append(f"地址 {url}")
             if parts:
-                return f"{exc.message}?{', '.join(parts)}?"
+                return f"{exc.message}（{', '.join(parts)}）"
         return f"{exc.message}\n{exc.detail}"
 
     def _log_tool_call_result(self, payload: dict[str, Any]) -> None:
@@ -439,6 +539,8 @@ class QzoneStablePlugin(Star):
         lowered = stripped.lower()
         if stripped.startswith(("{", "[", "```")) or "```json" in lowered:
             return True
+        if re.match(r"^\s*(?:result|结果)\s*[:：]", stripped, flags=re.IGNORECASE):
+            return True
         structured_markers = (
             '"ok"',
             '"tool"',
@@ -454,6 +556,11 @@ class QzoneStablePlugin(Star):
             "'status_code'",
         )
         return sum(1 for marker in structured_markers if marker in lowered) >= 2
+
+    @staticmethod
+    def _llm_reply_mentions_forbidden_terms(text: str) -> bool:
+        lowered = text.lower()
+        return any(term.lower() in lowered for term in LLM_REPLY_FORBIDDEN_TERMS)
 
     @staticmethod
     def _llm_reply_contradicts_payload(text: str, payload: dict[str, Any]) -> bool:
@@ -491,7 +598,56 @@ class QzoneStablePlugin(Star):
             return False
         if cls._llm_reply_looks_structured(text):
             return False
+        if cls._llm_reply_mentions_forbidden_terms(text):
+            return False
         return not cls._llm_reply_contradicts_payload(text, payload)
+
+    @staticmethod
+    def _llm_tool_reply_summary(payload: dict[str, Any]) -> str:
+        if payload.get("ok"):
+            result = payload.get("result")
+            if payload.get("tool") == "qzone_like_post" and isinstance(result, dict):
+                unlike = result.get("action") == "unlike"
+                action = "取消点赞" if unlike else "点赞"
+                summary = truncate(str(result.get("summary") or "").strip(), 60)
+                target = f"「{summary}」" if summary else "这条说说"
+                if result.get("already"):
+                    return f"{target}之前已经是{action}状态。"
+                if result.get("verified") is False:
+                    pending = "取消了" if unlike else "点上了"
+                    return f"{target}这次已经{pending}，QQ 空间显示可能会慢一点。"
+                done = "取消掉了" if unlike else "点好了"
+                return f"{target}这次已经{done}。"
+            visible = _safe_for_llm(result)
+            if isinstance(visible, dict):
+                message = visible.get("message") or visible.get("summary") or visible.get("text")
+                if message:
+                    return str(message)
+            return "这件事已经好了。"
+
+        reason = (
+            payload.get("public_reason")
+            or payload.get("public_message")
+            or payload.get("message")
+            or ""
+        )
+        error = payload.get("error")
+        if not reason and isinstance(error, dict):
+            reason = error.get("message") or ""
+        reason_text = _public_error_reason(reason)
+        return f"现在还没办法继续。可参考的简短原因：{reason_text}"
+
+    @staticmethod
+    def _llm_error_fallback_text(message: Any) -> str:
+        reason = _public_error_reason(message)
+        lowered = reason.lower()
+        if "参考图" in reason or "人设" in reason:
+            return "这会儿还没法弄，等参考内容准备好再来吧。"
+        if "cookie" in lowered or "登录" in reason or "登入" in reason:
+            return "这会儿还没法动空间，登录状态得先补一下。"
+        if "权限" in reason or "管理员" in reason:
+            return "这个我现在不能直接动，得让管理员来。"
+        return "这会儿还没法弄，晚点再试一下吧。"
 
     async def _current_provider_id(self, event: AstrMessageEvent) -> Any | None:
         context = getattr(self, "_context", None) or getattr(self, "context", None)
@@ -517,22 +673,21 @@ class QzoneStablePlugin(Star):
         return None
 
     async def _ask_llm_tool_reply(self, event: AstrMessageEvent, payload: dict[str, Any], fallback: str) -> str:
-        data = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+        summary = self._llm_tool_reply_summary(payload)
         prompt = (
-            "You are writing the final user-facing reply for an AstrBot Qzone tool call.\n"
-            "Input JSON:\n"
-            f"{data}\n"
-            "Rules:\n"
-            "- Reply in Chinese, using one or two short natural-language sentences.\n"
-            "- Do not output JSON, Markdown code fences, or field-by-field explanations.\n"
-            "- Do not expose internal keys such as tool, code, fid, cursor, raw, detail, diagnostic, or status_code.\n"
-            "- Treat ok=true as an accepted tool action. Never rewrite ok=true to ok=false.\n"
-            "- For qzone_like_post, verified=false means QQ readback is stale/eventually consistent after an accepted request. It is not a failure by itself.\n"
-            "- Only say the operation failed when ok=false or an error object is present.\n"
+            "下面这句只是给你理解刚才发生了什么，不要照抄，也不要复述成固定格式：\n"
+            f"{summary}\n"
+            "请沿用当前聊天里的人设和说话习惯，给用户回一句自然中文，像真人顺口聊天。\n"
+            "要求：\n"
+            "- 一句话为主，最多两句；可以很短。\n"
+            "- 不要输出 JSON、Markdown 代码块、字段解释、前缀或标签。\n"
+            "- 不要提工具、系统、后台、API、参数、指令、命令、错误代码、状态码或内部流程。\n"
+            "- 不要说“生成”“绘制”“绘图”“渲染”“处理完成”“任务完成”“已发送”。\n"
+            "- 失败或暂时不可用时，只生活化地说现在还不行或晚点再来，不要展开技术原因。\n"
+            "- 成功时随口收尾一句就好；如果只是显示同步慢，不要说成失败。\n"
         )
         system_prompt = (
-            "You are a careful AstrBot assistant for Qzone. Preserve the tool result semantics and "
-            "turn the structured payload into concise Chinese user-facing text."
+            "沿用当前聊天角色和语气。你只负责把结果变成自然口语回复，不能暴露任何内部实现信息。"
         )
         context = getattr(self, "_context", None) or getattr(self, "context", None)
 
@@ -634,42 +789,29 @@ class QzoneStablePlugin(Star):
 
     @staticmethod
     def _like_fallback_text(payload: dict[str, Any]) -> str:
-        action = "\u53d6\u6d88\u70b9\u8d5e" if payload.get("action") == "unlike" else "\u70b9\u8d5e"
+        unlike = payload.get("action") == "unlike"
+        action = "\u53d6\u6d88\u70b9\u8d5e" if unlike else "\u70b9\u8d5e"
         summary = truncate(str(payload.get("summary") or "").strip(), 60)
         target = f"\u300c{summary}\u300d" if summary else "\u8fd9\u6761\u8bf4\u8bf4"
         if payload.get("verified"):
             if payload.get("already"):
-                return f"{target}\u5df2\u7ecf\u662f{action}\u72b6\u6001\u4e86\u3002"
-            return f"{target}{action}\u6210\u529f\uff0cQQ \u7a7a\u95f4\u72b6\u6001\u5df2\u786e\u8ba4\u3002"
-        return (
-            f"{target}{action}\u8bf7\u6c42\u5df2\u53d1\u9001\uff0cQQ \u7a7a\u95f4\u8bfb\u56de\u53ef\u80fd\u8fd8\u5728"
-            f"\u540c\u6b65\uff0c\u8fd9\u4e0d\u6309\u5931\u8d25\u5904\u7406\u3002"
-        )
+                return f"{target}\u4e4b\u524d\u5c31\u5df2\u7ecf{action}\u4e86\u3002"
+            done = "\u53d6\u6d88\u6389" if unlike else "\u70b9\u597d"
+            return f"{target}\u6211\u5e2e\u4f60{done}\u4e86\u3002"
+        pending = "\u53d6\u6d88\u4e86" if unlike else "\u70b9\u4e0a\u4e86"
+        return f"{target}\u6211\u5148\u5e2e\u4f60{pending}\uff0cQQ \u7a7a\u95f4\u90a3\u8fb9\u53ef\u80fd\u8981\u7b49\u4e00\u4f1a\u513f\u624d\u663e\u793a\u3002"
 
     def _llm_error_payload(self, tool: str, exc: QzoneBridgeError) -> dict[str, Any]:
-        error: dict[str, Any] = {
-            "type": type(exc).__name__,
-            "code": exc.code,
-            "message": exc.message,
-        }
-        status_code = getattr(exc, "status_code", None)
-        if status_code is not None:
-            error["status_code"] = status_code
-        result: dict[str, Any] = {
+        return {
             "ok": False,
-            "tool": tool,
-            "error": error,
-            "reply_guidance": "??? error ? diagnostic ?????????????????????????",
+            "public_reason": _public_error_reason(exc.message),
+            "reply_guidance": "Use a short natural reply in the active persona. Do not expose error details.",
         }
-        diagnostic = _safe_for_llm(exc.detail)
-        if diagnostic not in (None, {}, []):
-            result["diagnostic"] = diagnostic
-        return result
 
     async def _ensure_daemon(self, *, allow_needs_rebind: bool = False) -> None:
         status = await self.controller.get_status()
         if status.get("needs_rebind") and not allow_needs_rebind:
-            raise QzoneNeedsRebind("QQ???????????? Cookie")
+            raise QzoneNeedsRebind("QQ 空间登录态已失效，需要重新绑定 Cookie")
         if allow_needs_rebind:
             if status.get("daemon_state") != "ready":
                 await self.controller.ensure_running()
@@ -678,7 +820,7 @@ class QzoneStablePlugin(Star):
             if status.get("daemon_state") != "ready":
                 await self.controller.ensure_running()
         elif status.get("daemon_state") != "ready":
-            raise DaemonUnavailableError("daemon ???")
+            raise DaemonUnavailableError("daemon 未运行")
 
     def _limit(self, limit: int | None) -> int:
         if not limit or limit <= 0:
@@ -699,12 +841,602 @@ class QzoneStablePlugin(Star):
         text = format_feed_detail(entry)
         comments = payload.get("comments") or []
         if comments:
-            lines = [text, "", "??"]
+            lines = [text, "", "评论"]
             for comment in comments[:5]:
                 nickname = comment.get("nickname") or comment.get("uin") or "-"
                 lines.append(f"- {nickname}: {truncate(str(comment.get('content') or ''), 80)}")
             return "\n".join(lines)
         return text
+
+    @staticmethod
+    def _event_text(event: AstrMessageEvent) -> str:
+        value = getattr(event, "message_str", None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        message_obj = getattr(event, "message_obj", None)
+        parts: list[str] = []
+        for item in getattr(message_obj, "message", []) or []:
+            if isinstance(item, str):
+                parts.append(item)
+                continue
+            text = getattr(item, "text", None)
+            if isinstance(text, str):
+                parts.append(text)
+                continue
+            data = getattr(item, "data", None)
+            if isinstance(data, dict) and isinstance(data.get("text"), str):
+                parts.append(data["text"])
+        return "".join(parts).strip()
+
+    @staticmethod
+    def _message_after_command(text: str, names: tuple[str, ...]) -> str:
+        text = str(text or "").strip()
+        text = re.sub(r"^(?:[!/／]\s*)", "", text).strip()
+        for name in sorted(names, key=len, reverse=True):
+            if text == name:
+                return ""
+            if text.startswith(name):
+                rest = text[len(name):]
+                if not rest or rest[0].isspace() or rest[0] in {":", "："}:
+                    return rest.lstrip(" \t:：")
+        return text
+
+    def _sender_name(self, event: AstrMessageEvent) -> str:
+        for getter in ("get_sender_name", "get_sender_nickname"):
+            method = getattr(event, getter, None)
+            if callable(method):
+                try:
+                    value = method()
+                except Exception:
+                    value = None
+                if value:
+                    return str(value)
+        message_obj = getattr(event, "message_obj", None)
+        sender = getattr(message_obj, "sender", None)
+        for attr in ("nickname", "card", "name"):
+            value = getattr(sender, attr, None)
+            if value:
+                return str(value)
+        return str(self._sender_id(event) or "")
+
+    def _group_id(self, event: AstrMessageEvent) -> int:
+        getter = getattr(event, "get_group_id", None)
+        if callable(getter):
+            try:
+                value = getter()
+                if value:
+                    return int(value)
+            except Exception:
+                pass
+        message_obj = getattr(event, "message_obj", None)
+        try:
+            return int(getattr(message_obj, "group_id", 0) or 0)
+        except Exception:
+            return 0
+
+    def _self_id(self, event: AstrMessageEvent) -> int:
+        getter = getattr(event, "get_self_id", None)
+        if callable(getter):
+            try:
+                value = getter()
+                if value:
+                    return int(value)
+            except Exception:
+                pass
+        try:
+            status = getattr(self.controller, "store", None).read()  # type: ignore[union-attr]
+            return int(status.session.uin or 0)
+        except Exception:
+            return 0
+
+    @staticmethod
+    def _at_uins(event: AstrMessageEvent, text: str = "") -> list[int]:
+        uins: list[int] = []
+        message_obj = getattr(event, "message_obj", None)
+        for item in getattr(message_obj, "message", []) or []:
+            data = getattr(item, "data", None)
+            if isinstance(data, dict):
+                value = data.get("qq") or data.get("uin") or data.get("user_id")
+                if value and str(value).isdigit():
+                    uins.append(int(value))
+            for attr in ("qq", "uin", "user_id"):
+                value = getattr(item, attr, None)
+                if value and str(value).isdigit():
+                    uins.append(int(value))
+        for match in re.finditer(r"\[CQ:at,qq=(\d+)[^\]]*\]|@(\d{5,})", text):
+            value = match.group(1) or match.group(2)
+            if value:
+                uins.append(int(value))
+        deduped: list[int] = []
+        for uin in uins:
+            if uin not in deduped:
+                deduped.append(uin)
+        return deduped
+
+    def _parse_target_range(self, event: AstrMessageEvent, names: tuple[str, ...]) -> tuple[int, int, int]:
+        raw = self._message_after_command(self._event_text(event), names)
+        target = 0
+        at_uins = self._at_uins(event, raw)
+        if at_uins:
+            target = at_uins[0]
+            raw = re.sub(r"\[CQ:at,qq=\d+[^\]]*\]|@\d{5,}", " ", raw, count=1).strip()
+        tokens = raw.split()
+        if not target and tokens and re.fullmatch(r"\d{5,}", tokens[0]):
+            target = int(tokens.pop(0))
+        start = end = 0
+        if tokens:
+            token = tokens[0].strip()
+            match = re.fullmatch(r"(-?\d+)(?:\s*~\s*(-?\d+))?", token)
+            if match:
+                start = int(match.group(1))
+                end = int(match.group(2) if match.group(2) is not None else start)
+                if start >= 0 and end >= 0 and end < start:
+                    start, end = end, start
+        return target, start, end
+
+    async def _posts_for_event(
+        self,
+        event: AstrMessageEvent,
+        names: tuple[str, ...],
+        *,
+        target_id: int | None = None,
+        with_detail: bool = False,
+        no_commented: bool = False,
+        no_self: bool = False,
+    ) -> list[QzonePost]:
+        parsed_target, start, end = self._parse_target_range(event, names)
+        hostuin = int(target_id if target_id is not None else parsed_target)
+        if start < 0 or end < 0:
+            limit = self.settings.max_feed_limit
+        else:
+            limit = min(max(end + 1, 1), self.settings.max_feed_limit)
+        payload = await self.controller.list_feeds(
+            hostuin=hostuin,
+            limit=limit,
+            scope="profile" if hostuin else "",
+        )
+        entries = self._to_feed_entries(payload)
+        if start < 0 or end < 0:
+            selected = entries[-1:] if entries else []
+        else:
+            selected = entries[start : end + 1]
+        login_uin = self._self_id(event)
+        posts: list[QzonePost] = []
+        for offset, entry in enumerate(selected, start=max(start, 0)):
+            detail_payload: dict[str, Any] | None = None
+            if with_detail or no_commented:
+                try:
+                    detail_payload = await self.controller.detail_feed(
+                        hostuin=entry.hostuin,
+                        fid=entry.fid,
+                        appid=entry.appid,
+                    )
+                    entry_data = detail_payload.get("entry")
+                    if isinstance(entry_data, dict):
+                        detail_entry = FeedEntry(**entry_data)
+                        if detail_entry.fid == entry.fid and detail_entry.hostuin == entry.hostuin:
+                            entry = detail_entry
+                except Exception as exc:
+                    if with_detail:
+                        raise
+                    logger.debug("qzone detail fetch for filtering failed: %s", exc)
+            post = post_from_entry(entry, detail=(detail_payload or {}).get("raw"), local_id=offset)
+            if detail_payload and detail_payload.get("comments"):
+                post.comments = [
+                    QzoneComment(
+                        commentid=str(item.get("commentid") or ""),
+                        uin=int(item.get("uin") or 0),
+                        nickname=str(item.get("nickname") or ""),
+                        content=str(item.get("content") or ""),
+                        created_at=int(item.get("created_at") or item.get("date") or 0),
+                        parent_id=str(item.get("parent_id") or ""),
+                    )
+                    for item in detail_payload.get("comments") or []
+                    if isinstance(item, dict)
+                ]
+                post.comment_count = max(post.comment_count, len(post.comments))
+            if no_self and login_uin and post.hostuin == login_uin:
+                continue
+            if no_commented and login_uin and any(comment.uin == login_uin for comment in post.comments):
+                continue
+            self._post_store().upsert(post)
+            posts.append(post)
+        return posts
+
+    @staticmethod
+    def _format_posts(posts: list[QzonePost], *, detail: bool = False) -> str:
+        if not posts:
+            return "没有找到可见说说。"
+        if detail:
+            return "\n\n".join(post.detail_text(post.local_id) for post in posts)
+        return "\n\n".join(post.brief(post.local_id) for post in posts)
+
+    @staticmethod
+    def _format_visitors(payload: dict[str, Any]) -> str:
+        items = payload.get("items") or []
+        if not items:
+            return "暂时没有访客记录。"
+        lines = ["最近访客"]
+        for index, item in enumerate(items[:20], 1):
+            if not isinstance(item, dict):
+                continue
+            name = item.get("nickname") or item.get("uin") or "-"
+            uin = item.get("uin") or ""
+            lines.append(f"{index}. {name} {uin}".strip())
+        return "\n".join(lines)
+
+    def _draft_id_from_event(self, event: AstrMessageEvent, names: tuple[str, ...]) -> tuple[int, str]:
+        raw = self._message_after_command(self._event_text(event), names)
+        parts = raw.split(maxsplit=1)
+        if not parts:
+            return -1, ""
+        try:
+            return int(parts[0]), parts[1] if len(parts) > 1 else ""
+        except ValueError:
+            return -1, raw
+
+    def _collect_target_post_payload(self, event: AstrMessageEvent, content: str, prefixes: tuple[str, ...]) -> PostPayload:
+        return collect_post_payload(
+            event,
+            fallback_content=content,
+            include_event_text=True,
+            command_prefixes=prefixes,
+        )
+
+    def _create_draft(self, event: AstrMessageEvent, post: PostPayload, *, anonymous: bool = False) -> DraftPost:
+        return self.drafts.add(
+            author_uin=self._sender_id(event),
+            author_name=self._sender_name(event),
+            group_id=self._group_id(event),
+            content=post.content,
+            media=[item.to_dict() for item in post.media],
+            anonymous=anonymous,
+        )
+
+    async def _notify_review_target(self, event: AstrMessageEvent, draft: DraftPost, message: str) -> None:
+        bot = self._capture_onebot_client(event)
+        if bot is None:
+            return
+        text = f"{message}\n{draft.preview(include_private=True)}"
+        rendered = await self._render_markdown_image(text, subdir="drafts")
+        outgoing: Any = text
+        if rendered is not None:
+            outgoing = [
+                {"type": "text", "data": {"text": f"{message}\n"}},
+                {"type": "image", "data": {"file": self._onebot_file_uri(rendered)}},
+            ]
+        try:
+            if self.settings.manage_group and hasattr(bot, "send_group_msg"):
+                result = bot.send_group_msg(group_id=self.settings.manage_group, message=outgoing)
+                await self._maybe_await(result)
+                return
+            if hasattr(bot, "send_private_msg"):
+                for admin in self.settings.admin_uins:
+                    result = bot.send_private_msg(user_id=admin, message=outgoing)
+                    await self._maybe_await(result)
+        except Exception as exc:
+            logger.debug("qzone draft review notification failed: %s", exc)
+
+    async def _notify_draft_author(self, event: AstrMessageEvent, draft: DraftPost, message: str) -> None:
+        bot = self._capture_onebot_client(event)
+        if bot is None or not draft.author_uin:
+            return
+        try:
+            if draft.group_id and hasattr(bot, "send_group_msg"):
+                result = bot.send_group_msg(group_id=draft.group_id, message=message)
+            elif hasattr(bot, "send_private_msg"):
+                result = bot.send_private_msg(user_id=draft.author_uin, message=message)
+            else:
+                return
+            await self._maybe_await(result)
+        except Exception as exc:
+            logger.debug("qzone draft author notification failed: %s", exc)
+
+    def _draft_publish_content(self, draft: DraftPost) -> str:
+        content = draft.content.strip()
+        if not self.settings.show_name:
+            return content
+        name = "匿名者" if draft.anonymous else (draft.author_name or str(draft.author_uin or "未知用户"))
+        header = f"【来自 {name} 的投稿】"
+        return "\n\n".join(part for part in (header, content) if part)
+
+    def _auto_comment_state_path(self) -> Path:
+        return self.data_dir / "auto_comment_state.json"
+
+    def _load_auto_comment_keys(self) -> set[str]:
+        path = self._auto_comment_state_path()
+        if not path.exists():
+            return set()
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return set()
+        items = payload.get("commented") if isinstance(payload, dict) else payload
+        if not isinstance(items, list):
+            return set()
+        return {str(item) for item in items if item}
+
+    def _save_auto_comment_keys(self, keys: set[str]) -> None:
+        path = self._auto_comment_state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"commented": sorted(keys)[-500:]}, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    def _auto_comment_key(self, post: QzonePost | FeedEntry) -> str:
+        return f"{int(getattr(post, 'hostuin', 0) or 0)}:{getattr(post, 'fid', '')}"
+
+    async def _chat_history_context(self, event: AstrMessageEvent | None = None) -> str:
+        bot = self._capture_onebot_client(event)
+        if bot is None:
+            return ""
+        group_id = self._group_id(event) if event is not None else 0
+        if group_id and str(group_id) in self.settings.ignore_groups:
+            return ""
+        if not group_id:
+            group_id = await self._pick_history_group_id(bot)
+        if not group_id or str(group_id) in self.settings.ignore_groups:
+            return ""
+        lines = await self._fetch_group_history_lines(bot, group_id)
+        return "\n".join(lines[-self.settings.post_max_msg :])
+
+    async def _pick_history_group_id(self, bot: Any) -> int:
+        getter = getattr(bot, "get_group_list", None)
+        if not callable(getter):
+            return 0
+        try:
+            groups = await self._maybe_await(getter())
+        except Exception:
+            return 0
+        candidates: list[int] = []
+        for item in groups or []:
+            if not isinstance(item, dict):
+                continue
+            group_id = str(item.get("group_id") or "")
+            if group_id.isdigit() and group_id not in self.settings.ignore_groups:
+                candidates.append(int(group_id))
+        return random.choice(candidates) if candidates else 0
+
+    async def _fetch_group_history_lines(self, bot: Any, group_id: int) -> list[str]:
+        lines: list[str] = []
+        message_seq = 0
+        max_messages = max(1, int(self.settings.post_max_msg or 500))
+        while len(lines) < max_messages:
+            try:
+                result = await self._get_group_history_page(bot, group_id, message_seq)
+            except Exception as exc:
+                logger.debug("qzone group history fetch failed: %s", exc)
+                break
+            messages = result.get("messages") if isinstance(result, dict) else []
+            if not isinstance(messages, list) or not messages:
+                break
+            for message in messages:
+                line = self._history_message_to_line(message)
+                if line:
+                    lines.append(line)
+                    if len(lines) >= max_messages:
+                        break
+            first = messages[0] if isinstance(messages[0], dict) else {}
+            next_seq = int(first.get("message_id") or first.get("message_seq") or 0)
+            if not next_seq or next_seq == message_seq:
+                break
+            message_seq = next_seq
+        return lines
+
+    async def _get_group_history_page(self, bot: Any, group_id: int, message_seq: int) -> dict[str, Any]:
+        api = getattr(bot, "api", None)
+        call_action = getattr(api, "call_action", None)
+        payload = {
+            "group_id": int(group_id),
+            "message_seq": int(message_seq or 0),
+            "count": min(200, max(1, int(self.settings.post_max_msg or 500))),
+            "reverseOrder": True,
+        }
+        if callable(call_action):
+            return await self._maybe_await(call_action("get_group_msg_history", **payload))
+        getter = getattr(bot, "get_group_msg_history", None)
+        if callable(getter):
+            return await self._maybe_await(getter(**payload))
+        return {}
+
+    def _history_message_to_line(self, message: Any) -> str:
+        if not isinstance(message, dict):
+            return ""
+        sender = message.get("sender") if isinstance(message.get("sender"), dict) else {}
+        sender_id = str(sender.get("user_id") or message.get("user_id") or "")
+        if sender_id and sender_id in self.settings.ignore_users:
+            return ""
+        nickname = str(sender.get("card") or sender.get("nickname") or sender_id or "用户")
+        parts: list[str] = []
+        for segment in message.get("message") or []:
+            if not isinstance(segment, dict) or segment.get("type") != "text":
+                continue
+            data = segment.get("data") if isinstance(segment.get("data"), dict) else {}
+            text = str(data.get("text") or "").strip()
+            if text:
+                parts.append(text)
+        content = "".join(parts).strip()
+        if not content:
+            return ""
+        return f"{nickname}: {content}"
+
+    async def _generate_text(
+        self,
+        event: AstrMessageEvent,
+        prompt: str,
+        *,
+        provider_id: str = "",
+        system_prompt: str = "",
+    ) -> str:
+        context = getattr(self, "_context", None) or getattr(self, "context", None)
+        provider = None
+        if context is not None:
+            try:
+                getter = getattr(context, "get_provider_by_id", None)
+                provider = getter(provider_id) if provider_id and callable(getter) else None
+            except Exception:
+                provider = None
+            if provider is None:
+                try:
+                    getter = getattr(context, "get_using_provider", None)
+                    provider = getter() if callable(getter) else None
+                except Exception:
+                    provider = None
+        text_chat = getattr(provider, "text_chat", None)
+        if callable(text_chat):
+            kwargs: dict[str, Any] = {"prompt": prompt}
+            if system_prompt:
+                kwargs["system_prompt"] = system_prompt
+            response = await self._maybe_await(text_chat(**kwargs))
+            return self._text_from_llm_response(response)
+        generator = getattr(context, "llm_generate", None)
+        if callable(generator):
+            kwargs: dict[str, Any] = {"prompt": prompt}
+            if system_prompt:
+                kwargs["system_prompt"] = system_prompt
+            if provider_id:
+                kwargs["chat_provider_id"] = provider_id
+            try:
+                response = await self._maybe_await(generator(**kwargs))
+            except TypeError:
+                kwargs.pop("chat_provider_id", None)
+                response = await self._maybe_await(generator(**kwargs))
+            return self._text_from_llm_response(response)
+        return ""
+
+    async def _generate_post_text(self, event: AstrMessageEvent, topic: str = "") -> str:
+        prompt = self.settings.post_prompt
+        if topic.strip():
+            prompt = f"{prompt}\n\n主题：{topic.strip()}"
+        history = await self._chat_history_context(event)
+        if history:
+            prompt = f"{prompt}\n\n聊天记录参考：\n{truncate(history, 8000)}"
+        return await self._generate_text(event, prompt, provider_id=self.settings.post_provider_id)
+
+    async def _generate_comment_text(self, event: AstrMessageEvent, post: QzonePost) -> str:
+        prompt = f"{self.settings.comment_prompt}\n\n说说内容：{post.summary}"
+        text = await self._generate_text(event, prompt, provider_id=self.settings.comment_provider_id)
+        return re.sub(r"[\s\u3000]+", "", text).rstrip("。")
+
+    async def _generate_reply_text(self, event: AstrMessageEvent, post: QzonePost, comment: QzoneComment) -> str:
+        prompt = f"{self.settings.reply_prompt}\n\n说说内容：{post.summary}\n评论：{comment.content}"
+        text = await self._generate_text(event, prompt, provider_id=self.settings.reply_provider_id)
+        return re.sub(r"[\s\u3000]+", "", text).rstrip("。")
+
+    @staticmethod
+    def _cron_delay_seconds(cron: str, offset_seconds: int) -> float:
+        parts = str(cron or "").split()
+        if len(parts) < 2:
+            return 0.0
+        try:
+            minute = int(parts[0])
+            hour = int(parts[1])
+        except ValueError:
+            return 0.0
+        now = datetime.now()
+        target = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        if target <= now:
+            target += timedelta(days=1)
+        offset = int(offset_seconds or 0)
+        if offset > 0:
+            target += timedelta(seconds=random.randint(-offset, offset))
+            if target <= now:
+                target = now + timedelta(seconds=1)
+        return max(1.0, (target - now).total_seconds())
+
+    def _start_scheduled_tasks(self) -> None:
+        if self._scheduled_tasks:
+            return
+        if self.settings.publish_cron:
+            self._scheduled_tasks.append(
+                asyncio.create_task(
+                    self._scheduled_loop("publish", self.settings.publish_cron, self.settings.publish_offset, self._auto_publish_once)
+                )
+            )
+        if self.settings.comment_cron:
+            self._scheduled_tasks.append(
+                asyncio.create_task(
+                    self._scheduled_loop("comment", self.settings.comment_cron, self.settings.comment_offset, self._auto_comment_once)
+                )
+            )
+
+    async def _scheduled_loop(self, name: str, cron: str, offset: int, action: Any) -> None:
+        while True:
+            delay = self._cron_delay_seconds(cron, offset)
+            if delay <= 0:
+                return
+            await asyncio.sleep(delay)
+            try:
+                await action()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("qzone scheduled %s failed: %s", name, exc)
+
+    async def _auto_publish_once(self) -> None:
+        fake_event = None
+        text = await self._generate_post_text(fake_event, "")  # type: ignore[arg-type]
+        if not text.strip():
+            return
+        await self._ensure_cookie_ready()
+        await self._ensure_daemon()
+        await self.controller.publish_post(content=text.strip(), content_sanitized=True)
+
+    async def _auto_comment_once(self) -> None:
+        await self._ensure_cookie_ready()
+        await self._ensure_daemon()
+        payload = await self.controller.list_feeds(hostuin=0, limit=5)
+        entries = self._to_feed_entries(payload)
+        commented_keys = self._load_auto_comment_keys()
+        login_uin = 0
+        try:
+            status = await self.controller.get_status(probe_daemon=False)
+            login_uin = int(status.get("login_uin") or 0)
+        except Exception:
+            pass
+        for entry in entries:
+            if login_uin and entry.hostuin == login_uin:
+                continue
+            key = self._auto_comment_key(entry)
+            if key in commented_keys:
+                continue
+            detail_payload: dict[str, Any] | None = None
+            try:
+                detail_payload = await self.controller.detail_feed(hostuin=entry.hostuin, fid=entry.fid, appid=entry.appid)
+                entry_data = detail_payload.get("entry")
+                if isinstance(entry_data, dict):
+                    detail_entry = FeedEntry(**entry_data)
+                    if detail_entry.fid == entry.fid and detail_entry.hostuin == entry.hostuin:
+                        entry = detail_entry
+            except Exception as exc:
+                logger.debug("qzone scheduled comment detail check failed: %s", exc)
+            post = post_from_entry(entry, detail=(detail_payload or {}).get("raw"), local_id=0)
+            if detail_payload and detail_payload.get("comments"):
+                post.comments = [
+                    QzoneComment(
+                        commentid=str(item.get("commentid") or ""),
+                        uin=int(item.get("uin") or 0),
+                        nickname=str(item.get("nickname") or ""),
+                        content=str(item.get("content") or ""),
+                    )
+                    for item in detail_payload.get("comments") or []
+                    if isinstance(item, dict)
+                ]
+            if login_uin and any(comment.uin == login_uin for comment in post.comments):
+                commented_keys.add(key)
+                self._save_auto_comment_keys(commented_keys)
+                continue
+            self._post_store().upsert(post)
+            text = await self._generate_comment_text(None, post)  # type: ignore[arg-type]
+            if not text.strip():
+                continue
+            await self.controller.comment_post(hostuin=entry.hostuin, fid=entry.fid, content=text.strip(), appid=entry.appid)
+            if self.settings.like_when_comment:
+                await self.controller.like_post(hostuin=entry.hostuin, fid=entry.fid, appid=entry.appid)
+            commented_keys.add(key)
+            self._save_auto_comment_keys(commented_keys)
+            break
 
     def _get_cookie_lock(self) -> asyncio.Lock:
         if self._cookie_lock is None:
@@ -743,7 +1475,7 @@ class QzoneStablePlugin(Star):
         return self._capture_onebot_client_from_context()
 
     def _cookie_binding_hint(self) -> str:
-        return "??? AstrBot ???? aiocqhttp(OneBot v11) ???????? /qzone bind ?? Cookie?"
+        return "没有从 AstrBot 拿到 aiocqhttp(OneBot v11) 客户端，请先用 /qzone bind 手动绑定 Cookie。"
 
     async def _auto_bind_cookie(
         self,
@@ -754,11 +1486,11 @@ class QzoneStablePlugin(Star):
     ) -> dict[str, Any]:
         async with self._get_cookie_lock():
             if not self.settings.auto_bind_cookie and not force:
-                raise QzoneCookieAcquireError("???? Cookie ??????????")
+                raise QzoneCookieAcquireError("自动绑定 Cookie 未开启")
 
             bot = self._capture_onebot_client(event)
             if bot is None:
-                raise QzoneCookieAcquireError(f"???? OneBot ?????????? Cookie?{self._cookie_binding_hint()}")
+                raise QzoneCookieAcquireError(f"无法从 OneBot 获取 Cookie。{self._cookie_binding_hint()}")
 
             try:
                 status = await self.controller.get_status(probe_daemon=False)
@@ -770,7 +1502,7 @@ class QzoneStablePlugin(Star):
 
             cookie_text = await fetch_cookie_text(bot, domain=self.settings.cookie_domain)
             if not cookie_text:
-                raise QzoneCookieAcquireError(f"OneBot ????? Cookie?{self._cookie_binding_hint()}")
+                raise QzoneCookieAcquireError(f"OneBot 没有返回可用 Cookie。{self._cookie_binding_hint()}")
 
             try:
                 cookie_uin = normalize_uin(parse_cookie_text(cookie_text))
@@ -835,34 +1567,405 @@ class QzoneStablePlugin(Star):
 
         self._daemon_warmup_task = asyncio.create_task(runner())
 
+    async def initialize(self):
+        if self.settings.cookies_str:
+            try:
+                await self.controller.bind_cookie_local(self.settings.cookies_str, source="config")
+            except QzoneBridgeError as exc:
+                logger.warning("qzone config cookie bind failed: %s", exc)
+        self._start_scheduled_tasks()
+
     @filter.command_group("qzone")
     def qzone(self):
         pass
 
     @filter.on_platform_loaded()
     async def qzone_on_platform_loaded(self):
+        self._start_scheduled_tasks()
         await self._bootstrap_auto_bind("platform load")
 
     @filter.platform_adapter_type(filter.PlatformAdapterType.AIOCQHTTP)
     async def qzone_capture_aiocqhttp_client(self, event: AstrMessageEvent):
         self._capture_onebot_client(event)
+        if self.settings.read_prob <= 0 or random.random() >= self.settings.read_prob:
+            return
+        group_id = str(self._group_id(event) or "")
+        sender_id = str(self._sender_id(event) or "")
+        if group_id and group_id in self.settings.ignore_groups:
+            return
+        if sender_id and sender_id in self.settings.ignore_users:
+            return
+        try:
+            await self._ensure_cookie_ready(event)
+            await self._ensure_daemon()
+            posts = await self._posts_for_event(
+                event,
+                ("看说说", "查看说说"),
+                target_id=int(sender_id or 0),
+                no_commented=True,
+                no_self=True,
+            )
+            if not posts:
+                return
+            post = posts[0]
+            content = await self._generate_comment_text(event, post)
+            if not content.strip():
+                return
+            await self.controller.comment_post(hostuin=post.hostuin, fid=post.fid, content=content.strip(), appid=post.appid)
+            if self.settings.like_when_comment:
+                await self.controller.like_post(hostuin=post.hostuin, fid=post.fid, appid=post.appid)
+        except Exception as exc:
+            logger.debug("qzone probabilistic read/comment failed: %s", exc)
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("查看访客")
+    async def view_visitor(self, event: AstrMessageEvent):
+        try:
+            await self._ensure_cookie_ready(event)
+            await self._ensure_daemon()
+            payload = await self.controller.view_visitors()
+        except QzoneBridgeError as exc:
+            yield self._command_result(event, self._error_text(exc))
+            return
+        yield await self._markdown_result(event, self._format_visitors(payload), subdir="visitors")
+
+    @filter.command("看说说", alias={"查看说说"})
+    async def view_feed(self, event: AstrMessageEvent):
+        try:
+            await self._ensure_cookie_ready(event)
+            await self._ensure_daemon()
+            posts = await self._posts_for_event(event, ("看说说", "查看说说"), with_detail=True)
+        except QzoneBridgeError as exc:
+            yield self._command_result(event, self._error_text(exc))
+            return
+        yield await self._markdown_result(event, self._format_posts(posts, detail=True), subdir="posts")
+
+    @filter.command("评说说", alias={"评论说说", "读说说"})
+    async def comment_feed(self, event: AstrMessageEvent):
+        try:
+            await self._ensure_cookie_ready(event)
+            await self._ensure_daemon()
+            posts = await self._posts_for_event(
+                event,
+                ("评说说", "评论说说", "读说说"),
+                with_detail=True,
+                no_commented=True,
+                no_self=True,
+            )
+            if not posts:
+                yield self._command_result(event, "没有找到适合评论的说说。")
+                return
+            lines: list[str] = []
+            for post in posts:
+                content = await self._generate_comment_text(event, post)
+                if not content.strip():
+                    content = "挺有意思的。"
+                await self.controller.comment_post(
+                    hostuin=post.hostuin,
+                    fid=post.fid,
+                    content=content.strip(),
+                    appid=post.appid,
+                )
+                if self.settings.like_when_comment:
+                    await self.controller.like_post(hostuin=post.hostuin, fid=post.fid, appid=post.appid)
+                lines.append(f"已评论第 {post.local_id} 条：{truncate(content, 60)}")
+        except QzoneBridgeError as exc:
+            yield self._command_result(event, self._error_text(exc))
+            return
+        yield await self._markdown_result(event, "\n".join(lines), subdir="posts")
+
+    @filter.command("赞说说")
+    async def like_feed(self, event: AstrMessageEvent):
+        try:
+            await self._ensure_cookie_ready(event)
+            await self._ensure_daemon()
+            posts = await self._posts_for_event(event, ("赞说说",))
+            if not posts:
+                yield self._command_result(event, "没有找到可点赞的说说。")
+                return
+            lines: list[str] = []
+            for post in posts:
+                payload = await self.controller.like_post(hostuin=post.hostuin, fid=post.fid, appid=post.appid)
+                lines.append(format_like_result(payload))
+        except QzoneBridgeError as exc:
+            yield self._command_result(event, self._error_text(exc))
+            return
+        yield await self._markdown_result(event, "\n".join(lines), subdir="posts")
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("发说说")
+    async def publish_feed(self, event: AstrMessageEvent, content: str = ""):
+        self._stop_event(event)
+        post = self._collect_target_post_payload(event, content, ("发说说",))
+        profile_task: asyncio.Task | None = None
+        try:
+            await self._ensure_cookie_ready(event)
+            profile_task = self._schedule_publisher_profile(event)
+            payload = await self.controller.publish_post(
+                content=post.content,
+                media=[item.to_dict() for item in post.media],
+                content_sanitized=True,
+            )
+            if payload.get("fid"):
+                self._post_store().upsert(
+                    QzonePost(
+                        hostuin=self._self_id(event),
+                        fid=str(payload.get("fid") or ""),
+                        appid=311,
+                        summary=post.content,
+                        images=[str(item.source) for item in post.media],
+                    )
+                )
+        except QzoneBridgeError as exc:
+            if profile_task is not None:
+                profile_task.cancel()
+            yield self._command_result(event, self._error_text(exc))
+            return
+        yield await self._publish_result(event, post, payload, profile_task=profile_task)
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("写说说", alias={"写稿"})
+    async def write_feed(self, event: AstrMessageEvent):
+        topic = self._message_after_command(self._event_text(event), ("写说说", "写稿"))
+        post = self._collect_target_post_payload(event, topic, ("写说说", "写稿"))
+        try:
+            text = await self._generate_post_text(event, post.content)
+        except Exception as exc:
+            logger.warning("qzone write feed generation failed: %s", exc)
+            text = ""
+        post.content = text.strip() or post.content
+        if not post.content.strip() and not post.media:
+            yield self._command_result(event, "说说生成失败。")
+            return
+        draft = self._create_draft(event, post, anonymous=False)
+        await self._notify_review_target(event, draft, "有一条 AI 写稿等待审核")
+        yield await self._markdown_result(event, f"已生成稿件 #{draft.id}，可用 过稿 {draft.id} 发布。", subdir="drafts")
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("删说说")
+    async def delete_feed(self, event: AstrMessageEvent):
+        try:
+            await self._ensure_cookie_ready(event)
+            await self._ensure_daemon()
+            posts = await self._posts_for_event(
+                event,
+                ("删说说",),
+                target_id=self._self_id(event),
+            )
+            if not posts:
+                yield self._command_result(event, "没有找到可删除的说说。")
+                return
+            lines: list[str] = []
+            for post in posts:
+                payload = await self.controller.delete_post(fid=post.fid, appid=post.appid)
+                lines.append(format_action_result("删除结果", payload))
+        except QzoneBridgeError as exc:
+            yield self._command_result(event, self._error_text(exc))
+            return
+        yield await self._markdown_result(event, "\n".join(lines), subdir="posts")
+
+    @filter.command("回评", alias={"回复评论"})
+    async def reply_comment(self, event: AstrMessageEvent):
+        raw = self._message_after_command(self._event_text(event), ("回评", "回复评论"))
+        parts = raw.split()
+        post_id = int(parts[0]) if parts and re.fullmatch(r"-?\d+", parts[0]) else -1
+        comment_index = int(parts[1]) if len(parts) > 1 and re.fullmatch(r"-?\d+", parts[1]) else -1
+        saved = self._post_store().get(post_id)
+        draft = None if saved else self.drafts.get(post_id)
+        if saved is None and (draft is None or not draft.published_fid):
+            yield self._command_result(event, f"稿件 #{post_id} 不存在或还没有发布。")
+            return
+        try:
+            await self._ensure_cookie_ready(event)
+            await self._ensure_daemon()
+            status = await self.controller.get_status(probe_daemon=False)
+            if saved is not None:
+                hostuin = saved.hostuin
+                fid = saved.fid
+                appid = saved.appid
+            else:
+                hostuin = int(status.get("login_uin") or self._self_id(event) or 0)
+                fid = draft.published_fid  # type: ignore[union-attr]
+                appid = 311
+            detail = await self.controller.detail_feed(hostuin=hostuin, fid=fid, appid=appid)
+            entry = FeedEntry(**detail["entry"])
+            post = post_from_entry(entry, detail=detail.get("raw"), local_id=post_id)
+            if detail.get("comments"):
+                post.comments = [
+                    QzoneComment(
+                        commentid=str(item.get("commentid") or ""),
+                        uin=int(item.get("uin") or 0),
+                        nickname=str(item.get("nickname") or ""),
+                        content=str(item.get("content") or ""),
+                    )
+                    for item in detail.get("comments") or []
+                    if isinstance(item, dict)
+                ]
+            self._post_store().upsert(post)
+            login_uin = int(status.get("login_uin") or 0)
+            comments = [item for item in post.comments if not login_uin or item.uin != login_uin]
+            if not comments:
+                yield self._command_result(event, "这条说说暂时没有可回复的评论。")
+                return
+            comment = comments[comment_index] if 0 <= comment_index < len(comments) else comments[-1]
+            content = await self._generate_reply_text(event, post, comment)
+            if not content.strip():
+                content = "收到啦。"
+            payload = await self.controller.reply_comment(
+                hostuin=hostuin,
+                fid=fid,
+                commentid=comment.commentid,
+                comment_uin=comment.uin,
+                content=content.strip(),
+                appid=post.appid,
+            )
+        except QzoneBridgeError as exc:
+            yield self._command_result(event, self._error_text(exc))
+            return
+        yield await self._markdown_result(event, format_action_result("回复结果", payload), subdir="posts")
+
+    @filter.command("投稿")
+    async def contribute_post(self, event: AstrMessageEvent, content: str = ""):
+        post = self._collect_target_post_payload(event, content, ("投稿",))
+        if not post.content.strip() and not post.media:
+            yield self._command_result(event, "投稿内容或图片不能为空。")
+            return
+        draft = self._create_draft(event, post, anonymous=False)
+        await self._notify_review_target(event, draft, "收到一条投稿")
+        yield await self._markdown_result(event, f"投稿已收到，稿件编号 #{draft.id}。", subdir="drafts")
+
+    @filter.command("匿名投稿")
+    async def anon_contribute_post(self, event: AstrMessageEvent, content: str = ""):
+        post = self._collect_target_post_payload(event, content, ("匿名投稿",))
+        if not post.content.strip() and not post.media:
+            yield self._command_result(event, "投稿内容或图片不能为空。")
+            return
+        draft = self._create_draft(event, post, anonymous=True)
+        await self._notify_review_target(event, draft, "收到一条匿名投稿")
+        yield await self._markdown_result(event, f"匿名投稿已收到，稿件编号 #{draft.id}。", subdir="drafts")
+
+    @filter.command("撤稿")
+    async def recall_post(self, event: AstrMessageEvent):
+        draft_id, _ = self._draft_id_from_event(event, ("撤稿",))
+        draft = self.drafts.get(draft_id)
+        if draft is None:
+            yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
+            return
+        if draft.author_uin != self._sender_id(event) and not self._is_admin(event):
+            yield self._command_result(event, "只能撤回自己的投稿。")
+            return
+        if draft.status != "pending":
+            yield self._command_result(event, f"稿件 #{draft.id} 当前是 {draft.status}，不能撤回。")
+            return
+        draft.status = "recalled"
+        self.drafts.save(draft)
+        yield await self._markdown_result(event, f"稿件 #{draft.id} 已撤回。", subdir="drafts")
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("看稿", alias={"查看稿件"})
+    async def view_post(self, event: AstrMessageEvent):
+        draft_id, _ = self._draft_id_from_event(event, ("看稿", "查看稿件"))
+        if draft_id > 0:
+            draft = self.drafts.get(draft_id)
+            text = draft.preview(include_private=True) if draft else f"稿件 #{draft_id} 不存在。"
+        else:
+            drafts = self.drafts.list(status="pending")[-10:]
+            text = "\n\n".join(draft.preview(include_private=True) for draft in drafts) or "暂无待审核稿件。"
+        yield await self._markdown_result(event, text, subdir="drafts")
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("过稿", alias={"通过稿件", "通过投稿"})
+    async def approve_post(self, event: AstrMessageEvent):
+        draft_id, _ = self._draft_id_from_event(event, ("过稿", "通过稿件", "通过投稿"))
+        draft = self.drafts.get(draft_id)
+        if draft is None:
+            yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
+            return
+        if draft.status != "pending":
+            yield self._command_result(event, f"稿件 #{draft.id} 当前是 {draft.status}，不能过稿。")
+            return
+        post = PostPayload(content=self._draft_publish_content(draft), media=normalize_media_list(draft.media))
+        profile_task: asyncio.Task | None = None
+        try:
+            await self._ensure_cookie_ready(event)
+            profile_task = self._schedule_publisher_profile(event)
+            payload = await self.controller.publish_post(
+                content=post.content,
+                media=[item.to_dict() for item in post.media],
+                content_sanitized=True,
+            )
+            draft.status = "published"
+            draft.published_fid = str(payload.get("fid") or "")
+            self.drafts.save(draft)
+            if draft.published_fid:
+                login_uin = 0
+                try:
+                    login_uin = int((await self.controller.get_status(probe_daemon=False)).get("login_uin") or 0)
+                except Exception:
+                    login_uin = self._self_id(event)
+                saved_post = QzonePost(
+                    hostuin=login_uin,
+                    fid=draft.published_fid,
+                    appid=311,
+                    summary=post.content,
+                    nickname="",
+                    images=[str(item.source) for item in post.media],
+                )
+                self._post_store().upsert(saved_post)
+            await self._notify_draft_author(event, draft, f"你的投稿 #{draft.id} 已通过并发布。")
+        except QzoneBridgeError as exc:
+            if profile_task is not None:
+                profile_task.cancel()
+            yield self._command_result(event, self._error_text(exc))
+            return
+        yield await self._publish_result(event, post, payload, profile_task=profile_task)
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("拒稿", alias={"拒绝稿件", "拒绝投稿"})
+    async def reject_post(self, event: AstrMessageEvent):
+        draft_id, reason = self._draft_id_from_event(event, ("拒稿", "拒绝稿件", "拒绝投稿"))
+        draft = self.drafts.get(draft_id)
+        if draft is None:
+            yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
+            return
+        if draft.status != "pending":
+            yield self._command_result(event, f"稿件 #{draft.id} 当前是 {draft.status}，不能拒稿。")
+            return
+        draft.status = "rejected"
+        draft.reject_reason = reason or "未填写原因"
+        self.drafts.save(draft)
+        await self._notify_draft_author(event, draft, f"你的投稿 #{draft.id} 未通过：{draft.reject_reason}")
+        yield await self._markdown_result(event, f"稿件 #{draft.id} 已拒绝。", subdir="drafts")
 
     @qzone.command("help")
     async def qzone_help(self, event: AstrMessageEvent):
         text = "\n".join(
             [
-                "QQ????",
+                "QQ 空间命令",
+                "查看访客",
+                "看说说/查看说说 [@用户] [序号/范围]",
+                "评说说/评论说说/读说说 [@用户] [序号/范围]",
+                "赞说说 [@用户] [序号/范围]",
+                "发说说 <内容> [图片]",
+                "写说说/写稿 <主题> [图片]",
+                "删说说 <序号>",
+                "回评/回复评论 <稿件ID> [评论序号]",
+                "投稿 <内容> [图片]",
+                "匿名投稿 <内容> [图片]",
+                "撤稿 <稿件ID>",
+                "看稿/查看稿件 [稿件ID]",
+                "过稿/通过稿件/通过投稿 <稿件ID>",
+                "拒稿/拒绝稿件/拒绝投稿 <稿件ID> [原因]",
+                "",
+                "保留的管理命令:",
                 "/qzone status",
                 "/qzone bind <cookie>",
                 "/qzone autobind",
                 "/qzone unbind",
-                "/qzone feed [hostuin] [limit] [cursor]",
-                "/qzone detail <hostuin> <fid> [appid]",
-                "/qzone post <content> [??/????]",
-                "/qzone comment <hostuin> <fid> <content>",
-                "/qzone like <hostuin> <fid> [appid] [unlike]",
                 "",
                 "LLM tools:",
+                "llm_view_feed",
+                "llm_publish_feed",
                 "qzone_get_status",
                 "qzone_list_feed",
                 "qzone_detail_feed",
@@ -876,7 +1979,7 @@ class QzoneStablePlugin(Star):
     @qzone.command("status")
     async def qzone_status(self, event: AstrMessageEvent):
         if not self._is_admin(event):
-            yield self._command_result(event, "??????????")
+            yield self._command_result(event, "只有管理员可以查看状态。")
             return
         try:
             payload = await self._status_with_recovery()
@@ -888,7 +1991,7 @@ class QzoneStablePlugin(Star):
     @qzone.command("bind")
     async def qzone_bind(self, event: AstrMessageEvent, cookie: str):
         if not self._is_admin(event):
-            yield self._command_result(event, "??????? Cookie?")
+            yield self._command_result(event, "只有管理员可以绑定 Cookie。")
             return
         try:
             payload = await self.controller.bind_cookie_local(cookie)
@@ -906,7 +2009,7 @@ class QzoneStablePlugin(Star):
     @qzone.command("autobind")
     async def qzone_autobind(self, event: AstrMessageEvent):
         if not self._is_admin(event):
-            yield self._command_result(event, "????????? Cookie?")
+            yield self._command_result(event, "只有管理员可以自动绑定 Cookie。")
             return
         try:
             payload = await self._auto_bind_cookie(event, force=True, source="aiocqhttp")
@@ -924,7 +2027,7 @@ class QzoneStablePlugin(Star):
     @qzone.command("unbind")
     async def qzone_unbind(self, event: AstrMessageEvent):
         if not self._is_admin(event):
-            yield self._command_result(event, "????????")
+            yield self._command_result(event, "只有管理员可以解绑。")
             return
         try:
             payload = await self.controller.unbind_local()
@@ -933,7 +2036,6 @@ class QzoneStablePlugin(Star):
             return
         yield self._command_result(event, format_status(payload))
 
-    @qzone.command("feed")
     async def qzone_feed(self, event: AstrMessageEvent, hostuin: int = 0, limit: int = 0, cursor: str = ""):
         try:
             await self._ensure_cookie_ready(event)
@@ -950,7 +2052,6 @@ class QzoneStablePlugin(Star):
         text = format_feed_list(entries, cursor=str(payload.get("cursor") or ""), has_more=bool(payload.get("has_more")))
         yield self._command_result(event, text)
 
-    @qzone.command("detail")
     async def qzone_detail(self, event: AstrMessageEvent, hostuin: int, fid: str, appid: int = 311):
         try:
             await self._ensure_cookie_ready(event)
@@ -961,11 +2062,10 @@ class QzoneStablePlugin(Star):
             return
         yield self._command_result(event, self._render_detail(payload))
 
-    @qzone.command("post")
     async def qzone_post(self, event: AstrMessageEvent, content: str = ""):
         self._stop_event(event)
         if not self._is_admin(event):
-            yield self._command_result(event, "?????????")
+            yield self._command_result(event, "只有管理员可以发说说。")
             return
         post = collect_post_payload(
             event,
@@ -989,10 +2089,9 @@ class QzoneStablePlugin(Star):
             return
         yield await self._publish_result(event, post, payload, profile_task=profile_task)
 
-    @qzone.command("comment")
     async def qzone_comment(self, event: AstrMessageEvent, hostuin: int, fid: str, content: str):
         if not self._is_admin(event):
-            yield self._command_result(event, "????????")
+            yield self._command_result(event, "只有管理员可以评论。")
             return
         try:
             await self._ensure_cookie_ready(event)
@@ -1001,12 +2100,11 @@ class QzoneStablePlugin(Star):
         except QzoneBridgeError as exc:
             yield self._command_result(event, self._error_text(exc))
             return
-        yield self._command_result(event, format_action_result("????", payload))
+        yield self._command_result(event, format_action_result("评论结果", payload))
 
-    @qzone.command("like")
     async def qzone_like(self, event: AstrMessageEvent, hostuin: int, fid: str, appid: int = 311, unlike: bool = False):
         if not self._is_admin(event):
-            yield self._command_result(event, "????????")
+            yield self._command_result(event, "只有管理员可以点赞。")
             return
         try:
             await self._ensure_cookie_ready(event)
@@ -1017,15 +2115,85 @@ class QzoneStablePlugin(Star):
             return
         yield self._command_result(event, format_like_result(payload))
 
+    @filter.llm_tool()
+    async def llm_view_feed(
+        self,
+        event: AstrMessageEvent,
+        user_id: str | None = None,
+        pos: int = 0,
+        like: bool = False,
+        reply: bool = False,
+    ):
+        """查看、点赞、评论某位用户 QQ 空间的一条说说。"""
+        try:
+            await self._ensure_cookie_ready(event)
+            await self._ensure_daemon()
+            hostuin = int(user_id or self._sender_id(event) or 0)
+            limit = self.settings.max_feed_limit if pos < 0 else min(max(pos + 1, 1), self.settings.max_feed_limit)
+            payload = await self.controller.list_feeds(hostuin=hostuin, limit=limit, scope="profile")
+            entries = self._to_feed_entries(payload)
+            if not entries:
+                return "查询结果为空。"
+            entry = entries[pos] if 0 <= pos < len(entries) else entries[-1]
+            detail = await self.controller.detail_feed(hostuin=entry.hostuin, fid=entry.fid, appid=entry.appid)
+            entry_data = detail.get("entry")
+            detail_entry = FeedEntry(**entry_data) if isinstance(entry_data, dict) else entry
+            post = post_from_entry(detail_entry, detail=detail.get("raw"), local_id=pos)
+            actions: list[str] = []
+            if reply:
+                content = await self._generate_comment_text(event, post)
+                if not content.strip():
+                    content = "挺有意思的。"
+                await self.controller.comment_post(hostuin=post.hostuin, fid=post.fid, content=content.strip(), appid=post.appid)
+                actions.append("已评论")
+            if like:
+                await self.controller.like_post(hostuin=post.hostuin, fid=post.fid, appid=post.appid)
+                actions.append("已点赞")
+            prefix = "，".join(actions)
+            return "\n".join(part for part in (prefix, post.detail_text(pos)) if part)
+        except Exception as exc:
+            logger.warning("llm_view_feed failed: %s", exc)
+            return str(getattr(exc, "message", str(exc)))
+
+    @filter.llm_tool()
+    async def llm_publish_feed(
+        self,
+        event: AstrMessageEvent,
+        text: str = "",
+        get_image: bool = True,
+    ):
+        """发布一条 QQ 空间说说。"""
+        if not self._is_admin(event):
+            return "只有管理员可以发说说。"
+        post = collect_post_payload(
+            event,
+            fallback_content=text,
+            include_event_text=bool(get_image),
+            command_prefixes=("发说说", "qzone post"),
+        )
+        if not get_image:
+            post.media = []
+        try:
+            await self._ensure_cookie_ready(event)
+            await self._ensure_daemon()
+            payload = await self.controller.publish_post(
+                content=post.content,
+                media=[item.to_dict() for item in post.media],
+                content_sanitized=True,
+            )
+        except QzoneBridgeError as exc:
+            return self._error_text(exc)
+        return f"已发布说说到 QQ 空间：\n{post.content}\n{format_action_result('发布结果', payload)}"
+
     @filter.llm_tool(name="qzone_get_status")
     async def tool_get_status(self, event: AstrMessageEvent):
-        """?? QQ ?? daemon ???
+        """获取 QQ 空间 daemon 状态。
 
         Returns:
-            ???????
+            当前状态摘要。
         """
         if not self._is_admin(event):
-            yield event.plain_result("???????????")
+            yield event.plain_result("只有管理员可以查看 QQ 空间状态。")
             return
         try:
             payload = await self._status_with_recovery()
@@ -1036,12 +2204,12 @@ class QzoneStablePlugin(Star):
 
     @filter.llm_tool(name="qzone_list_feed")
     async def tool_list_feed(self, event: AstrMessageEvent, hostuin: int = 0, limit: int = 5, cursor: str = "", scope: str = ""):
-        """?? QQ ?????
+        """获取 QQ 空间说说列表。
 
         Args:
-            hostuin (number): ?? QQ ??0 ?????????
-            limit (number): ?????
-            cursor (string): ?????
+            hostuin (number): 目标 QQ 号，0 表示当前登录账号。
+            limit (number): 返回数量。
+            cursor (string): 翻页游标。
             scope (string): self ? profile?
         """
         try:
@@ -1061,12 +2229,12 @@ class QzoneStablePlugin(Star):
 
     @filter.llm_tool(name="qzone_detail_feed")
     async def tool_detail_feed(self, event: AstrMessageEvent, hostuin: int, fid: str, appid: int = 311):
-        """?????????
+        """获取说说详情。
 
         Args:
-            hostuin (number): ???? QQ ??
-            fid (string): ?? fid?
-            appid (number): ?? id??? 311?
+            hostuin (number): 目标 QQ 号。
+            fid (string): 说说 fid。
+            appid (number): 应用 id，默认 311。
         """
         try:
             await self._ensure_cookie_ready(event)
@@ -1086,15 +2254,15 @@ class QzoneStablePlugin(Star):
         sync_weibo: bool = False,
         media: list[str] | None = None,
     ):
-        """???? QQ ?????
+        """发布 QQ 空间说说。
 
         Args:
-            content (string): ?????
-            confirm (boolean): ???????
-            sync_weibo (boolean): ???????
+            content (string): 说说内容。
+            confirm (boolean): 是否确认发布。
+            sync_weibo (boolean): 是否同步到微博。
         """
         if not self._is_admin(event):
-            yield event.plain_result("??????????")
+            yield event.plain_result("只有管理员可以发说说。")
             return
         post = collect_post_payload(
             event,
@@ -1104,9 +2272,9 @@ class QzoneStablePlugin(Star):
             extra_media=media,
         )
         if self.settings.preview_writes and not confirm:
-            draft = truncate(post.content or "?????", 120)
-            suffix = f"??? {len(post.media)} ?" if post.media else ""
-            yield event.plain_result(f"?????: {draft}{suffix}????????")
+            draft = truncate(post.content or "空内容", 120)
+            suffix = f"，附带 {len(post.media)} 个媒体" if post.media else ""
+            yield event.plain_result(f"发布预览: {draft}{suffix}。确认后再发布。")
             return
         profile_task: asyncio.Task | None = None
         try:
@@ -1136,22 +2304,22 @@ class QzoneStablePlugin(Star):
         appid: int = 311,
         private: bool = False,
     ):
-        """???????
+        """评论一条说说。
 
         Args:
-            hostuin (number): ?? QQ ??
-            fid (string): ?? fid?
-            content (string): ?????
-            confirm (boolean): ????????????????
-            appid (number): ?? id?
-            private (boolean): ???????
+            hostuin (number): 目标 QQ 号。
+            fid (string): 说说 fid。
+            content (string): 评论内容。
+            confirm (boolean): 是否确认评论。
+            appid (number): 应用 id。
+            private (boolean): 是否私密评论。
         """
         if not self._is_admin(event):
-            yield event.plain_result("????????")
+            yield event.plain_result("只有管理员可以评论。")
             return
         if self.settings.preview_writes and not confirm:
             yield event.plain_result(
-                f"?????: hostuin={hostuin}, fid={fid}, content={truncate(content, 120)}????????"
+                f"评论预览: hostuin={hostuin}, fid={fid}, content={truncate(content, 120)}。确认后再发布。"
             )
             return
         try:
@@ -1167,7 +2335,7 @@ class QzoneStablePlugin(Star):
         except QzoneBridgeError as exc:
             yield event.plain_result(self._error_text(exc))
             return
-        yield event.plain_result(format_action_result("????", payload))
+        yield event.plain_result(format_action_result("评论结果", payload))
 
     @filter.llm_tool(name="qzone_like_post")
     async def tool_like_post(
@@ -1181,16 +2349,16 @@ class QzoneStablePlugin(Star):
         latest: bool = False,
         index: int = 0,
     ):
-        """????????????
+        """点赞或取消点赞一条说说。
 
         Args:
-            hostuin (number): ?? QQ ??`0` ?????? QQ?????????????????????
-            fid (string): ????? fid???????????? N ????????? `latest` / `index`???? `latest`?`?3?` ???????
-            confirm (boolean): ???????????????
-            appid (number): ?? appid???? `311`?
-            unlike (boolean): ? `true` ?????????????
-            latest (boolean): ? `true` ??????? QQ ????????
-            index (number): ?????? QQ ?? N ????`1` ???????
+            hostuin (number): 目标 QQ 号，`0` 表示当前登录账号。
+            fid (string): 说说 fid，也可以用最近列表的序号。
+            confirm (boolean): 兼容旧参数，目前不会拦截执行。
+            appid (number): 说说 appid，默认 `311`。
+            unlike (boolean): 为 `true` 时取消点赞。
+            latest (boolean): 为 `true` 时操作最新一条说说。
+            index (number): 操作最近列表第 N 条，`1` 表示第一条。
         """
         arguments = {
             "hostuin": hostuin,
@@ -1202,18 +2370,26 @@ class QzoneStablePlugin(Star):
             "index": index,
         }
         if not self._is_admin(event):
-            payload = {
+            log_payload = {
                 "ok": False,
                 "tool": "qzone_like_post",
                 "error": {
                     "type": "PermissionError",
                     "code": "QZONE_PERMISSION",
-                    "message": "????????",
+                    "message": "没有权限",
                 },
-                "reply_guidance": "???????????????????",
             }
-            self._log_tool_call_result({**payload, "arguments": arguments})
-            text = await self._ask_llm_tool_reply(event, payload, "????????")
+            self._log_tool_call_result({**log_payload, "arguments": arguments})
+            llm_payload = {
+                "ok": False,
+                "public_reason": "没有权限",
+                "reply_guidance": "Use a short natural reply in the active persona. Do not expose error details.",
+            }
+            text = await self._ask_llm_tool_reply(
+                event,
+                llm_payload,
+                self._llm_error_fallback_text("没有权限"),
+            )
             yield event.plain_result(text)
             return
         try:
@@ -1234,7 +2410,7 @@ class QzoneStablePlugin(Star):
             text = await self._ask_llm_tool_reply(
                 event,
                 llm_payload,
-                exc.message,
+                self._llm_error_fallback_text(exc.message),
             )
             yield event.plain_result(text)
             return
@@ -1254,6 +2430,11 @@ class QzoneStablePlugin(Star):
         yield event.plain_result(text)
 
     async def terminate(self):
+        for task in self._scheduled_tasks:
+            task.cancel()
+        if self._scheduled_tasks:
+            await asyncio.gather(*self._scheduled_tasks, return_exceptions=True)
+            self._scheduled_tasks.clear()
         try:
             await self.controller.close()
         except Exception as exc:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,9 +1,9 @@
 name: astrbot_plugin_qzone_ultra
-version: 0.1.2
+version: 0.2.0
 author: 雪碧bir
-description: QQ空间Ultra bridge with a local daemon and LLM tools.
-desc: QQ空间Ultra bridge with a local daemon and LLM tools.
-short_desc: QQ空间Ultra 接入与 LLM 工具插件
+description: QQ空间Ultra，对标 QQ 空间中文命令体系，支持看/评/赞/发/写/删说说、回评、投稿审核、自动发评和 LLM tools。
+desc: QQ空间Ultra，对标 QQ 空间中文命令体系，支持看/评/赞/发/写/删说说、回评、投稿审核、自动发评和 LLM tools。
+short_desc: QQ空间Ultra 中文命令与 LLM 工具插件
 display_name: QQ空间Ultra
 repo: https://github.com/diaomin66/astrbot_plugin_qzone_ultra
 entry: main.py

--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -1,4 +1,4 @@
-"""Low-level QQ?? HTTP client."""
+"""Low-level QQ 空间 HTTP client."""
 
 from __future__ import annotations
 
@@ -54,6 +54,9 @@ QZONE_LIKE_PROXY_URL = "https://user.qzone.qq.com/proxy/domain/w.qzone.qq.com/cg
 QZONE_UNLIKE_PROXY_URL = "https://user.qzone.qq.com/proxy/domain/w.qzone.qq.com/cgi-bin/likes/internal_unlike_app"
 QZONE_LIKE_URL = QZONE_LIKE_DIRECT_URL
 QZONE_UNLIKE_URL = QZONE_UNLIKE_DIRECT_URL
+QZONE_VISITOR_URL = "https://h5.qzone.qq.com/proxy/domain/g.qzone.qq.com/cgi-bin/friendshow/cgi_get_visitor_more"
+QZONE_REPLY_URL = "https://h5.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_re_feeds"
+QZONE_DELETE_URL = "https://h5.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_delete_v6"
 MAX_UPLOAD_IMAGE_BYTES = 32 * 1024 * 1024
 IMAGE_SOURCE_CACHE_TTL_SECONDS = 10 * 60
 IMAGE_SOURCE_CACHE_MAX_ITEMS = 16
@@ -175,9 +178,9 @@ class QzoneClient:
                     code = 0
                 message = str(payload.get("msg") or payload.get("message") or payload.get("text") or "")
                 if self._payload_needs_rebind(code, message):
-                    raise QzoneNeedsRebind(message or "QQ????????", detail=payload)
+                    raise QzoneNeedsRebind(message or "QQ 空间登录态已失效", detail=payload)
                 code_text = raw_code if raw_code not in (None, "") else code
-                raise QzoneRequestError(message or f"QQ??????? {code_text}", status_code=response.status_code, detail=payload)
+                raise QzoneRequestError(message or f"QQ 空间接口返回错误 {code_text}", status_code=response.status_code, detail=payload)
 
     @staticmethod
     def _response_detail(response: httpx.Response) -> dict[str, Any]:
@@ -299,7 +302,7 @@ class QzoneClient:
         if login_required and not self.session.cookies:
             raise QzoneNeedsRebind()
         if login_required and self.gtk == 0:
-            raise QzoneNeedsRebind("Cookie ??? p_skey ? skey????? g_tk")
+            raise QzoneNeedsRebind("Cookie 缺少 p_skey 或 skey，无法计算 g_tk")
 
         params = self._merge_params(params, hostuin=hostuin, attach_token=attach_token)
         attempts = self.max_retries if max_attempts is None else max(1, int(max_attempts))
@@ -324,7 +327,7 @@ class QzoneClient:
                         if accept_qzone_redirects and self._is_allowed_qzone_redirect(str(response.request.url), location):
                             return response
                         raise QzoneRequestError(
-                            "QQ?? H5 ?????????????????",
+                            "QQ 空间 H5 页面跳转到主页，接口数据不可用",
                             status_code=response.status_code,
                             detail=self._response_detail(response),
                         )
@@ -332,7 +335,7 @@ class QzoneClient:
                         response.status_code in QZONE_REDIRECT_STATUS_CODES and self._is_login_redirect(location)
                     ):
                         raise QzoneNeedsRebind(
-                            "QQ???????????? Cookie",
+                            "QQ 空间登录态已失效，需要重新绑定 Cookie",
                             detail=self._response_detail(response),
                         )
                     if response.status_code in QZONE_REDIRECT_STATUS_CODES:
@@ -354,32 +357,32 @@ class QzoneClient:
                         if accept_qzone_redirects and allowed_redirect:
                             return response
                         raise QzoneRequestError(
-                            f"QQ????????? {response.status_code}",
+                            f"QQ 空间接口跳转异常 {response.status_code}",
                             status_code=response.status_code,
                             detail=self._response_detail(response),
                         )
                     break
                 if response.status_code == 403:
                     raise QzoneRequestError(
-                        "QQ???????????",
+                        "QQ 空间拒绝访问，可能没有权限",
                         status_code=response.status_code,
                         detail=self._response_detail(response),
                     )
                 if response.status_code == 429:
                     raise QzoneRequestError(
-                        "QQ?????????????",
+                        "QQ 空间请求过于频繁，请稍后再试",
                         status_code=response.status_code,
                         detail=self._response_detail(response),
                     )
                 if response.status_code >= 500:
                     raise QzoneRequestError(
-                        f"QQ?????????? ({response.status_code})",
+                        f"QQ 空间服务暂时不可用 ({response.status_code})",
                         status_code=response.status_code,
                         detail=self._response_detail(response),
                     )
                 if response.status_code >= 400:
                     raise QzoneRequestError(
-                        f"QQ???? HTTP {response.status_code}",
+                        f"QQ 空间接口 HTTP {response.status_code}",
                         status_code=response.status_code,
                         detail=self._response_detail(response),
                     )
@@ -416,7 +419,7 @@ class QzoneClient:
             if not json_like:
                 detail = {"text": text[:500], "url": str(response.request.url)}
                 raise QzoneParseError(
-                    "QQ ???????? JSON ??",
+                    "QQ 空间接口返回的内容不是 JSON",
                     detail=detail,
                 ) from (callback_error or json_exc)
             try:
@@ -424,7 +427,7 @@ class QzoneClient:
             except Exception as js_exc:
                 detail = {"text": text[:500], "url": str(response.request.url)}
                 raise QzoneParseError(
-                    "???? QQ ?? JSON ??",
+                    "无法解析 QQ 空间 JSON 内容",
                     detail=detail,
                 ) from (js_exc or json_exc)
 
@@ -473,7 +476,7 @@ class QzoneClient:
         try:
             payload = parse_profile_html(response_text) if profile else parse_index_html(response_text)
         except Exception as exc:
-            raise QzoneParseError("QQ ????????", detail={"text": response_text[:500]}) from exc
+            raise QzoneParseError("QQ 空间页面解析失败", detail={"text": response_text[:500]}) from exc
         return payload
 
     def _store_token(self, hostuin: int, token: str) -> None:
@@ -650,7 +653,7 @@ class QzoneClient:
     async def _load_image_source(self, media: dict[str, Any]) -> tuple[bytes, str, str]:
         item = normalize_media_item(media, default_kind="image")
         if item is None or not item.source:
-            raise QzoneParseError("???????????")
+            raise QzoneParseError("图片来源为空或无效")
 
         source = item.source.strip()
         filename = item.name or source_name(source) or "image.jpg"
@@ -664,19 +667,19 @@ class QzoneClient:
             try:
                 return base64.b64decode(source[len("base64://") :], validate=False), filename, mime_type
             except Exception as exc:
-                raise QzoneParseError("???? base64 ????") from exc
+                raise QzoneParseError("图片 base64 解码失败") from exc
         if source.startswith("data:"):
             try:
                 header, encoded = source.split(",", 1)
             except ValueError as exc:
-                raise QzoneParseError("???? data URI ????") from exc
+                raise QzoneParseError("图片 data URI 格式错误") from exc
             header_mime = header[5:].split(";", 1)[0]
             if ";base64" not in header:
-                raise QzoneParseError("data URI ?????? base64 ??")
+                raise QzoneParseError("data URI 必须使用 base64 编码")
             try:
                 data = base64.b64decode(encoded, validate=False)
             except Exception as exc:
-                raise QzoneParseError("???? data URI ????") from exc
+                raise QzoneParseError("图片 data URI 解码失败") from exc
             return data, filename, mime_type or header_mime
 
         if parsed.scheme.lower() in {"http", "https"}:
@@ -691,14 +694,14 @@ class QzoneClient:
                     if response.status_code >= 400:
                         text = (await response.aread()).decode("utf-8", errors="ignore")
                         raise QzoneRequestError(
-                            f"?????? HTTP {response.status_code}",
+                            f"图片下载失败 HTTP {response.status_code}",
                             status_code=response.status_code,
                             detail={"url": source, "text": text[:500]},
                         )
                     length = response.headers.get("content-length")
                     try:
                         if length and int(length) > MAX_UPLOAD_IMAGE_BYTES:
-                            raise QzoneParseError("?????????????", detail={"url": source})
+                            raise QzoneParseError("图片大小超过限制", detail={"url": source})
                     except ValueError:
                         pass
                     chunks: list[bytes] = []
@@ -708,10 +711,10 @@ class QzoneClient:
                             continue
                         total += len(chunk)
                         if total > MAX_UPLOAD_IMAGE_BYTES:
-                            raise QzoneParseError("?????????????", detail={"url": source})
+                            raise QzoneParseError("图片大小超过限制", detail={"url": source})
                         chunks.append(chunk)
             except httpx.HTTPError as exc:
-                raise QzoneRequestError("??????", detail={"url": source}) from exc
+                raise QzoneRequestError("图片下载失败", detail={"url": source}) from exc
             content_type = response.headers.get("content-type", "").split(";", 1)[0]
             data = b"".join(chunks)
             self._store_image_source_cache(source, data, content_type)
@@ -720,10 +723,10 @@ class QzoneClient:
         path = Path(source)
         def read_local_image() -> bytes:
             if not path.exists() or not path.is_file():
-                raise QzoneParseError("???????", detail={"path": source})
+                raise QzoneParseError("图片文件不存在", detail={"path": source})
             stat = path.stat()
             if stat.st_size > MAX_UPLOAD_IMAGE_BYTES:
-                raise QzoneParseError("?????????????", detail={"path": source})
+                raise QzoneParseError("图片大小超过限制", detail={"path": source})
             return path.read_bytes()
 
         data = await asyncio.to_thread(read_local_image)
@@ -733,7 +736,7 @@ class QzoneClient:
     def _photo_payload_from_upload(payload: dict[str, Any], *, filename: str = "", mime_type: str = "") -> dict[str, Any]:
         data = unwrap_payload(payload)
         if not isinstance(data, dict):
-            raise QzoneParseError("??????????", detail=payload)
+            raise QzoneParseError("图片上传返回格式异常", detail=payload)
         albumid = str(data.get("albumid") or data.get("albumId") or "")
         lloc = str(data.get("lloc") or data.get("LLoc") or "")
         sloc = str(data.get("sloc") or data.get("SLoc") or "")
@@ -741,7 +744,7 @@ class QzoneClient:
         height = str(data.get("height") or data.get("h") or 0)
         width = str(data.get("width") or data.get("w") or 0)
         if not albumid or not lloc or not sloc:
-            raise QzoneParseError("???????? richval ??", detail=data)
+            raise QzoneParseError("图片上传返回缺少 richval 字段", detail=data)
         url = str(data.get("url") or data.get("origin_url") or data.get("originUrl") or data.get("pre") or "")
         pic_bo = str(data.get("pic_bo") or data.get("picBo") or QzoneClient._extract_pic_bo(url) or "")
         richval = f",{albumid},{lloc},{sloc},{photo_type},{height},{width},,{height},{width}"
@@ -760,10 +763,10 @@ class QzoneClient:
     async def upload_photo(self, media: dict[str, Any]) -> dict[str, Any]:
         item = normalize_media_item(media, default_kind="image")
         if item is None or not is_supported_image(item):
-            raise QzoneParseError("QQ?????????????", detail=media)
+            raise QzoneParseError("QQ 空间只支持上传图片文件", detail=media)
         data, filename, mime_type = await self._load_image_source(item.to_dict())
         if not data:
-            raise QzoneParseError("???????????", detail={"name": filename})
+            raise QzoneParseError("图片内容为空或无法读取", detail={"name": filename})
 
         encoded_bytes = await asyncio.to_thread(base64.b64encode, data)
         encoded = encoded_bytes.decode("ascii")
@@ -810,7 +813,7 @@ class QzoneClient:
 
     async def _prepare_publish_photos(self, photos: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
         if photos and len(photos) > QZONE_MAX_IMAGES:
-            raise QzoneParseError(f"QQ???????? {QZONE_MAX_IMAGES} ???")
+            raise QzoneParseError(f"QQ 空间一次最多只能上传 {QZONE_MAX_IMAGES} 张图片")
         source_photos = list(photos or [])
         prepared: list[dict[str, Any] | None] = [None] * len(source_photos)
         pending: list[tuple[int, dict[str, Any]]] = []
@@ -850,7 +853,7 @@ class QzoneClient:
 
         final = [photo for photo in prepared if photo is not None]
         if len(final) > QZONE_MAX_IMAGES:
-            raise QzoneParseError(f"QQ???????? {QZONE_MAX_IMAGES} ???")
+            raise QzoneParseError(f"QQ 空间一次最多只能上传 {QZONE_MAX_IMAGES} 张图片")
         return final
 
     async def publish_mood(self, content: str, *, sync_weibo: bool = False, photos: list[dict[str, Any]] | None = None) -> dict[str, Any]:
@@ -926,6 +929,89 @@ class QzoneClient:
             referer=f"https://user.qzone.qq.com/{hostuin}/mood/{fid}",
             origin="https://user.qzone.qq.com",
             hostuin=hostuin,
+            attach_token=False,
+        )
+        return payload
+
+    async def get_visitors(self, *, page: int = 1, count: int = 20) -> dict[str, Any]:
+        payload = await self._request_json(
+            "GET",
+            QZONE_VISITOR_URL,
+            params={
+                "uin": self.login_uin,
+                "mask": 7,
+                "mod": 2,
+                "fupdate": 1,
+                "page": max(1, int(page or 1)),
+                "count": max(1, min(int(count or 20), 50)),
+                "format": "json",
+            },
+            referer=f"https://user.qzone.qq.com/{self.login_uin}",
+            hostuin=self.login_uin,
+            attach_token=False,
+        )
+        return payload
+
+    async def reply_comment(
+        self,
+        hostuin: int,
+        fid: str,
+        commentid: str,
+        comment_uin: int,
+        content: str,
+        *,
+        appid: int = 311,
+    ) -> dict[str, Any]:
+        payload = await self._request_json(
+            "POST",
+            QZONE_REPLY_URL,
+            data={
+                "topicId": f"{hostuin}_{fid}__1",
+                "uin": self.login_uin,
+                "hostUin": hostuin,
+                "feedsType": 100,
+                "inCharset": "utf-8",
+                "outCharset": "utf-8",
+                "plat": "qzone",
+                "source": "ic",
+                "platformid": 52,
+                "format": "fs",
+                "ref": "feeds",
+                "content": content,
+                "commentId": commentid,
+                "commentUin": comment_uin,
+                "private": 0,
+                "appid": appid,
+                "richval": "",
+                "richtype": "",
+            },
+            referer=f"https://user.qzone.qq.com/{hostuin}/mood/{fid}",
+            origin="https://user.qzone.qq.com",
+            hostuin=hostuin,
+            attach_token=False,
+        )
+        return payload
+
+    async def delete_post(self, fid: str, *, appid: int = 311) -> dict[str, Any]:
+        payload = await self._request_json(
+            "POST",
+            QZONE_DELETE_URL,
+            data={
+                "uin": self.login_uin,
+                "topicId": f"{self.login_uin}_{fid}__1",
+                "feedsType": 0,
+                "feedsFlag": 0,
+                "feedsKey": fid,
+                "feedsAppid": appid,
+                "feedsTime": int(time.time()),
+                "fupdate": 1,
+                "ref": "feeds",
+                "format": "json",
+                "qzreferrer": f"https://user.qzone.qq.com/{self.login_uin}",
+            },
+            referer=f"https://user.qzone.qq.com/{self.login_uin}/mood/{fid}",
+            origin="https://user.qzone.qq.com",
+            hostuin=self.login_uin,
             attach_token=False,
         )
         return payload
@@ -1020,13 +1106,13 @@ class QzoneClient:
 
         if isinstance(last_exc, QzoneRequestError):
             status_code = last_exc.status_code
-            message = f"{last_exc.message}??????????"
+            message = f"{last_exc.message}；所有点赞入口都尝试失败"
         elif last_exc is not None:
             status_code = None
-            message = f"{getattr(last_exc, 'message', str(last_exc))}??????????"
+            message = f"{getattr(last_exc, 'message', str(last_exc))}；所有点赞入口都尝试失败"
         else:
             status_code = None
-            message = "QQ???????????????????"
+            message = "QQ 空间点赞入口不可用，请稍后再试"
         raise QzoneRequestError(message, status_code=status_code, detail={"attempts": attempts}) from last_exc
 
     async def detail(self, hostuin: int, fid: str, *, appid: int = 311, busi_param: str = "") -> dict[str, Any]:

--- a/qzone_bridge/controller.py
+++ b/qzone_bridge/controller.py
@@ -416,7 +416,7 @@ class QzoneDaemonController:
                         break
                 if not found_port:
                     exc = DaemonUnavailableError(
-                        "QQ?? daemon ????????????????",
+                        "QQ 空间 daemon 端口被占用，未找到可用备用端口",
                         detail={"daemon_port": port, "checked_ports": f"{port + 1}-{port + 32}"},
                     )
                     self._record_daemon_start_error(exc, port=port)
@@ -428,7 +428,7 @@ class QzoneDaemonController:
 
             if not self._daemon_script().exists():
                 exc = DaemonUnavailableError(
-                    "??? daemon_main.py",
+                    "找不到 daemon_main.py",
                     detail={"path": str(self._daemon_script())},
                 )
                 self._record_daemon_start_error(exc, port=port)
@@ -438,7 +438,7 @@ class QzoneDaemonController:
                 self._process = self._spawn_daemon(port)
             except OSError as exc:
                 error = DaemonUnavailableError(
-                    "QQ?? daemon ????",
+                    "QQ 空间 daemon 启动失败",
                     detail=self._daemon_start_detail(port, error=str(exc)),
                 )
                 self._record_daemon_start_error(error, port=port)
@@ -469,7 +469,7 @@ class QzoneDaemonController:
 
             returncode = self._process.poll() if self._process else None
             error = DaemonUnavailableError(
-                "QQ?? daemon ????",
+                "QQ 空间 daemon 启动超时",
                 detail=self._daemon_start_detail(port, returncode=returncode),
             )
             self._record_daemon_start_error(error, port=port)
@@ -491,7 +491,7 @@ class QzoneDaemonController:
                 await self.ensure_running()
                 runtime = self._runtime()
             elif not await self._probe_health(runtime.daemon_port):
-                raise DaemonUnavailableError("daemon ???")
+                raise DaemonUnavailableError("daemon 未运行")
             try:
                 response = await self._client.request(
                     method,
@@ -506,18 +506,18 @@ class QzoneDaemonController:
                 last_exc = exc
                 if not self.auto_start_daemon or attempt > 0:
                     raise DaemonUnavailableError(
-                        "daemon ????",
+                        "daemon 请求失败",
                         detail={"error": str(exc), "path": path},
                     ) from exc
         if response is None:
             raise DaemonUnavailableError(
-                "daemon ????",
+                "daemon 请求失败",
                 detail={"error": str(last_exc), "path": path},
             )
         try:
             payload = response.json()
         except Exception as exc:
-            raise DaemonUnavailableError("daemon ???? JSON ??", detail={"text": response.text[:500]}) from exc
+            raise DaemonUnavailableError("daemon 返回的 JSON 无法解析", detail={"text": response.text[:500]}) from exc
         if not payload.get("ok", False):
             error = payload.get("error") or {}
             code = str(error.get("code") or "DAEMON_ERROR")
@@ -552,10 +552,10 @@ class QzoneDaemonController:
     @staticmethod
     def cookie_summary(cookies: dict[str, str]) -> str:
         if not cookies:
-            return "???"
+            return "无 Cookie"
         keys = ["uin", "p_uin", "skey", "p_skey", "pt4_token", "pt_key"]
         found = [key for key in keys if key in cookies]
-        return f"{len(cookies)}???: " + ", ".join(found or ["????"])
+        return f"{len(cookies)} 个 Cookie: " + ", ".join(found or ["未识别关键字段"])
 
     async def bind_cookie(self, cookie_text: str, *, uin: int = 0, source: str = "manual") -> dict[str, Any]:
         return await self._request("POST", "/bind", json_body={"cookie_text": cookie_text, "uin": uin, "source": source})
@@ -568,10 +568,10 @@ class QzoneDaemonController:
         except DaemonUnavailableError:
             cookies = parse_cookie_text(cookie_text)
             if not cookies:
-                raise QzoneParseError("Cookie ???????")
+                raise QzoneParseError("Cookie 内容为空或无法解析")
             resolved_uin = normalize_uin(cookies, override=uin)
             if not resolved_uin:
-                raise QzoneParseError("Cookie ???? uin / p_uin???????")
+                raise QzoneParseError("Cookie 缺少 uin / p_uin，无法识别登录 QQ")
 
             state = self.store.read()
             runtime = self._runtime()
@@ -630,6 +630,13 @@ class QzoneDaemonController:
             params={"hostuin": hostuin, "fid": fid, "appid": appid, "busi_param": busi_param},
         )
 
+    async def view_visitors(self, *, page: int = 1, count: int = 20) -> dict[str, Any]:
+        return await self._request(
+            "GET",
+            "/visitors",
+            params={"page": page, "count": count},
+        )
+
     async def publish_post(
         self,
         *,
@@ -671,6 +678,36 @@ class QzoneDaemonController:
                 "appid": appid,
                 "private": private,
             },
+        )
+
+    async def reply_comment(
+        self,
+        *,
+        hostuin: int,
+        fid: str,
+        commentid: str,
+        comment_uin: int,
+        content: str,
+        appid: int = 311,
+    ) -> dict[str, Any]:
+        return await self._request(
+            "POST",
+            "/reply",
+            json_body={
+                "hostuin": hostuin,
+                "fid": fid,
+                "commentid": commentid,
+                "comment_uin": comment_uin,
+                "content": content,
+                "appid": appid,
+            },
+        )
+
+    async def delete_post(self, *, fid: str, appid: int = 311) -> dict[str, Any]:
+        return await self._request(
+            "POST",
+            "/delete",
+            json_body={"fid": fid, "appid": appid},
         )
 
     async def like_post(

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -27,6 +27,7 @@ from .parser import (
     unwrap_payload,
 )
 from .protocol import SECRET_HEADER, fail, ok
+from .social import extract_comments
 from .storage import StateStore, ensure_state_secret
 from .utils import now_iso, from_iso
 
@@ -44,7 +45,7 @@ LATEST_FEED_REFERENCES = {
 }
 FEED_REFERENCE_PREFIXES = ("\u7b2c",)
 FEED_REFERENCE_SUFFIXES = ("\u6761",)
-LOSSY_LATEST_FEED_REFERENCES = {"??", "????"}
+LOSSY_LATEST_FEED_REFERENCES = {"最新", "最近"}
 
 
 class QzoneDaemonService:
@@ -222,10 +223,10 @@ class QzoneDaemonService:
     async def bind_cookie(self, cookie_text: str, *, uin: int = 0, source: str = "manual") -> dict[str, Any]:
         cookies = parse_cookie_text(cookie_text)
         if not cookies:
-            raise QzoneParseError("Cookie ???????")
+            raise QzoneParseError("Cookie 内容为空或无法解析")
         resolved_uin = normalize_uin(cookies, override=uin)
         if not resolved_uin:
-            raise QzoneParseError("Cookie ???? uin / p_uin???????")
+            raise QzoneParseError("Cookie 缺少 uin / p_uin，无法识别登录 QQ")
         self.state.session = SessionState(
             uin=resolved_uin,
             cookies=cookies,
@@ -344,28 +345,36 @@ class QzoneDaemonService:
         await self.ensure_token(hostuin)
         payload = unwrap_payload(await self.client.detail(hostuin, fid, appid=appid, busi_param=busi_param))
         if not isinstance(payload, dict):
-            raise QzoneParseError("??????????")
+            raise QzoneParseError("说说详情返回格式异常")
         entry = self.client.feed_entry_from_payload(payload, default_hostuin=hostuin)
         self.client.cache_feed_page(hostuin, [entry])
-        comments = []
-        comment_block = payload.get("comment")
-        if isinstance(comment_block, dict):
-            raw_comments = comment_block.get("comments") or []
-            if isinstance(raw_comments, list):
-                for item in raw_comments:
-                    if not isinstance(item, dict):
-                        continue
-                    comments.append(
-                        {
-                            "commentid": item.get("commentid"),
-                            "content": item.get("content") or "",
-                            "date": item.get("date") or 0,
-                            "nickname": (item.get("user") or {}).get("nickname") if isinstance(item.get("user"), dict) else "",
-                            "uin": (item.get("user") or {}).get("uin") if isinstance(item.get("user"), dict) else 0,
-                            "is_private": bool(item.get("isPrivate") or False),
-                        }
-                    )
+        comments = [item.to_dict() for item in extract_comments(payload)]
         return {"entry": asdict(entry), "comments": comments, "raw": payload}
+
+    async def view_visitors(self, *, page: int = 1, count: int = 20) -> dict[str, Any]:
+        self._ensure_session_ready()
+        payload = unwrap_payload(await self.client.get_visitors(page=page, count=count))
+        if not isinstance(payload, dict):
+            raise QzoneParseError("访客列表返回格式异常")
+        raw_items = payload.get("items") or payload.get("visitors") or payload.get("data") or payload.get("list") or []
+        if isinstance(raw_items, dict):
+            raw_items = raw_items.get("items") or raw_items.get("list") or raw_items.get("visitors") or []
+        visitors: list[dict[str, Any]] = []
+        if isinstance(raw_items, list):
+            for item in raw_items:
+                if not isinstance(item, dict):
+                    continue
+                user = item.get("user") if isinstance(item.get("user"), dict) else {}
+                visitors.append(
+                    {
+                        "uin": int(item.get("uin") or user.get("uin") or item.get("user_id") or 0),
+                        "nickname": item.get("nickname") or user.get("nickname") or item.get("name") or "",
+                        "time": item.get("time") or item.get("visitTime") or item.get("timestamp") or 0,
+                        "raw": item,
+                    }
+                )
+        self._set_success(defer_save=True)
+        return {"items": visitors, "count": len(visitors), "raw": payload}
 
     async def publish_post(
         self,
@@ -381,12 +390,12 @@ class QzoneDaemonService:
         normalized_media = normalize_media_list(media)
         photos, fallback_media = split_publishable_images(normalized_media)
         if len(photos) > QZONE_MAX_IMAGES:
-            raise QzoneParseError(f"QQ???????? {QZONE_MAX_IMAGES} ???")
+            raise QzoneParseError(f"QQ 空间一次最多只能上传 {QZONE_MAX_IMAGES} 张图片")
         if fallback_media:
             refs = "\n".join(media_reference_text(item) for item in fallback_media)
             content = "\n".join(part for part in (content.strip(), refs) if part)
         if not content.strip() and not photos:
-            raise QzoneParseError("????????")
+            raise QzoneParseError("说说内容或图片不能为空")
         self._ensure_session_ready()
         payload = unwrap_payload(
             await self.client.publish_mood(
@@ -396,7 +405,7 @@ class QzoneDaemonService:
             )
         )
         if not isinstance(payload, dict):
-            raise QzoneParseError("??????????")
+            raise QzoneParseError("说说发布返回格式异常")
         self._set_success(defer_save=True)
         return {
             "fid": payload.get("fid") or payload.get("tid") or "",
@@ -416,15 +425,61 @@ class QzoneDaemonService:
         private: bool = False,
     ) -> dict[str, Any]:
         if not content.strip():
-            raise QzoneParseError("????????")
+            raise QzoneParseError("评论内容不能为空")
         self._ensure_session_ready()
         payload = unwrap_payload(await self.client.add_comment(hostuin, fid, content, appid=appid, private=private))
         if not isinstance(payload, dict):
-            raise QzoneParseError("????????")
+            raise QzoneParseError("评论发布返回格式异常")
         self._set_success(defer_save=True)
         return {
             "commentid": payload.get("commentid") or payload.get("commentId") or 0,
             "commentLikekey": payload.get("commentLikekey") or "",
+            "message": payload.get("msg") or payload.get("message") or "",
+            "raw": payload,
+        }
+
+    async def reply_comment(
+        self,
+        *,
+        hostuin: int,
+        fid: str,
+        commentid: str,
+        comment_uin: int,
+        content: str,
+        appid: int = 311,
+    ) -> dict[str, Any]:
+        if not content.strip():
+            raise QzoneParseError("回复内容不能为空")
+        self._ensure_session_ready()
+        payload = unwrap_payload(
+            await self.client.reply_comment(
+                hostuin,
+                fid,
+                commentid,
+                comment_uin,
+                content,
+                appid=appid,
+            )
+        )
+        if not isinstance(payload, dict):
+            raise QzoneParseError("回复评论返回格式异常")
+        self._set_success(defer_save=True)
+        return {
+            "commentid": payload.get("commentid") or payload.get("commentId") or 0,
+            "message": payload.get("msg") or payload.get("message") or "",
+            "raw": payload,
+        }
+
+    async def delete_post(self, *, fid: str, appid: int = 311) -> dict[str, Any]:
+        if not str(fid or "").strip():
+            raise QzoneParseError("说说 fid 不能为空")
+        self._ensure_session_ready()
+        payload = unwrap_payload(await self.client.delete_post(str(fid), appid=appid))
+        if not isinstance(payload, dict):
+            raise QzoneParseError("删除说说返回格式异常")
+        self._set_success(defer_save=True)
+        return {
+            "fid": fid,
             "message": payload.get("msg") or payload.get("message") or "",
             "raw": payload,
         }
@@ -513,7 +568,7 @@ class QzoneDaemonService:
             feed_payload = await self.list_feeds(hostuin=target_hostuin, limit=reference_index, scope="profile")
             items = feed_payload.get("items") or []
             if reference_index > len(items):
-                raise QzoneParseError(f"???? {reference_index} ???????")
+                raise QzoneParseError(f"第 {reference_index} 条说说不存在")
             entry = FeedEntry(**items[reference_index - 1])
             return entry.hostuin, entry.fid, entry.appid or appid, curkey or entry.curkey
         return target_hostuin, fid_text, int(appid or 311), curkey
@@ -599,7 +654,7 @@ class QzoneDaemonService:
             index=index,
         )
         if not hostuin or not fid:
-            raise QzoneParseError("????????????????")
+            raise QzoneParseError("没有指定要点赞的说说")
 
         target_liked = not unlike
         before_entry = await self._refresh_like_entry(hostuin, fid, appid)
@@ -740,7 +795,7 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
     async def auth_middleware(request: web.Request, handler):
         secret = request.headers.get(SECRET_HEADER) or request.query.get("secret") or ""
         if secret != service.state.runtime.secret:
-            return fail("UNAUTHORIZED", "secret ???", status=401)
+            return fail("UNAUTHORIZED", "secret 不正确", status=401)
         return await handler(request)
 
     app.middlewares.append(auth_middleware)
@@ -794,6 +849,16 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
             return fail(exc.code, exc.message, detail=_error_detail(exc))
         return ok(payload)
 
+    async def visitors(request: web.Request) -> web.Response:
+        page = int(request.query.get("page") or 1)
+        count = int(request.query.get("count") or 20)
+        try:
+            payload = await service.view_visitors(page=page, count=count)
+        except QzoneBridgeError as exc:
+            service._set_error(exc)
+            return fail(exc.code, exc.message, detail=_error_detail(exc))
+        return ok(payload)
+
     async def post(request: web.Request) -> web.Response:
         body = await _json_body(request)
         content = str(body.get("content") or "")
@@ -821,6 +886,34 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
                 content=str(body.get("content") or ""),
                 appid=int(body.get("appid") or 311),
                 private=bool(body.get("private") or False),
+            )
+        except QzoneBridgeError as exc:
+            service._set_error(exc)
+            return fail(exc.code, exc.message, detail=_error_detail(exc))
+        return ok(payload)
+
+    async def reply(request: web.Request) -> web.Response:
+        body = await _json_body(request)
+        try:
+            payload = await service.reply_comment(
+                hostuin=int(body.get("hostuin") or 0),
+                fid=str(body.get("fid") or ""),
+                commentid=str(body.get("commentid") or body.get("commentId") or ""),
+                comment_uin=int(body.get("comment_uin") or body.get("commentUin") or 0),
+                content=str(body.get("content") or ""),
+                appid=int(body.get("appid") or 311),
+            )
+        except QzoneBridgeError as exc:
+            service._set_error(exc)
+            return fail(exc.code, exc.message, detail=_error_detail(exc))
+        return ok(payload)
+
+    async def delete(request: web.Request) -> web.Response:
+        body = await _json_body(request)
+        try:
+            payload = await service.delete_post(
+                fid=str(body.get("fid") or ""),
+                appid=int(body.get("appid") or 311),
             )
         except QzoneBridgeError as exc:
             service._set_error(exc)
@@ -858,8 +951,11 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
     app.router.add_post("/unbind", unbind)
     app.router.add_get("/feeds", feeds)
     app.router.add_get("/detail", detail)
+    app.router.add_get("/visitors", visitors)
     app.router.add_post("/post", post)
     app.router.add_post("/comment", comment)
+    app.router.add_post("/reply", reply)
+    app.router.add_post("/delete", delete)
     app.router.add_post("/like", like)
     app.router.add_post("/shutdown", shutdown)
     return app

--- a/qzone_bridge/drafts.py
+++ b/qzone_bridge/drafts.py
@@ -1,0 +1,164 @@
+"""Persistent draft store for target-style campus-wall workflows."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+DraftStatus = Literal["pending", "approved", "rejected", "recalled", "published"]
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(slots=True)
+class DraftPost:
+    id: int
+    author_uin: int
+    author_name: str = ""
+    group_id: int = 0
+    content: str = ""
+    media: list[dict[str, Any]] = field(default_factory=list)
+    anonymous: bool = False
+    status: DraftStatus = "pending"
+    reject_reason: str = ""
+    published_fid: str = ""
+    created_at: str = field(default_factory=now_iso)
+    updated_at: str = field(default_factory=now_iso)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "DraftPost":
+        status = str(data.get("status") or "pending")
+        if status not in {"pending", "approved", "rejected", "recalled", "published"}:
+            status = "pending"
+        return cls(
+            id=int(data.get("id") or 0),
+            author_uin=int(data.get("author_uin") or 0),
+            author_name=str(data.get("author_name") or ""),
+            group_id=int(data.get("group_id") or 0),
+            content=str(data.get("content") or ""),
+            media=list(data.get("media") or []),
+            anonymous=bool(data.get("anonymous") or False),
+            status=status,  # type: ignore[arg-type]
+            reject_reason=str(data.get("reject_reason") or ""),
+            published_fid=str(data.get("published_fid") or ""),
+            created_at=str(data.get("created_at") or now_iso()),
+            updated_at=str(data.get("updated_at") or now_iso()),
+        )
+
+    def title(self) -> str:
+        author = "匿名投稿" if self.anonymous else (self.author_name or str(self.author_uin or "未知用户"))
+        return f"稿件 #{self.id} · {author} · {self.status}"
+
+    def preview(self, *, include_private: bool = True) -> str:
+        lines = [self.title()]
+        if include_private and not self.anonymous:
+            lines.append(f"投稿人: {self.author_name or self.author_uin}")
+        if self.group_id:
+            lines.append(f"来源群: {self.group_id}")
+        if self.content:
+            lines.append(self.content)
+        if self.media:
+            lines.append(f"媒体: {len(self.media)} 个")
+        if self.reject_reason:
+            lines.append(f"拒绝原因: {self.reject_reason}")
+        if self.published_fid:
+            lines.append(f"已发布 fid: {self.published_fid}")
+        return "\n".join(lines)
+
+
+class DraftStore:
+    def __init__(self, path: Path):
+        self.path = path
+
+    def _read_payload(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {"next_id": 1, "items": []}
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except Exception:
+            return {"next_id": 1, "items": []}
+        if not isinstance(payload, dict):
+            return {"next_id": 1, "items": []}
+        payload.setdefault("next_id", 1)
+        payload.setdefault("items", [])
+        return payload
+
+    def _write_payload(self, payload: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def list(self, *, status: str | None = None) -> list[DraftPost]:
+        payload = self._read_payload()
+        items = [DraftPost.from_dict(item) for item in payload.get("items") or [] if isinstance(item, dict)]
+        if status:
+            items = [item for item in items if item.status == status]
+        return sorted(items, key=lambda item: item.id)
+
+    def get(self, draft_id: int | None = None) -> DraftPost | None:
+        items = self.list()
+        if not items:
+            return None
+        if not draft_id or draft_id < 0:
+            pending = [item for item in items if item.status == "pending"]
+            return pending[-1] if pending else items[-1]
+        for item in items:
+            if item.id == draft_id:
+                return item
+        return None
+
+    def add(
+        self,
+        *,
+        author_uin: int,
+        author_name: str = "",
+        group_id: int = 0,
+        content: str = "",
+        media: list[dict[str, Any]] | None = None,
+        anonymous: bool = False,
+    ) -> DraftPost:
+        payload = self._read_payload()
+        draft_id = int(payload.get("next_id") or 1)
+        draft = DraftPost(
+            id=draft_id,
+            author_uin=author_uin,
+            author_name=author_name,
+            group_id=group_id,
+            content=content,
+            media=list(media or []),
+            anonymous=anonymous,
+        )
+        items = [item for item in payload.get("items") or [] if isinstance(item, dict)]
+        items.append(draft.to_dict())
+        payload["items"] = items
+        payload["next_id"] = draft_id + 1
+        self._write_payload(payload)
+        return draft
+
+    def save(self, draft: DraftPost) -> DraftPost:
+        draft.updated_at = now_iso()
+        payload = self._read_payload()
+        items: list[dict[str, Any]] = []
+        found = False
+        for item in payload.get("items") or []:
+            if not isinstance(item, dict):
+                continue
+            if int(item.get("id") or 0) == draft.id:
+                items.append(draft.to_dict())
+                found = True
+            else:
+                items.append(item)
+        if not found:
+            items.append(draft.to_dict())
+        payload["items"] = items
+        payload["next_id"] = max(int(payload.get("next_id") or 1), draft.id + 1)
+        self._write_payload(payload)
+        return draft
+

--- a/qzone_bridge/posts.py
+++ b/qzone_bridge/posts.py
@@ -1,0 +1,159 @@
+"""Persistent cache for target-style Qzone post operations."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .social import QzoneComment, QzonePost
+
+
+@dataclass(slots=True)
+class SavedPost:
+    id: int
+    hostuin: int
+    fid: str
+    appid: int = 311
+    summary: str = ""
+    nickname: str = ""
+    created_at: int = 0
+    like_count: int = 0
+    comment_count: int = 0
+    liked: bool = False
+    images: list[str] = field(default_factory=list)
+    comments: list[dict[str, Any]] = field(default_factory=list)
+
+    @classmethod
+    def from_post(cls, post: QzonePost, post_id: int) -> "SavedPost":
+        return cls(
+            id=post_id,
+            hostuin=post.hostuin,
+            fid=post.fid,
+            appid=post.appid,
+            summary=post.summary,
+            nickname=post.nickname,
+            created_at=post.created_at,
+            like_count=post.like_count,
+            comment_count=post.comment_count,
+            liked=post.liked,
+            images=list(post.images),
+            comments=[comment.to_dict() for comment in post.comments],
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "SavedPost":
+        return cls(
+            id=int(data.get("id") or 0),
+            hostuin=int(data.get("hostuin") or 0),
+            fid=str(data.get("fid") or ""),
+            appid=int(data.get("appid") or 311),
+            summary=str(data.get("summary") or ""),
+            nickname=str(data.get("nickname") or ""),
+            created_at=int(data.get("created_at") or 0),
+            like_count=int(data.get("like_count") or 0),
+            comment_count=int(data.get("comment_count") or 0),
+            liked=bool(data.get("liked") or False),
+            images=[str(item) for item in data.get("images") or []],
+            comments=[item for item in data.get("comments") or [] if isinstance(item, dict)],
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_post(self) -> QzonePost:
+        comments = [
+            QzoneComment(
+                commentid=str(item.get("commentid") or ""),
+                uin=int(item.get("uin") or 0),
+                nickname=str(item.get("nickname") or ""),
+                content=str(item.get("content") or ""),
+                created_at=int(item.get("created_at") or item.get("date") or 0),
+                parent_id=str(item.get("parent_id") or item.get("parentId") or ""),
+            )
+            for item in self.comments
+            if isinstance(item, dict)
+        ]
+        return QzonePost(
+            hostuin=self.hostuin,
+            fid=self.fid,
+            appid=self.appid,
+            summary=self.summary,
+            nickname=self.nickname,
+            created_at=self.created_at,
+            like_count=self.like_count,
+            comment_count=max(self.comment_count, len(comments)),
+            liked=self.liked,
+            images=list(self.images),
+            comments=comments,
+            saved_id=self.id,
+        )
+
+
+class PostStore:
+    def __init__(self, path: Path):
+        self.path = path
+
+    def _read_payload(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {"next_id": 1, "items": []}
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except Exception:
+            return {"next_id": 1, "items": []}
+        if not isinstance(payload, dict):
+            return {"next_id": 1, "items": []}
+        payload.setdefault("next_id", 1)
+        payload.setdefault("items", [])
+        return payload
+
+    def _write_payload(self, payload: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def list(self) -> list[SavedPost]:
+        payload = self._read_payload()
+        return sorted(
+            [SavedPost.from_dict(item) for item in payload.get("items") or [] if isinstance(item, dict)],
+            key=lambda item: item.id,
+        )
+
+    def get(self, post_id: int | None = None) -> SavedPost | None:
+        items = self.list()
+        if not items:
+            return None
+        if not post_id or post_id < 0:
+            return items[-1]
+        for item in items:
+            if item.id == post_id:
+                return item
+        return None
+
+    def upsert(self, post: QzonePost) -> SavedPost:
+        payload = self._read_payload()
+        items = [item for item in payload.get("items") or [] if isinstance(item, dict)]
+        next_id = int(payload.get("next_id") or 1)
+        matched_id = 0
+        updated_items: list[dict[str, Any]] = []
+        for item in items:
+            if (
+                str(item.get("fid") or "") == str(post.fid or "")
+                and int(item.get("hostuin") or 0) == int(post.hostuin or 0)
+                and str(post.fid or "")
+            ):
+                matched_id = int(item.get("id") or 0) or next_id
+                updated_items.append(SavedPost.from_post(post, matched_id).to_dict())
+            else:
+                updated_items.append(item)
+
+        if not matched_id:
+            matched_id = next_id
+            updated_items.append(SavedPost.from_post(post, matched_id).to_dict())
+            next_id += 1
+
+        payload["items"] = updated_items
+        payload["next_id"] = max(next_id, matched_id + 1)
+        self._write_payload(payload)
+        post.saved_id = matched_id
+        return SavedPost.from_post(post, matched_id)

--- a/qzone_bridge/render.py
+++ b/qzone_bridge/render.py
@@ -10,7 +10,7 @@ from .utils import to_local_time_text, truncate
 
 def cookie_summary(cookies: dict[str, str]) -> str:
     if not cookies:
-        return "???"
+        return "无 Cookie"
     keys = [
         "uin",
         "p_uin",
@@ -28,12 +28,12 @@ def cookie_summary(cookies: dict[str, str]) -> str:
     ]
     found = [key for key in keys if key in cookies]
     extras = len(cookies) - len(found)
-    return f"{len(cookies)}???: " + ", ".join(found + ([f"??{extras}?"] if extras > 0 else []))
+    return f"{len(cookies)} 个 Cookie: " + ", ".join(found + ([f"另 {extras} 个"] if extras > 0 else []))
 
 
 def format_status(status: dict) -> str:
     lines = [
-        "QQ????",
+        "QQ 空间状态",
         f"- daemon: {status.get('daemon_state', 'unknown')}",
         f"- login: {status.get('login_uin') or '-'}",
         f"- source: {status.get('session_source') or '-'}",
@@ -48,7 +48,7 @@ def format_status(status: dict) -> str:
         lines.append(f"- pid: {status['daemon_pid']}")
     start_error = status.get("daemon_start_error")
     if isinstance(start_error, dict):
-        message = start_error.get("message") or "daemon ????"
+        message = start_error.get("message") or "daemon 启动失败"
         lines.append(f"- daemon_error: {message}")
         detail = start_error.get("detail")
         if isinstance(detail, dict):
@@ -71,8 +71,8 @@ def format_feed_entry(entry: FeedEntry, index: int | None = None, *, include_int
             f"like={entry.like_count} comment={entry.comment_count} liked={entry.liked}"
         )
     else:
-        liked_text = "???" if entry.liked else "???"
-        lines.append(f"   {liked_text}?{entry.like_count} ??{entry.comment_count} ??")
+        liked_text = "已赞" if entry.liked else "未赞"
+        lines.append(f"   {liked_text} | {entry.like_count} 赞 | {entry.comment_count} 评论")
     lines.append(f"   {headline}")
     return "\n".join(lines)
 
@@ -101,14 +101,14 @@ def format_feed_list(
 def format_llm_feed_list(entries: Iterable[FeedEntry]) -> str:
     entries = list(entries)
     if not entries:
-        return "???????????"
+        return "没有找到可展示的说说。"
     body = format_feed_list(entries, include_internal=False, include_pagination=False)
-    return f"{body}\n?????????????????"
+    return f"{body}\n可以用上面的序号继续指定要查看或操作的说说。"
 
 
 def format_feed_detail(entry: FeedEntry) -> str:
     lines = [
-        "????",
+        "说说详情",
         f"- hostuin: {entry.hostuin}",
         f"- fid: {entry.fid}",
         f"- appid: {entry.appid}",
@@ -133,14 +133,14 @@ def format_action_result(title: str, payload: dict) -> str:
 
 
 def format_like_result(payload: dict) -> str:
-    action = "????" if payload.get("action") == "unlike" else "??"
+    action = "取消点赞" if payload.get("action") == "unlike" else "点赞"
     summary = truncate(str(payload.get("summary") or ""), 80)
-    suffix = f"?{summary}" if summary else ""
+    suffix = f"「{summary}」" if summary else ""
     if payload.get("verified"):
         if payload.get("already"):
-            state = "??????"
+            state = "已经是目标状态"
         else:
-            state = "??"
-        liked = "?????" if payload.get("liked") else "?????"
-        return f"{action}{state}{suffix}?{liked}??"
-    return f"{action}???????????? QQ ????{suffix}?"
+            state = "已完成"
+        liked = "当前已点赞" if payload.get("liked") else "当前未点赞"
+        return f"{action}{state}{suffix}，{liked}。"
+    return f"{action}已受理，QQ 空间可能还在同步{suffix}。"

--- a/qzone_bridge/settings.py
+++ b/qzone_bridge/settings.py
@@ -41,6 +41,30 @@ def _pick(mapping: dict[str, Any], key: str, default: Any) -> Any:
     return default
 
 
+def _nested(mapping: dict[str, Any], section: str, key: str, default: Any) -> Any:
+    section_value = mapping.get(section)
+    if isinstance(section_value, dict) and key in section_value:
+        return section_value[key]
+    nested = mapping.get("qzone")
+    if isinstance(nested, dict):
+        section_value = nested.get(section)
+        if isinstance(section_value, dict) and key in section_value:
+            return section_value[key]
+    return default
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    return [value]
+
+
 def _as_bool(value: Any, default: bool) -> bool:
     if value is None:
         return default
@@ -72,19 +96,42 @@ class PluginSettings:
     render_publish_result: bool = True
     render_result_width: int = 900
     render_remote_timeout: float = 0.35
+    manage_group: int = 0
+    pillowmd_style_dir: str = ""
+    post_provider_id: str = ""
+    post_prompt: str = "找出一个你感兴趣的主题来写一段适合 QQ 空间的说说，简短、有个性、不要解释。"
+    comment_provider_id: str = ""
+    comment_prompt: str = "生成一句简短、直接、贴题的评论，不要解释。"
+    reply_provider_id: str = ""
+    reply_prompt: str = "这条帖子收到了一条评论，请自然回复此条评论，不要解释。"
+    ignore_groups: list[str] = field(default_factory=list)
+    ignore_users: list[str] = field(default_factory=list)
+    post_max_msg: int = 500
+    publish_cron: str = ""
+    publish_offset: int = 0
+    comment_cron: str = ""
+    comment_offset: int = 0
+    read_prob: float = 0.0
+    send_admin: bool = False
+    like_when_comment: bool = False
+    cookies_str: str = ""
+    show_name: bool = True
 
     @classmethod
     def from_mapping(cls, config: Any) -> "PluginSettings":
         mapping = _as_mapping(config)
         admin_uins = _pick(mapping, "admin_uins", [])
+        if not admin_uins:
+            admin_uins = _pick(mapping, "admins_id", [])
         if isinstance(admin_uins, str):
             admin_uins = [int(item.strip()) for item in admin_uins.split(",") if item.strip().isdigit()]
         if not isinstance(admin_uins, list):
             admin_uins = []
+        timeout = _pick(mapping, "timeout", None)
         return cls(
             daemon_port=int(_pick(mapping, "daemon_port", 18999) or 18999),
             keepalive_interval=int(_pick(mapping, "keepalive_interval", 120) or 120),
-            request_timeout=float(_pick(mapping, "request_timeout", 15.0) or 15.0),
+            request_timeout=float(_pick(mapping, "request_timeout", timeout if timeout is not None else 15.0) or 15.0),
             start_timeout=float(_pick(mapping, "start_timeout", 20.0) or 20.0),
             public_feed_limit=int(_pick(mapping, "public_feed_limit", 5) or 5),
             max_feed_limit=int(_pick(mapping, "max_feed_limit", 20) or 20),
@@ -98,4 +145,40 @@ class PluginSettings:
             render_publish_result=_as_bool(_pick(mapping, "render_publish_result", True), True),
             render_result_width=int(_pick(mapping, "render_result_width", 900) or 900),
             render_remote_timeout=float(_pick(mapping, "render_remote_timeout", 0.35) or 0.35),
+            manage_group=int(_pick(mapping, "manage_group", 0) or 0),
+            pillowmd_style_dir=str(_pick(mapping, "pillowmd_style_dir", "") or ""),
+            post_provider_id=str(_nested(mapping, "llm", "post_provider_id", "") or ""),
+            post_prompt=str(_nested(mapping, "llm", "post_prompt", cls.post_prompt) or cls.post_prompt),
+            comment_provider_id=str(_nested(mapping, "llm", "comment_provider_id", "") or ""),
+            comment_prompt=str(_nested(mapping, "llm", "comment_prompt", cls.comment_prompt) or cls.comment_prompt),
+            reply_provider_id=str(_nested(mapping, "llm", "reply_provider_id", "") or ""),
+            reply_prompt=str(_nested(mapping, "llm", "reply_prompt", cls.reply_prompt) or cls.reply_prompt),
+            ignore_groups=[str(item) for item in _as_list(_nested(mapping, "source", "ignore_groups", []))],
+            ignore_users=[str(item) for item in _as_list(_nested(mapping, "source", "ignore_users", []))],
+            post_max_msg=int(_nested(mapping, "source", "post_max_msg", 500) or 500),
+            publish_cron=str(_nested(mapping, "trigger", "publish_cron", "") or ""),
+            publish_offset=int(
+                _nested(
+                    mapping,
+                    "trigger",
+                    "publish_offset",
+                    _nested(mapping, "trigger", "publish_offset_minutes", 0),
+                )
+                or 0
+            ),
+            comment_cron=str(_nested(mapping, "trigger", "comment_cron", "") or ""),
+            comment_offset=int(
+                _nested(
+                    mapping,
+                    "trigger",
+                    "comment_offset",
+                    _nested(mapping, "trigger", "comment_offset_minutes", 0),
+                )
+                or 0
+            ),
+            read_prob=float(_nested(mapping, "trigger", "read_prob", 0.0) or 0.0),
+            send_admin=_as_bool(_nested(mapping, "trigger", "send_admin", False), False),
+            like_when_comment=_as_bool(_nested(mapping, "trigger", "like_when_comment", False), False),
+            cookies_str=str(_pick(mapping, "cookies_str", "") or ""),
+            show_name=_as_bool(_pick(mapping, "show_name", True), True),
         )

--- a/qzone_bridge/social.py
+++ b/qzone_bridge/social.py
@@ -1,0 +1,227 @@
+"""Target-style Qzone post and comment adapters."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from html import unescape
+from typing import Any, Iterable
+
+from .models import FeedEntry
+from .utils import truncate
+
+
+TAG_RE = re.compile(r"<[^>]+>")
+EM_RE = re.compile(r"\[em\].*?\[/em\]")
+
+
+def _to_int(value: Any, default: int = 0) -> int:
+    try:
+        if value in (None, ""):
+            return default
+        return int(value)
+    except Exception:
+        return default
+
+
+def clean_qzone_text(value: Any) -> str:
+    text = str(value or "")
+    text = EM_RE.sub("", text)
+    text = TAG_RE.sub("", text)
+    return unescape(text).strip()
+
+
+def _first_mapping(*values: Any) -> dict[str, Any]:
+    for value in values:
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def _first_text(raw: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = raw.get(key)
+        if value not in (None, ""):
+            return clean_qzone_text(value)
+    return ""
+
+
+def _iter_mappings(value: Any) -> Iterable[dict[str, Any]]:
+    if isinstance(value, dict):
+        yield value
+    elif isinstance(value, list):
+        for item in value:
+            if isinstance(item, dict):
+                yield item
+
+
+@dataclass(slots=True)
+class QzoneComment:
+    commentid: str
+    uin: int = 0
+    nickname: str = ""
+    content: str = ""
+    created_at: int = 0
+    parent_id: str = ""
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def brief(self, index: int | None = None) -> str:
+        prefix = f"{index}. " if index is not None else ""
+        name = self.nickname or str(self.uin or "")
+        return f"{prefix}{name}: {truncate(self.content, 80)}"
+
+
+@dataclass(slots=True)
+class QzonePost:
+    hostuin: int
+    fid: str
+    appid: int = 311
+    summary: str = ""
+    nickname: str = ""
+    created_at: int = 0
+    like_count: int = 0
+    comment_count: int = 0
+    liked: bool = False
+    images: list[str] = field(default_factory=list)
+    comments: list[QzoneComment] = field(default_factory=list)
+    local_id: int = 0
+    saved_id: int = 0
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["comments"] = [item.to_dict() for item in self.comments]
+        return data
+
+    def brief(self, index: int | None = None) -> str:
+        prefix = f"{index}. " if index is not None else ""
+        saved = f"稿件 #{self.saved_id} | " if self.saved_id else ""
+        liked = "已赞" if self.liked else "未赞"
+        name = self.nickname or str(self.hostuin or "")
+        return (
+            f"{prefix}{saved}{name}({self.hostuin})\n"
+            f"{truncate(self.summary, 220)}\n"
+            f"{liked} | {self.like_count} 赞 | {self.comment_count} 评论"
+        )
+
+    def detail_text(self, index: int | None = None, *, max_comments: int = 8) -> str:
+        lines = [self.brief(index)]
+        if self.images:
+            lines.append("图片: " + ", ".join(self.images[:9]))
+        if self.comments:
+            lines.append("评论:")
+            for offset, comment in enumerate(self.comments[:max_comments]):
+                lines.append(comment.brief(offset))
+        return "\n".join(lines)
+
+
+def comment_from_raw(raw: dict[str, Any], *, parent_id: str = "") -> QzoneComment:
+    user = _first_mapping(raw.get("user"), raw.get("userinfo"), raw.get("commenter"))
+    commentid = raw.get("commentid") or raw.get("commentId") or raw.get("tid") or raw.get("id") or ""
+    uin = _to_int(raw.get("uin") or raw.get("commentUin") or user.get("uin") or user.get("user_id"))
+    nickname = _first_text(user, "nickname", "name", "uinname") or _first_text(raw, "nickname", "name")
+    content = _first_text(raw, "content", "commentContent", "htmlContent", "text")
+    created_at = _to_int(raw.get("date") or raw.get("created_at") or raw.get("pubtime") or raw.get("abstime"))
+    return QzoneComment(
+        commentid=str(commentid),
+        uin=uin,
+        nickname=nickname,
+        content=content,
+        created_at=created_at,
+        parent_id=str(parent_id or raw.get("parentId") or raw.get("parent_tid") or ""),
+        raw=dict(raw),
+    )
+
+
+def _extract_nested_replies(raw: dict[str, Any], parent_id: str) -> list[QzoneComment]:
+    replies: list[QzoneComment] = []
+    for key in ("replyList", "replylist", "replies", "list_3", "children"):
+        for item in _iter_mappings(raw.get(key)):
+            replies.append(comment_from_raw(item, parent_id=parent_id))
+            replies.extend(_extract_nested_replies(item, parent_id=str(item.get("commentid") or item.get("tid") or parent_id)))
+    return replies
+
+
+def extract_comments(payload: dict[str, Any]) -> list[QzoneComment]:
+    candidates: list[Any] = []
+    comment_block = payload.get("comment")
+    if isinstance(comment_block, dict):
+        candidates.extend(
+            [
+                comment_block.get("comments"),
+                comment_block.get("commentlist"),
+                comment_block.get("list"),
+            ]
+        )
+    candidates.extend(
+        [
+            payload.get("comments"),
+            payload.get("commentlist"),
+            payload.get("list_3"),
+        ]
+    )
+    data = payload.get("data")
+    if isinstance(data, dict):
+        candidates.extend([data.get("comments"), data.get("commentlist")])
+
+    comments: list[QzoneComment] = []
+    seen: set[tuple[str, int, str]] = set()
+    for candidate in candidates:
+        for item in _iter_mappings(candidate):
+            comment = comment_from_raw(item)
+            key = (comment.commentid, comment.uin, comment.content)
+            if key not in seen:
+                comments.append(comment)
+                seen.add(key)
+            for reply in _extract_nested_replies(item, comment.commentid):
+                reply_key = (reply.commentid, reply.uin, reply.content)
+                if reply_key not in seen:
+                    comments.append(reply)
+                    seen.add(reply_key)
+    return comments
+
+
+def extract_images(payload: dict[str, Any]) -> list[str]:
+    images: list[str] = []
+
+    def add(value: Any) -> None:
+        if isinstance(value, str) and value and value not in images:
+            images.append(value)
+
+    for key in ("images", "pics", "pic"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            for item in value:
+                if isinstance(item, str):
+                    add(item)
+                elif isinstance(item, dict):
+                    add(item.get("url") or item.get("pic_url") or item.get("smallurl") or item.get("origin_url"))
+        elif isinstance(value, dict):
+            add(value.get("url") or value.get("pic_url") or value.get("smallurl") or value.get("origin_url"))
+
+    for item in _iter_mappings(payload.get("picdata")):
+        add(item.get("url") or item.get("pic_url") or item.get("smallurl") or item.get("origin_url"))
+    return images
+
+
+def post_from_entry(entry: FeedEntry, *, detail: dict[str, Any] | None = None, local_id: int = 0) -> QzonePost:
+    raw = detail if isinstance(detail, dict) else entry.raw
+    comments = extract_comments(raw or {})
+    return QzonePost(
+        hostuin=entry.hostuin,
+        fid=entry.fid,
+        appid=entry.appid,
+        summary=clean_qzone_text(entry.summary),
+        nickname=entry.nickname,
+        created_at=entry.created_at,
+        like_count=entry.like_count,
+        comment_count=max(entry.comment_count, len(comments)),
+        liked=entry.liked,
+        images=extract_images(raw or {}),
+        comments=comments,
+        local_id=local_id,
+        raw=dict(raw or {}),
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ httpx>=0.27,<1
 # AstrBot 4.24.x ships aiohttp 3.13.5; keep this aligned with the core runtime.
 aiohttp>=3.13.5,<4
 Pillow>=10
+pillowmd
+json5

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -68,27 +68,27 @@ class ClientErrorMappingTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(QzoneRequestError) as caught:
             await self.client._request_text("GET", "https://h5.qzone.qq.com/mqzone/profile")
         self.assertEqual(caught.exception.status_code, 403)
-        self.assertIn("??", caught.exception.message)
+        self.assertIn("权限", caught.exception.message)
 
     async def test_payload_login_code_requires_rebind(self):
         await self._use_response(
-            lambda request: httpx.Response(200, json={"code": -3000, "message": "?????"}, request=request)
+            lambda request: httpx.Response(200, json={"code": -3000, "message": "登录态失效"}, request=request)
         )
         with self.assertRaises(QzoneNeedsRebind):
             await self.client._request_json("GET", "https://mobile.qzone.qq.com/feeds/mfeeds_get_count")
 
     async def test_payload_login_code_inside_data_requires_rebind(self):
         await self._use_response(
-            lambda request: httpx.Response(200, json={"data": {"code": -3000, "message": "?????"}}, request=request)
+            lambda request: httpx.Response(200, json={"data": {"code": -3000, "message": "登录态失效"}}, request=request)
         )
         with self.assertRaises(QzoneNeedsRebind):
             await self.client._request_json("GET", "https://mobile.qzone.qq.com/feeds/mfeeds_get_count")
 
     async def test_generic_negative_code_is_not_forced_to_rebind(self):
         await self._use_response(
-            lambda request: httpx.Response(200, json={"code": -10000, "message": "????"}, request=request)
+            lambda request: httpx.Response(200, json={"code": -10000, "message": "普通错误"}, request=request)
         )
-        self.assertFalse(self.client._payload_needs_rebind(-10000, "????"))
+        self.assertFalse(self.client._payload_needs_rebind(-10000, "普通错误"))
         with self.assertRaises(QzoneRequestError) as caught:
             await self.client._request_json("GET", "https://mobile.qzone.qq.com/feeds/mfeeds_get_count")
         self.assertNotIsInstance(caught.exception, QzoneNeedsRebind)
@@ -199,7 +199,7 @@ class ClientErrorMappingTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(QzoneRequestError) as caught:
             await self.client.like_post(123456, "fid-1")
 
-        self.assertIn("?????????", caught.exception.message)
+        self.assertIn("所有点赞入口", caught.exception.message)
         self.assertEqual(caught.exception.status_code, 503)
         attempts = caught.exception.detail["attempts"]
         self.assertEqual(len(attempts), 2)

--- a/tests/test_controller_bind.py
+++ b/tests/test_controller_bind.py
@@ -197,7 +197,7 @@ class ControllerBindTests(unittest.IsolatedAsyncioTestCase):
                         "ok": False,
                         "error": {
                             "code": "QZONE_REQUEST",
-                            "message": "QQ?????????? (503)",
+                            "message": "QQ 空间服务暂时不可用 (503)",
                             "detail": {
                                 "status_code": 503,
                                 "url": "https://w.qzone.qq.com/cgi-bin/likes/internal_dolike_app",

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -48,9 +48,8 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             QzoneDaemonService._feed_reference_index("\u7b2c\uff12\u6761", hostuin=123456),
             2,
         )
-        self.assertEqual(QzoneDaemonService._feed_reference_index("?2?", hostuin=123456), 2)
-        self.assertEqual(QzoneDaemonService._feed_reference_index("??2??", hostuin=123456), 2)
-        self.assertEqual(QzoneDaemonService._feed_reference_index("????", hostuin=123456), 1)
+        self.assertEqual(QzoneDaemonService._feed_reference_index("第2条", hostuin=123456), 2)
+        self.assertEqual(QzoneDaemonService._feed_reference_index("最新", hostuin=123456), 1)
         self.assertEqual(QzoneDaemonService._feed_reference_index("2", hostuin=123456), 0)
 
     async def test_warmup_uses_json_health_check_instead_of_h5_index(self):
@@ -81,7 +80,7 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             service.client.update_session(service.state.session)
             service.health_state = "ready"
 
-            service._set_error(QzoneRequestError("?????", status_code=403))
+            service._set_error(QzoneRequestError("禁止访问", status_code=403))
 
             self.assertEqual(service.health_state, "ready")
             self.assertFalse(service.state.session.needs_rebind)
@@ -110,6 +109,44 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(service.state.session.qzonetokens, {})
             self.assertEqual(service.client.feed_cache, {})
             await service.close()
+
+    async def test_visitor_reply_and_delete_backend_methods(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(uin=123456, cookies={"uin": "o123456", "p_skey": "abc"})
+            service.client.update_session(service.state.session)
+            try:
+                with patch.object(
+                    service.client,
+                    "get_visitors",
+                    new=AsyncMock(return_value={"items": [{"uin": 9988, "nickname": "Alice"}]}),
+                ) as visitors, patch.object(
+                    service.client,
+                    "reply_comment",
+                    new=AsyncMock(return_value={"commentid": "r1", "message": "ok"}),
+                ) as reply, patch.object(
+                    service.client,
+                    "delete_post",
+                    new=AsyncMock(return_value={"message": "deleted"}),
+                ) as delete:
+                    visitor_payload = await service.view_visitors()
+                    reply_payload = await service.reply_comment(
+                        hostuin=9988,
+                        fid="fid-1",
+                        commentid="c1",
+                        comment_uin=9988,
+                        content="hi",
+                    )
+                    delete_payload = await service.delete_post(fid="fid-1")
+
+                visitors.assert_awaited_once()
+                reply.assert_awaited_once()
+                delete.assert_awaited_once_with("fid-1", appid=311)
+                self.assertEqual(visitor_payload["items"][0]["nickname"], "Alice")
+                self.assertEqual(reply_payload["commentid"], "r1")
+                self.assertEqual(delete_payload["fid"], "fid-1")
+            finally:
+                await service.close()
 
     async def test_list_feeds_falls_back_when_h5_home_redirects(self):
         with TemporaryDirectory() as tmp:
@@ -595,7 +632,7 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
                     hostuin=3112333596,
                     fid="1c7182b96589046ad3380900",
                     appid=311,
-                    summary="??????",
+                    summary="甜酷风怎么样",
                     liked=False,
                     curkey="cached-curkey",
                 )
@@ -603,13 +640,13 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             before = {
                 "tid": "1c7182b96589046ad3380900",
                 "uin": 3112333596,
-                "content": "??????",
+                "content": "甜酷风怎么样",
                 "like": {"isliked": "0"},
             }
             after = {
                 "tid": "1c7182b96589046ad3380900",
                 "uin": 3112333596,
-                "content": "??????",
+                "content": "甜酷风怎么样",
                 "like": {"isliked": "1"},
             }
             try:
@@ -623,7 +660,7 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(args[:2], (3112333596, "1c7182b96589046ad3380900"))
                 self.assertEqual(kwargs["curkey"], "cached-curkey")
                 self.assertTrue(payload["verified"])
-                self.assertEqual(payload["summary"], "??????")
+                self.assertEqual(payload["summary"], "甜酷风怎么样")
             finally:
                 await service.close()
 

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -195,7 +195,7 @@ class MainPublishTests(unittest.TestCase):
             "login_uin": 3112333596,
             "session_source": "aiocqhttp",
             "cookie_count": 14,
-            "cookie_summary": "14???: uin, p_uin, skey, p_skey",
+            "cookie_summary": "14 个 Cookie: uin, p_uin, skey, p_skey",
             "needs_rebind": False,
             "daemon_port": 18999,
         }
@@ -221,7 +221,7 @@ class MainPublishTests(unittest.TestCase):
             "login_uin": 3112333596,
             "session_source": "aiocqhttp",
             "cookie_count": 14,
-            "cookie_summary": "14???: uin, p_uin, skey, p_skey",
+            "cookie_summary": "14 个 Cookie: uin, p_uin, skey, p_skey",
             "needs_rebind": False,
             "daemon_port": 18999,
         }
@@ -229,7 +229,7 @@ class MainPublishTests(unittest.TestCase):
             get_status=AsyncMock(return_value=degraded),
             ensure_running=AsyncMock(
                 side_effect=module.DaemonUnavailableError(
-                    "QQ?? daemon ????",
+                    "QQ 空间 daemon 启动失败",
                     detail={"returncode": 7, "log_path": "D:/qzone/daemon.log", "log_tail": "daemon boom"},
                 )
             ),
@@ -239,7 +239,7 @@ class MainPublishTests(unittest.TestCase):
         results = asyncio.run(collect_async_generator(plugin.qzone_status(event)))
 
         self.assertIn("- daemon: degraded", results[0])
-        self.assertIn("- daemon_error: QQ?? daemon ????", results[0])
+        self.assertIn("- daemon_error: QQ 空间 daemon 启动失败", results[0])
         self.assertIn("- daemon_returncode: 7", results[0])
         self.assertIn("- daemon_log: D:/qzone/daemon.log", results[0])
         self.assertIn("daemon boom", results[0])
@@ -252,7 +252,7 @@ class MainPublishTests(unittest.TestCase):
             "login_uin": 3112333596,
             "session_source": "manual",
             "cookie_count": 4,
-            "cookie_summary": "4???: uin, p_uin, skey, p_skey",
+            "cookie_summary": "4 个 Cookie: uin, p_uin, skey, p_skey",
             "needs_rebind": False,
             "daemon_port": 18999,
         }
@@ -362,7 +362,7 @@ class MainPublishTests(unittest.TestCase):
             hostuin=3112333596,
             fid="1c7182b96589046ad3380900",
             appid=311,
-            summary="??????",
+            summary="甜酷风怎么样",
             liked=False,
         )
         plugin.controller.list_feeds = AsyncMock(
@@ -377,8 +377,12 @@ class MainPublishTests(unittest.TestCase):
         results = asyncio.run(collect_async_generator(plugin.tool_list_feed(event, limit=1)))
 
         self.assertEqual(len(results), 1)
-        self.assertIn("??", results[0])
-        self.assertIn("???", results[0])
+        self.assertIn("未赞", results[0])
+        self.assertIn("0 赞", results[0])
+        self.assertIn("0 评论", results[0])
+        self.assertIn("甜酷风怎么样", results[0])
+        self.assertIn("可以用上面的序号", results[0])
+        self.assertNotIn("?" * 3, results[0])
         self.assertNotIn("cursor=", results[0])
         self.assertNotIn("has_more", results[0])
         self.assertNotIn("fid=", results[0])
@@ -388,7 +392,7 @@ class MainPublishTests(unittest.TestCase):
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
             get_current_chat_provider_id=AsyncMock(return_value="provider-1"),
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="?????????")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="这条已经点好了。")),
         )
         plugin.controller.like_post = AsyncMock(
             return_value={
@@ -396,7 +400,7 @@ class MainPublishTests(unittest.TestCase):
                 "liked": True,
                 "verified": True,
                 "already": False,
-                "summary": "??????",
+                "summary": "甜酷风怎么样",
             }
         )
         event = Event([])
@@ -413,12 +417,14 @@ class MainPublishTests(unittest.TestCase):
             latest=False,
             index=0,
         )
-        self.assertEqual(results[0], "?????????")
+        self.assertEqual(results[0], "这条已经点好了。")
         plugin._context.llm_generate.assert_awaited_once()
         prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
-        self.assertIn('"ok":true', prompt)
-        self.assertIn('"verified":true', prompt)
-        self.assertIn("??????", prompt)
+        self.assertIn("不要照抄", prompt)
+        self.assertIn("当前聊天里的人设", prompt)
+        self.assertIn("甜酷风怎么样", prompt)
+        self.assertNotIn('"ok"', prompt)
+        self.assertNotIn('"verified"', prompt)
         self.assertNotIn("fid=", results[0])
         self.assertFalse(results[0].lstrip().startswith("{"))
 
@@ -426,7 +432,7 @@ class MainPublishTests(unittest.TestCase):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="????")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="好了")),
         )
         plugin.controller.like_post = AsyncMock(
             return_value={
@@ -458,7 +464,7 @@ class MainPublishTests(unittest.TestCase):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="?????? 2 ??????")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="第 2 条已经点好了。")),
         )
         plugin.controller.like_post = AsyncMock(
             return_value={
@@ -490,7 +496,7 @@ class MainPublishTests(unittest.TestCase):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="???????????????????")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="先帮你点上了，显示可能慢一点。")),
         )
         plugin.settings.preview_writes = True
         plugin.controller.like_post = AsyncMock(
@@ -509,11 +515,12 @@ class MainPublishTests(unittest.TestCase):
         )
 
         plugin.controller.like_post.assert_awaited_once()
-        self.assertEqual(results[0], "???????????????????")
+        self.assertEqual(results[0], "先帮你点上了，显示可能慢一点。")
         prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
-        self.assertIn('"verified":false', prompt)
-        self.assertIn("accepted_pending_verification", prompt)
-        self.assertIn("verified=false means QQ readback is stale", prompt)
+        self.assertIn("QQ 空间显示可能会慢一点", prompt)
+        self.assertIn("不要说成失败", prompt)
+        self.assertNotIn('"verified"', prompt)
+        self.assertNotIn("accepted_pending_verification", prompt)
         self.assertNotIn("actual_liked", prompt)
         self.assertFalse(results[0].lstrip().startswith("{"))
 
@@ -546,39 +553,42 @@ class MainPublishTests(unittest.TestCase):
         )
 
         plugin._context.llm_generate.assert_awaited_once()
-        self.assertIn("\u8bf7\u6c42\u5df2\u53d1\u9001", results[0])
-        self.assertIn("\u4e0d\u6309\u5931\u8d25\u5904\u7406", results[0])
+        self.assertIn("\u6211\u5148\u5e2e\u4f60\u70b9\u4e0a\u4e86", results[0])
+        self.assertIn("\u7b49\u4e00\u4f1a\u513f\u624d\u663e\u793a", results[0])
         self.assertNotIn('"ok"', results[0])
         self.assertNotIn("status_code", results[0])
+        self.assertNotIn("\u5df2\u53d1\u9001", results[0])
         self.assertFalse(results[0].lstrip().startswith("{"))
 
     def test_llm_like_tool_asks_llm_for_natural_error_reply(self):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="?????QQ ??????????")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="这会儿 QQ 空间还动不了。")),
         )
-        plugin.controller.like_post = AsyncMock(side_effect=module.QzoneBridgeError("????"))
+        plugin.controller.like_post = AsyncMock(side_effect=module.QzoneBridgeError("点赞失败"))
         event = Event([])
 
         results = asyncio.run(
             collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
         )
 
-        self.assertEqual(results[0], "?????QQ ??????????")
+        self.assertEqual(results[0], "这会儿 QQ 空间还动不了。")
         prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
-        self.assertIn('"ok":false', prompt)
-        self.assertIn("????", prompt)
+        self.assertIn("\u73b0\u5728\u8fd8\u6ca1\u529e\u6cd5\u7ee7\u7eed", prompt)
+        self.assertIn("点赞失败", prompt)
+        self.assertNotIn('"ok"', prompt)
+        self.assertNotIn("QZONE_ERROR", prompt)
         self.assertFalse(results[0].lstrip().startswith("{"))
 
-    def test_llm_like_tool_logs_error_and_sends_diagnostic_to_llm(self):
+    def test_llm_like_tool_logs_error_without_sending_diagnostic_to_llm(self):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin._context = types.SimpleNamespace(
-            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="?????QQ ??????????")),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="这会儿 QQ 空间还动不了。")),
         )
         exc = module.QzoneBridgeError(
-            "QQ?????????? (503)",
+            "QQ 空间服务暂时不可用 (503)",
             detail={
                 "status_code": 503,
                 "url": "https://w.qzone.qq.com/cgi-bin/likes/internal_dolike_app?g_tk=123",
@@ -594,11 +604,12 @@ class MainPublishTests(unittest.TestCase):
                 collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
             )
 
-        self.assertEqual(results[0], "?????QQ ??????????")
+        self.assertEqual(results[0], "这会儿 QQ 空间还动不了。")
         prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
-        self.assertIn('"diagnostic"', prompt)
-        self.assertIn('"status_code":503', prompt)
-        self.assertIn("service unavailable", prompt)
+        self.assertNotIn('"diagnostic"', prompt)
+        self.assertNotIn("status_code", prompt)
+        self.assertNotIn("service unavailable", prompt)
+        self.assertNotIn("internal_dolike_app", prompt)
         log_line = next(
             call.args[1]
             for call in log_warning.call_args_list
@@ -628,15 +639,16 @@ class MainPublishTests(unittest.TestCase):
             collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
         )
 
-        self.assertIn("\u8bf7\u6c42\u5df2\u53d1\u9001", results[0])
-        self.assertIn("\u4e0d\u6309\u5931\u8d25\u5904\u7406", results[0])
+        self.assertIn("\u6211\u5148\u5e2e\u4f60\u70b9\u4e0a\u4e86", results[0])
+        self.assertIn("\u7b49\u4e00\u4f1a\u513f\u624d\u663e\u793a", results[0])
+        self.assertNotIn("\u5df2\u53d1\u9001", results[0])
         self.assertFalse(results[0].lstrip().startswith("{"))
 
     def test_llm_like_tool_error_fallback_does_not_expose_detail(self):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin.controller.like_post = AsyncMock(
-            side_effect=module.QzoneBridgeError("????", detail={"fid": "secret-fid", "raw": {"code": 1}})
+            side_effect=module.QzoneBridgeError("点赞失败", detail={"fid": "secret-fid", "raw": {"code": 1}})
         )
         event = Event([])
 
@@ -644,9 +656,235 @@ class MainPublishTests(unittest.TestCase):
             collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
         )
 
-        self.assertEqual(results[0], "????")
+        self.assertIn("\u665a\u70b9\u518d\u8bd5", results[0])
         self.assertNotIn("secret-fid", results[0])
+        self.assertNotIn("raw", results[0])
         self.assertFalse(results[0].lstrip().startswith("{"))
+
+    def test_target_range_parser_supports_at_and_zero_based_range(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        event = Event([], message_str="看说说 @123456 2~4")
+
+        target, start, end = plugin._parse_target_range(event, ("看说说", "查看说说"))
+
+        self.assertEqual(target, 123456)
+        self.assertEqual((start, end), (2, 4))
+
+    def test_view_feed_uses_target_command_detail_shape(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        entries = [
+            module.FeedEntry(hostuin=123456, fid="fid-0", appid=311, summary="zero"),
+            module.FeedEntry(hostuin=123456, fid="fid-1", appid=311, summary="one"),
+        ]
+        plugin.controller.list_feeds = AsyncMock(return_value={"items": [asdict(item) for item in entries]})
+        plugin.controller.detail_feed = AsyncMock(
+            return_value={
+                "entry": asdict(entries[1]),
+                "comments": [{"commentid": "c1", "uin": 9988, "nickname": "Alice", "content": "nice"}],
+                "raw": {},
+            }
+        )
+        event = Event([], message_str="看说说 1")
+
+        results = asyncio.run(collect_async_generator(plugin.view_feed(event)))
+
+        plugin.controller.list_feeds.assert_awaited_once()
+        plugin.controller.detail_feed.assert_awaited_once_with(hostuin=123456, fid="fid-1", appid=311)
+        self.assertIn("one", results[0])
+        self.assertIn("Alice", results[0])
+
+    def test_contribution_approve_publishes_draft(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin.settings.render_publish_result = False
+        plugin.drafts = module.DraftStore(plugin.data_dir / "drafts.json")
+        event = Event([Plain("投稿 hello")], message_str="投稿 hello")
+
+        contribute_results = asyncio.run(collect_async_generator(plugin.contribute_post(event)))
+        draft = plugin.drafts.get(1)
+        self.assertIsNotNone(draft)
+        self.assertIn("#1", contribute_results[0])
+
+        approve_event = Event([], message_str="过稿 1")
+        approve_results = asyncio.run(collect_async_generator(plugin.approve_post(approve_event)))
+
+        plugin.controller.publish_post.assert_awaited()
+        self.assertEqual(plugin.drafts.get(1).status, "published")
+        self.assertIn("发布结果", approve_results[0])
+
+    def test_approve_post_adds_submitter_name_when_configured(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin.settings.render_publish_result = False
+        plugin.settings.show_name = True
+        plugin.drafts = module.DraftStore(plugin.data_dir / "drafts.json")
+        event = Event([Plain("投稿 hello")], message_str="投稿 hello")
+        plugin._sender_id = lambda event: 123456
+        plugin._sender_name = lambda event: "Alice"
+
+        asyncio.run(collect_async_generator(plugin.contribute_post(event)))
+        approve_event = Event([], message_str="过稿 1")
+        asyncio.run(collect_async_generator(plugin.approve_post(approve_event)))
+
+        content = plugin.controller.publish_post.await_args.kwargs["content"]
+        self.assertTrue(content.startswith("【来自 Alice 的投稿】"))
+        self.assertIn("hello", content)
+
+    def test_reply_comment_accepts_cached_viewed_post_id(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        entry = module.FeedEntry(hostuin=123456, fid="fid-1", appid=311, summary="hello")
+        post = module.post_from_entry(entry, local_id=0)
+        plugin._post_store().upsert(post)
+        plugin.controller.detail_feed = AsyncMock(
+            return_value={
+                "entry": asdict(entry),
+                "comments": [{"commentid": "c1", "uin": 9988, "nickname": "Bob", "content": "nice"}],
+                "raw": {},
+            }
+        )
+        plugin.controller.reply_comment = AsyncMock(return_value={"commentid": "r1", "message": "ok"})
+        plugin.controller.get_status = AsyncMock(return_value={"login_uin": 123456})
+        plugin._generate_reply_text = AsyncMock(return_value="收到")
+        event = Event([], message_str="回评 1")
+
+        results = asyncio.run(collect_async_generator(plugin.reply_comment(event)))
+
+        plugin.controller.reply_comment.assert_awaited_once_with(
+            hostuin=123456,
+            fid="fid-1",
+            commentid="c1",
+            comment_uin=9988,
+            content="收到",
+            appid=311,
+        )
+        self.assertIn("回复结果", results[0])
+
+    def test_auto_comment_persists_dedupe_between_runs(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        entries = [
+            module.FeedEntry(hostuin=111, fid="fid-1", appid=311, summary="one"),
+            module.FeedEntry(hostuin=222, fid="fid-2", appid=311, summary="two"),
+        ]
+        plugin.controller.list_feeds = AsyncMock(return_value={"items": [asdict(item) for item in entries]})
+        plugin.controller.detail_feed = AsyncMock(
+            side_effect=[
+                {"entry": asdict(entries[0]), "comments": [], "raw": {}},
+                {"entry": asdict(entries[0]), "comments": [], "raw": {}},
+                {"entry": asdict(entries[1]), "comments": [], "raw": {}},
+            ]
+        )
+        plugin.controller.comment_post = AsyncMock(return_value={"commentid": "c1"})
+        plugin._generate_comment_text = AsyncMock(return_value="好")
+
+        asyncio.run(plugin._auto_comment_once())
+        asyncio.run(plugin._auto_comment_once())
+
+        self.assertEqual(plugin.controller.comment_post.await_count, 2)
+        first = plugin.controller.comment_post.await_args_list[0].kwargs
+        second = plugin.controller.comment_post.await_args_list[1].kwargs
+        self.assertEqual(first["fid"], "fid-1")
+        self.assertEqual(second["fid"], "fid-2")
+
+    def test_markdown_result_uses_pillowmd_when_configured(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin.settings.pillowmd_style_dir = "style-dir"
+        saved_pillowmd = sys.modules.get("pillowmd")
+
+        class FakeImage:
+            def Save(self, output_dir):
+                path = Path(output_dir) / "render.png"
+                path.write_bytes(b"png")
+                return path
+
+        class FakeStyle:
+            async def AioRender(self, **kwargs):
+                return FakeImage()
+
+        fake_pillowmd = types.SimpleNamespace(LoadMarkdownStyles=lambda style_dir: FakeStyle())
+        sys.modules["pillowmd"] = fake_pillowmd
+        if saved_pillowmd is None:
+            self.addCleanup(lambda: sys.modules.pop("pillowmd", None))
+        else:
+            self.addCleanup(lambda: sys.modules.__setitem__("pillowmd", saved_pillowmd))
+        event = Event([])
+
+        result = asyncio.run(plugin._markdown_result(event, "hello", subdir="test"))
+
+        self.assertIn("image", result)
+        self.assertTrue(Path(result["image"]).exists())
+
+    def test_generate_post_text_appends_filtered_group_history(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin.settings.post_max_msg = 10
+        plugin.settings.ignore_users = ["999"]
+        plugin._context = types.SimpleNamespace(
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="draft"))
+        )
+        event = Event([], message_str="写说说")
+        event.message_obj.group_id = 100
+        event.bot = types.SimpleNamespace(
+            api=types.SimpleNamespace(
+                call_action=AsyncMock(
+                    return_value={
+                        "messages": [
+                            {
+                                "message_id": 1,
+                                "sender": {"user_id": 123, "nickname": "Alice"},
+                                "message": [{"type": "text", "data": {"text": "今天真热"}}],
+                            },
+                            {
+                                "message_id": 2,
+                                "sender": {"user_id": 999, "nickname": "Ignored"},
+                                "message": [{"type": "text", "data": {"text": "跳过我"}}],
+                            },
+                        ]
+                    }
+                )
+            )
+        )
+
+        result = asyncio.run(plugin._generate_post_text(event, "天气"))
+
+        self.assertEqual(result, "draft")
+        prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
+        self.assertIn("聊天记录参考", prompt)
+        self.assertIn("Alice: 今天真热", prompt)
+        self.assertNotIn("跳过我", prompt)
+
+    def test_llm_like_tool_strips_tool_error_prefix_and_rejects_unsafe_error_reply(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        unsafe_reply = "Result: [TOOL_UNAVAILABLE] \u4eba\u8bbe\u53c2\u8003\u56fe\u8fd8\u6ca1\u914d\u7f6e\u597d\u3002"
+        plugin._context = types.SimpleNamespace(
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text=unsafe_reply)),
+        )
+        plugin.controller.like_post = AsyncMock(
+            side_effect=module.QzoneBridgeError(
+                "Result: [TOOL_UNAVAILABLE] \u4eba\u8bbe\u53c2\u8003\u56fe\u8fd8\u6ca1\u914d\u7f6e\u597d\u3002"
+                "\u8bf7\u7528\u81ea\u5df1\u5e73\u65f6\u7684\u8bed\u6c14\u544a\u8bc9\u7528\u6237\u73b0\u5728\u8fd8\u6ca1\u529e\u6cd5\uff0c\u4e0d\u8981\u63d0\u6307\u4ee4\u6216\u547d\u4ee4\u3002"
+            )
+        )
+        event = Event([])
+
+        results = asyncio.run(
+            collect_async_generator(plugin.tool_like_post(event, hostuin=0, fid="1", confirm=False))
+        )
+
+        prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
+        self.assertIn("\u4eba\u8bbe\u53c2\u8003\u56fe\u8fd8\u6ca1\u914d\u7f6e\u597d", prompt)
+        self.assertNotIn("TOOL_UNAVAILABLE", prompt)
+        self.assertIn("\u53c2\u8003\u5185\u5bb9\u51c6\u5907\u597d", results[0])
+        self.assertNotIn("Result:", results[0])
+        self.assertNotIn("TOOL_UNAVAILABLE", results[0])
+        self.assertNotIn("\u5de5\u5177", results[0])
+        self.assertNotIn("\u6307\u4ee4", results[0])
+        self.assertNotIn("\u547d\u4ee4", results[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_storage_settings.py
+++ b/tests/test_storage_settings.py
@@ -36,6 +36,40 @@ class StorageSettingsTests(unittest.TestCase):
         self.assertEqual(settings.cookie_domain, "https://user.qzone.qq.com/")
         self.assertEqual(settings.render_remote_timeout, 0.25)
 
+    def test_settings_accept_target_plugin_sections(self):
+        settings = PluginSettings.from_mapping(
+            {
+                "manage_group": "12345",
+                "cookies_str": "uin=o1; p_skey=abc",
+                "llm": {
+                    "post_provider_id": "post-provider",
+                    "comment_prompt": "comment prompt",
+                },
+                "source": {
+                    "ignore_groups": ["100"],
+                    "ignore_users": "200, 300",
+                    "post_max_msg": 250,
+                },
+                "trigger": {
+                    "publish_cron": "30 23 * * *",
+                    "publish_offset": 600,
+                    "comment_cron": "0 8 * * *",
+                    "like_when_comment": True,
+                },
+            }
+        )
+
+        self.assertEqual(settings.manage_group, 12345)
+        self.assertEqual(settings.cookies_str, "uin=o1; p_skey=abc")
+        self.assertEqual(settings.post_provider_id, "post-provider")
+        self.assertEqual(settings.comment_prompt, "comment prompt")
+        self.assertEqual(settings.ignore_groups, ["100"])
+        self.assertEqual(settings.ignore_users, ["200", "300"])
+        self.assertEqual(settings.post_max_msg, 250)
+        self.assertEqual(settings.publish_cron, "30 23 * * *")
+        self.assertEqual(settings.publish_offset, 600)
+        self.assertTrue(settings.like_when_comment)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
﻿## Summary
- align the public AstrBot command surface with Zhalslar/astrbot_plugin_qzone while keeping local daemon/Cookie/LLM safety behavior
- add target-style post/comment adapters, persistent draft and viewed-post stores, visitor/delete/reply backend routes, and campus-wall review flow
- wire target config keys, optional pillowmd rendering, AI write/comment/reply flows, scheduled publish/comment behavior, and docs/metadata updates

## Validation
- python -m compileall -q main.py qzone_bridge tests
- python -m json.tool .\_conf_schema.json > $null
- git diff --check
- python -m unittest discover -s tests
