### PR TITLE
[codex] Fix Qzone feed detail H5 redirect fallback

### DIFF
--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -338,18 +338,64 @@ class QzoneDaemonService:
             "count": min(len(items), limit),
         }
 
+    def _detail_payload_from_entry(self, entry: FeedEntry) -> dict[str, Any]:
+        self.client.cache_feed_page(entry.hostuin, [entry])
+        raw = entry.raw if isinstance(entry.raw, dict) else {}
+        comments = [item.to_dict() for item in extract_comments(raw)]
+        return {"entry": asdict(entry), "comments": comments, "raw": raw}
+
+    async def _detail_from_cached_or_legacy_feed(self, *, hostuin: int, fid: str) -> dict[str, Any] | None:
+        cached = self.client.feed_cache.get((hostuin, fid))
+        if cached is not None:
+            return self._detail_payload_from_entry(cached)
+
+        fetchers: list[Any] = []
+        if hostuin == self.state.session.uin:
+            fetchers.append(self.client.legacy_recent_feeds)
+        fetchers.append(lambda: self.client.legacy_feeds(hostuin, page=1, num=20))
+
+        for fetch in fetchers:
+            try:
+                payload = unwrap_payload(await fetch())
+            except Exception as exc:
+                log.debug("qzone detail feed fallback failed: %s", exc)
+                continue
+            feedpage, entries = extract_feed_page(payload, default_hostuin=hostuin)
+            if not feedpage:
+                continue
+            self.client.cache_feed_page(hostuin, entries)
+            for entry in entries:
+                if entry.fid == fid:
+                    return self._detail_payload_from_entry(entry)
+        return None
+
     async def detail_feed(self, *, hostuin: int, fid: str, appid: int = 311, busi_param: str = "") -> dict[str, Any]:
         hostuin = int(hostuin or self.state.session.uin or 0)
         if not hostuin:
             raise QzoneNeedsRebind()
-        await self.ensure_token(hostuin)
-        payload = unwrap_payload(await self.client.detail(hostuin, fid, appid=appid, busi_param=busi_param))
-        if not isinstance(payload, dict):
-            raise QzoneParseError("说说详情返回格式异常")
-        entry = self.client.feed_entry_from_payload(payload, default_hostuin=hostuin)
-        self.client.cache_feed_page(hostuin, [entry])
-        comments = [item.to_dict() for item in extract_comments(payload)]
-        return {"entry": asdict(entry), "comments": comments, "raw": payload}
+        token_error: Exception | None = None
+        try:
+            await self.ensure_token(hostuin)
+        except (QzoneRequestError, QzoneParseError) as exc:
+            if not self._should_fallback_feed_fetch(exc):
+                raise
+            token_error = exc
+            log.warning("qzone detail token probe failed, trying detail without fresh token: %s", exc)
+
+        try:
+            payload = unwrap_payload(await self.client.detail(hostuin, fid, appid=appid, busi_param=busi_param))
+            if not isinstance(payload, dict):
+                raise QzoneParseError("说说详情返回格式异常")
+            entry = self.client.feed_entry_from_payload(payload, default_hostuin=hostuin)
+            return self._detail_payload_from_entry(entry)
+        except (QzoneRequestError, QzoneParseError) as exc:
+            if token_error is None and not self._should_fallback_feed_fetch(exc):
+                raise
+            log.warning("qzone detail primary fetch failed, using feed fallback: %s", exc)
+            fallback = await self._detail_from_cached_or_legacy_feed(hostuin=hostuin, fid=fid)
+            if fallback is not None:
+                return fallback
+            raise
 
     async def view_visitors(self, *, page: int = 1, count: int = 20) -> dict[str, Any]:
         self._ensure_session_ready()

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -211,6 +211,89 @@ class DaemonStateTests(unittest.IsolatedAsyncioTestCase):
             finally:
                 await service.close()
 
+    async def test_detail_feed_continues_when_h5_token_probe_redirects(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            try:
+                with patch.object(
+                    service.client,
+                    "index",
+                    new=AsyncMock(side_effect=QzoneRequestError("h5 redirect", status_code=302)),
+                ) as index, patch.object(
+                    service.client,
+                    "detail",
+                    new=AsyncMock(
+                        return_value={
+                            "tid": "fid-1",
+                            "uin": 123456,
+                            "content": "hello",
+                            "commentlist": [{"commentid": "c1", "uin": 9988, "content": "nice"}],
+                        }
+                    ),
+                ) as detail:
+                    payload = await service.detail_feed(hostuin=123456, fid="fid-1")
+                index.assert_awaited_once()
+                detail.assert_awaited_once_with(123456, "fid-1", appid=311, busi_param="")
+                self.assertEqual(payload["entry"]["fid"], "fid-1")
+                self.assertEqual(payload["comments"][0]["commentid"], "c1")
+            finally:
+                await service.close()
+
+    async def test_detail_feed_uses_cached_feed_when_h5_detail_redirects(self):
+        with TemporaryDirectory() as tmp:
+            service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())
+            service.state.session = SessionState(
+                uin=123456,
+                cookies={"uin": "o123456", "p_uin": "o123456", "p_skey": "abc"},
+            )
+            service.client.update_session(service.state.session)
+            legacy_page = {
+                "main": {
+                    "hasMoreFeeds": False,
+                    "data": [
+                        {
+                            "tid": "fid-1",
+                            "uin": 123456,
+                            "content": "hello",
+                            "commentlist": [{"commentid": "c1", "uin": 9988, "content": "nice"}],
+                        }
+                    ],
+                }
+            }
+            try:
+                with patch.object(
+                    service.client,
+                    "index",
+                    new=AsyncMock(
+                        side_effect=[
+                            QzoneRequestError("index redirect", status_code=302),
+                            QzoneRequestError("index redirect", status_code=302),
+                        ]
+                    ),
+                ) as index, patch.object(
+                    service.client,
+                    "legacy_recent_feeds",
+                    new=AsyncMock(return_value=legacy_page),
+                ), patch.object(
+                    service.client,
+                    "detail",
+                    new=AsyncMock(side_effect=QzoneRequestError("detail redirect", status_code=302)),
+                ) as detail:
+                    list_payload = await service.list_feeds(limit=1)
+                    detail_payload = await service.detail_feed(hostuin=123456, fid="fid-1")
+                self.assertEqual(index.await_count, 2)
+                detail.assert_awaited_once_with(123456, "fid-1", appid=311, busi_param="")
+                self.assertEqual(list_payload["items"][0]["fid"], "fid-1")
+                self.assertEqual(detail_payload["entry"]["fid"], "fid-1")
+                self.assertEqual(detail_payload["comments"][0]["content"], "nice")
+            finally:
+                await service.close()
+
     async def test_publish_post_does_not_probe_h5_index_for_token(self):
         with TemporaryDirectory() as tmp:
             service = QzoneDaemonService(StateStore(Path(tmp)), secret="secret", port=free_port())


### PR DESCRIPTION
﻿## What changed

- Keeps `detail_feed` from failing immediately when the H5 token probe redirects `/mqzone/index` back to the Qzone home page.
- Allows detail fetches to continue without a freshly refreshed qzonetoken when the token probe is a fallback-worthy H5 redirect/parse failure.
- Falls back to cached feed data or legacy feed endpoints when the H5 detail endpoint also redirects or is unavailable.
- Adds daemon regressions for the exact `看说说` / `评说说` path: list feed fallback caches the post, then detail fallback returns that cached/legacy data instead of surfacing the H5 302.

## Root cause

`看说说` and `评说说` first list posts and then request each post detail. The list path already handled H5 `/mqzone/index` 302 redirects by falling back to legacy feeds, but `detail_feed()` called `ensure_token()` before trying the detail request. When `/mqzone/index` redirected to `user.qzone.qq.com/<uin>`, that token probe raised a `QzoneRequestError` and bypassed the existing feed fallback, so users saw the raw H5 redirect error.

## Validation

- `python -m pytest tests/test_daemon_lifecycle.py::DaemonStateTests::test_detail_feed_continues_when_h5_token_probe_redirects tests/test_daemon_lifecycle.py::DaemonStateTests::test_detail_feed_uses_cached_feed_when_h5_detail_redirects -q`
- `python -m pytest tests/test_daemon_lifecycle.py tests/test_main_publish.py -q`
- `python -m py_compile qzone_bridge\daemon.py tests\test_daemon_lifecycle.py`
- `python -m pytest tests/test_daemon_lifecycle.py tests/test_client_errors.py tests/test_controller_bind.py -q`
- `python -m pytest -q` -> 149 passed, 10 subtests passed
- `git diff --cached --check`
