### PR TITLE
[codex] Refactor Qzone post actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@
 
 ## 中文命令
 
-序号从 `0` 开始，`0` 表示最新一条，`-1` 表示当前页最后一条，支持范围语法如 `2~5`。`@用户` 或 QQ 号表示查看指定用户空间；不指定时默认查看好友动态流。
+序号按日常说法从 `1` 开始，`1`/`最新` 表示最新一条，`-1` 表示当前页最后一条，支持范围语法如 `1~3`。旧习惯里的 `0` 仍兼容为最新一条。`@用户` 或 QQ 号表示查看指定用户空间；不指定时默认查看好友动态流。
 
 | 命令 | 别名 | 权限 | 参数 | 功能 |
 | --- | --- | --- | --- | --- |
 | 查看访客 | - | ADMIN | - | 查看最近访客 |
 | 看说说 | 查看说说 | ALL | `[@用户/QQ] [序号/范围]` | 查看说说详情 |
-| 评说说 | 评论说说、读说说 | ALL | `[@用户/QQ] [序号/范围]` | AI 评论说说，可配置评论后点赞 |
+| 评说说 | 评论说说、读说说 | ALL | `[@用户/QQ] [序号/范围] [评论内容]` | 评论说说，内容为空时由 AI 生成，可配置评论后点赞 |
 | 赞说说 | - | ALL | `[@用户/QQ] [序号/范围]` | 点赞说说 |
 | 发说说 | - | ADMIN | `<文本> [图片]` | 立即发布说说 |
 | 写说说 | 写稿 | ADMIN | `<主题> [图片]` | AI 生成待审核稿件 |
@@ -52,10 +52,13 @@
 
 - `qzone_get_status`
 - `qzone_list_feed`
+- `qzone_view_post`
 - `qzone_detail_feed`
 - `qzone_publish_post`
 - `qzone_comment_post`
 - `qzone_like_post`
+
+`qzone_view_post`、`qzone_comment_post`、`qzone_like_post` 优先使用 `target_uin` + `selector`，其中 `selector` 可写 `latest`、`最新`、`第2条`、`2`、`1~3` 或真实 `fid`。旧的 `hostuin/fid/appid/latest/index` 仍保留兼容。
 
 `qzone_like_post` 会继续区分“请求已被 QQ 空间接受”和“读回校验暂未同步”，不会因为 QQ 空间显示滞后把成功操作误报成失败；用户可见回复会交给 LLM 组织成自然语言，避免泄露 raw JSON、fid、cursor、status_code 等内部字段。
 
@@ -67,6 +70,7 @@
 - `pillowmd_style_dir`：可选的 pillowmd 样式目录；配置后会优先把说说/稿件展示渲染成图片。
 - `llm.post_provider_id` / `llm.comment_provider_id` / `llm.reply_provider_id`：分别指定写稿、评论、回评的 LLM provider。
 - `llm.post_prompt` / `llm.comment_prompt` / `llm.reply_prompt`：提示词。
+- `llm.comment_max_length`：AI 评论和回评最大长度。
 - `source.ignore_groups` / `source.ignore_users` / `source.post_max_msg`：自动写稿/读说说来源控制，AI 写稿会尽量抽取群聊文本作为参考上下文。
 - `trigger.publish_cron` / `trigger.publish_offset`：自动发说说基准时间和随机偏移秒数。
 - `trigger.comment_cron` / `trigger.comment_offset`：自动评论基准时间和随机偏移秒数。

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -41,6 +41,17 @@
         "default": "生成一句简短、直接、贴题的评论，不要解释。",
         "hint": "用于 评说说/评论说说/读说说 和自动评论。"
       },
+      "comment_max_length": {
+        "description": "评论最大长度",
+        "type": "int",
+        "default": 60,
+        "slider": {
+          "min": 10,
+          "max": 200,
+          "step": 1
+        },
+        "hint": "AI 生成评论和回评时会截断到这个长度。"
+      },
       "reply_provider_id": {
         "description": "回复评论用的 LLM 提供商",
         "type": "string",

--- a/main.py
+++ b/main.py
@@ -164,10 +164,12 @@ _prepare_local_qzone_bridge_imports()
 from qzone_bridge.controller import QzoneDaemonController
 from qzone_bridge.drafts import DraftPost, DraftStore
 from qzone_bridge.errors import DaemonUnavailableError, QzoneBridgeError, QzoneCookieAcquireError, QzoneNeedsRebind
+from qzone_bridge.llm import QzoneLLM
 from qzone_bridge.media import PostPayload, collect_post_payload, normalize_media_list
 from qzone_bridge.models import FeedEntry
 from qzone_bridge.onebot_cookie import fetch_cookie_text
 from qzone_bridge.parser import normalize_uin, parse_cookie_text
+from qzone_bridge.post_service import QzonePostService
 from qzone_bridge.posts import PostStore
 from qzone_bridge.publish_renderer import RenderProfile, profile_from_event, render_publish_result_image
 from qzone_bridge.render import (
@@ -178,6 +180,7 @@ from qzone_bridge.render import (
     format_llm_feed_list,
     format_status,
 )
+from qzone_bridge.selection import PostSelection, parse_post_selection, selection_from_tool_args
 from qzone_bridge.settings import PluginSettings
 from qzone_bridge.social import QzoneComment, QzonePost, post_from_entry
 from qzone_bridge.utils import truncate
@@ -224,6 +227,7 @@ class QzoneStablePlugin(Star):
         self._publisher_profile_cache: tuple[int, float, Any] | None = None
         self.drafts = DraftStore(self.data_dir / "drafts.json")
         self.posts = PostStore(self.data_dir / "posts.json")
+        self.llm = QzoneLLM(self._context, self.settings)
         self._pillowmd_style: Any | None = None
         self._pillowmd_style_dir = ""
 
@@ -256,6 +260,18 @@ class QzoneStablePlugin(Star):
         if getattr(self.posts, "path", None) != expected:
             self.posts = PostStore(expected)
         return self.posts
+
+    def _post_service(self) -> QzonePostService:
+        return QzonePostService(
+            self.controller,
+            self._post_store(),
+            max_feed_limit=self.settings.max_feed_limit,
+        )
+
+    def _llm_adapter(self) -> QzoneLLM:
+        self.llm.context = getattr(self, "_context", None) or getattr(self, "context", None)
+        self.llm.settings = self.settings
+        return self.llm
 
     @staticmethod
     def _onebot_file_uri(path: Path) -> str:
@@ -689,77 +705,20 @@ class QzoneStablePlugin(Star):
         system_prompt = (
             "沿用当前聊天角色和语气。你只负责把结果变成自然口语回复，不能暴露任何内部实现信息。"
         )
-        context = getattr(self, "_context", None) or getattr(self, "context", None)
-
-        generator = getattr(context, "llm_generate", None)
-        if callable(generator):
-            kwargs: dict[str, Any] = {"prompt": prompt, "system_prompt": system_prompt}
-            provider_id = await self._current_provider_id(event)
-            if provider_id:
-                kwargs["chat_provider_id"] = provider_id
-            try:
-                response = await self._maybe_await(generator(**kwargs))
-            except TypeError:
-                kwargs.pop("chat_provider_id", None)
-                try:
-                    response = await self._maybe_await(generator(**kwargs))
-                except Exception as exc:
-                    logger.debug("qzone llm_generate reply failed: %s", exc)
-                else:
-                    text = self._text_from_llm_response(response)
-                    if self._llm_tool_reply_is_safe(text, payload):
-                        return text
-                    if text:
-                        logger.warning("discarded unsafe qzone llm tool reply: %s", truncate(text, 300))
-            except Exception as exc:
-                logger.debug("qzone llm_generate reply failed: %s", exc)
-            else:
-                text = self._text_from_llm_response(response)
-                if self._llm_tool_reply_is_safe(text, payload):
-                    return text
-                if text:
-                    logger.warning("discarded unsafe qzone llm tool reply: %s", truncate(text, 300))
-
-        provider_getter = getattr(context, "get_using_provider", None)
-        provider = None
-        if callable(provider_getter):
-            umo = getattr(event, "unified_msg_origin", None)
-            attempts: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
-            if umo is not None:
-                attempts.append(((), {"umo": umo}))
-                attempts.append(((umo,), {}))
-            attempts.append(((), {}))
-            for args, kwargs in attempts:
-                try:
-                    provider = await self._maybe_await(provider_getter(*args, **kwargs))
-                except TypeError:
-                    continue
-                except Exception as exc:
-                    logger.debug("qzone provider lookup failed: %s", exc)
-                    provider = None
-                    break
-                if provider is not None:
-                    break
-
-        text_chat = getattr(provider, "text_chat", None)
-        if callable(text_chat):
-            for kwargs in (
-                {"prompt": prompt, "contexts": [], "system_prompt": system_prompt},
-                {"prompt": prompt, "context": [], "system_prompt": system_prompt},
-                {"prompt": prompt},
-            ):
-                try:
-                    response = await self._maybe_await(text_chat(**kwargs))
-                except TypeError:
-                    continue
-                except Exception as exc:
-                    logger.debug("qzone provider text_chat reply failed: %s", exc)
-                    break
-                text = self._text_from_llm_response(response)
-                if self._llm_tool_reply_is_safe(text, payload):
-                    return text
-                if text:
-                    logger.warning("discarded unsafe qzone provider reply: %s", truncate(text, 300))
+        try:
+            text = await self._llm_adapter().generate_text(
+                event,
+                prompt,
+                system_prompt=system_prompt,
+                prefer_current_provider=True,
+            )
+        except Exception as exc:
+            logger.debug("qzone llm tool reply failed: %s", exc)
+        else:
+            if self._llm_tool_reply_is_safe(text, payload):
+                return text
+            if text:
+                logger.warning("discarded unsafe qzone llm tool reply: %s", truncate(text, 300))
 
         return fallback
 
@@ -954,25 +913,35 @@ class QzoneStablePlugin(Star):
         return deduped
 
     def _parse_target_range(self, event: AstrMessageEvent, names: tuple[str, ...]) -> tuple[int, int, int]:
-        raw = self._message_after_command(self._event_text(event), names)
-        target = 0
-        at_uins = self._at_uins(event, raw)
-        if at_uins:
-            target = at_uins[0]
-            raw = re.sub(r"\[CQ:at,qq=\d+[^\]]*\]|@\d{5,}", " ", raw, count=1).strip()
-        tokens = raw.split()
-        if not target and tokens and re.fullmatch(r"\d{5,}", tokens[0]):
-            target = int(tokens.pop(0))
-        start = end = 0
-        if tokens:
-            token = tokens[0].strip()
-            match = re.fullmatch(r"(-?\d+)(?:\s*~\s*(-?\d+))?", token)
-            if match:
-                start = int(match.group(1))
-                end = int(match.group(2) if match.group(2) is not None else start)
-                if start >= 0 and end >= 0 and end < start:
-                    start, end = end, start
-        return target, start, end
+        selection = parse_post_selection(self._event_text(event), names)
+        return selection.target_uin, selection.start, selection.end
+
+    def _selection_for_event(self, event: AstrMessageEvent, names: tuple[str, ...]) -> PostSelection:
+        return parse_post_selection(self._event_text(event), names)
+
+    async def _posts_for_selection(
+        self,
+        selection: PostSelection,
+        *,
+        target_id: int | None = None,
+        with_detail: bool = False,
+        no_commented: bool = False,
+        no_self: bool = False,
+        login_uin: int | None = None,
+    ) -> list[QzonePost]:
+        if target_id is not None:
+            selection.target_uin = int(target_id)
+        return await self._post_service().resolve_posts(
+            selection,
+            with_detail=with_detail,
+            no_commented=no_commented,
+            no_self=no_self,
+            login_uin=self._self_id_placeholder(login_uin),
+        )
+
+    @staticmethod
+    def _self_id_placeholder(login_uin: int | None) -> int:
+        return int(login_uin or 0)
 
     async def _posts_for_event(
         self,
@@ -984,64 +953,14 @@ class QzoneStablePlugin(Star):
         no_commented: bool = False,
         no_self: bool = False,
     ) -> list[QzonePost]:
-        parsed_target, start, end = self._parse_target_range(event, names)
-        hostuin = int(target_id if target_id is not None else parsed_target)
-        if start < 0 or end < 0:
-            limit = self.settings.max_feed_limit
-        else:
-            limit = min(max(end + 1, 1), self.settings.max_feed_limit)
-        payload = await self.controller.list_feeds(
-            hostuin=hostuin,
-            limit=limit,
-            scope="profile" if hostuin else "",
+        return await self._posts_for_selection(
+            self._selection_for_event(event, names),
+            target_id=target_id,
+            with_detail=with_detail,
+            no_commented=no_commented,
+            no_self=no_self,
+            login_uin=self._self_id(event),
         )
-        entries = self._to_feed_entries(payload)
-        if start < 0 or end < 0:
-            selected = entries[-1:] if entries else []
-        else:
-            selected = entries[start : end + 1]
-        login_uin = self._self_id(event)
-        posts: list[QzonePost] = []
-        for offset, entry in enumerate(selected, start=max(start, 0)):
-            detail_payload: dict[str, Any] | None = None
-            if with_detail or no_commented:
-                try:
-                    detail_payload = await self.controller.detail_feed(
-                        hostuin=entry.hostuin,
-                        fid=entry.fid,
-                        appid=entry.appid,
-                    )
-                    entry_data = detail_payload.get("entry")
-                    if isinstance(entry_data, dict):
-                        detail_entry = FeedEntry(**entry_data)
-                        if detail_entry.fid == entry.fid and detail_entry.hostuin == entry.hostuin:
-                            entry = detail_entry
-                except Exception as exc:
-                    if with_detail:
-                        raise
-                    logger.debug("qzone detail fetch for filtering failed: %s", exc)
-            post = post_from_entry(entry, detail=(detail_payload or {}).get("raw"), local_id=offset)
-            if detail_payload and detail_payload.get("comments"):
-                post.comments = [
-                    QzoneComment(
-                        commentid=str(item.get("commentid") or ""),
-                        uin=int(item.get("uin") or 0),
-                        nickname=str(item.get("nickname") or ""),
-                        content=str(item.get("content") or ""),
-                        created_at=int(item.get("created_at") or item.get("date") or 0),
-                        parent_id=str(item.get("parent_id") or ""),
-                    )
-                    for item in detail_payload.get("comments") or []
-                    if isinstance(item, dict)
-                ]
-                post.comment_count = max(post.comment_count, len(post.comments))
-            if no_self and login_uin and post.hostuin == login_uin:
-                continue
-            if no_commented and login_uin and any(comment.uin == login_uin for comment in post.comments):
-                continue
-            self._post_store().upsert(post)
-            posts.append(post)
-        return posts
 
     @staticmethod
     def _format_posts(posts: list[QzonePost], *, detail: bool = False) -> str:
@@ -1269,60 +1188,22 @@ class QzoneStablePlugin(Star):
         provider_id: str = "",
         system_prompt: str = "",
     ) -> str:
-        context = getattr(self, "_context", None) or getattr(self, "context", None)
-        provider = None
-        if context is not None:
-            try:
-                getter = getattr(context, "get_provider_by_id", None)
-                provider = getter(provider_id) if provider_id and callable(getter) else None
-            except Exception:
-                provider = None
-            if provider is None:
-                try:
-                    getter = getattr(context, "get_using_provider", None)
-                    provider = getter() if callable(getter) else None
-                except Exception:
-                    provider = None
-        text_chat = getattr(provider, "text_chat", None)
-        if callable(text_chat):
-            kwargs: dict[str, Any] = {"prompt": prompt}
-            if system_prompt:
-                kwargs["system_prompt"] = system_prompt
-            response = await self._maybe_await(text_chat(**kwargs))
-            return self._text_from_llm_response(response)
-        generator = getattr(context, "llm_generate", None)
-        if callable(generator):
-            kwargs: dict[str, Any] = {"prompt": prompt}
-            if system_prompt:
-                kwargs["system_prompt"] = system_prompt
-            if provider_id:
-                kwargs["chat_provider_id"] = provider_id
-            try:
-                response = await self._maybe_await(generator(**kwargs))
-            except TypeError:
-                kwargs.pop("chat_provider_id", None)
-                response = await self._maybe_await(generator(**kwargs))
-            return self._text_from_llm_response(response)
-        return ""
+        return await self._llm_adapter().generate_text(
+            event,
+            prompt,
+            provider_id=provider_id,
+            system_prompt=system_prompt,
+        )
 
     async def _generate_post_text(self, event: AstrMessageEvent, topic: str = "") -> str:
-        prompt = self.settings.post_prompt
-        if topic.strip():
-            prompt = f"{prompt}\n\n主题：{topic.strip()}"
         history = await self._chat_history_context(event)
-        if history:
-            prompt = f"{prompt}\n\n聊天记录参考：\n{truncate(history, 8000)}"
-        return await self._generate_text(event, prompt, provider_id=self.settings.post_provider_id)
+        return await self._llm_adapter().generate_post_text(event, topic, history=history)
 
     async def _generate_comment_text(self, event: AstrMessageEvent, post: QzonePost) -> str:
-        prompt = f"{self.settings.comment_prompt}\n\n说说内容：{post.summary}"
-        text = await self._generate_text(event, prompt, provider_id=self.settings.comment_provider_id)
-        return re.sub(r"[\s\u3000]+", "", text).rstrip("。")
+        return await self._llm_adapter().generate_comment_text(event, post)
 
     async def _generate_reply_text(self, event: AstrMessageEvent, post: QzonePost, comment: QzoneComment) -> str:
-        prompt = f"{self.settings.reply_prompt}\n\n说说内容：{post.summary}\n评论：{comment.content}"
-        text = await self._generate_text(event, prompt, provider_id=self.settings.reply_provider_id)
-        return re.sub(r"[\s\u3000]+", "", text).rstrip("。")
+        return await self._llm_adapter().generate_reply_text(event, post, comment)
 
     @staticmethod
     def _cron_delay_seconds(cron: str, offset_seconds: int) -> float:
@@ -1431,15 +1312,9 @@ class QzoneStablePlugin(Star):
             text = await self._generate_comment_text(None, post)  # type: ignore[arg-type]
             if not text.strip():
                 continue
-            await self.controller.comment_post(
-                hostuin=entry.hostuin,
-                fid=entry.fid,
-                content=text.strip(),
-                appid=entry.appid,
-                busi_param=entry.busi_param,
-            )
+            await self._post_service().comment_post(post, text.strip())
             if self.settings.like_when_comment:
-                await self.controller.like_post(hostuin=entry.hostuin, fid=entry.fid, appid=entry.appid)
+                await self._post_service().like_post(post)
             commented_keys.add(key)
             self._save_auto_comment_keys(commented_keys)
             break
@@ -1617,15 +1492,9 @@ class QzoneStablePlugin(Star):
             content = await self._generate_comment_text(event, post)
             if not content.strip():
                 return
-            await self.controller.comment_post(
-                hostuin=post.hostuin,
-                fid=post.fid,
-                content=content.strip(),
-                appid=post.appid,
-                busi_param=post.busi_param,
-            )
+            await self._post_service().comment_post(post, content.strip())
             if self.settings.like_when_comment:
-                await self.controller.like_post(hostuin=post.hostuin, fid=post.fid, appid=post.appid)
+                await self._post_service().like_post(post)
         except Exception as exc:
             logger.debug("qzone probabilistic read/comment failed: %s", exc)
 
@@ -1657,30 +1526,25 @@ class QzoneStablePlugin(Star):
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
-            posts = await self._posts_for_event(
-                event,
-                ("评说说", "评论说说", "读说说"),
+            selection = self._selection_for_event(event, ("评说说", "评论说说", "读说说"))
+            posts = await self._posts_for_selection(
+                selection,
                 with_detail=True,
                 no_commented=True,
                 no_self=True,
+                login_uin=self._self_id(event),
             )
             if not posts:
                 yield self._command_result(event, "没有找到适合评论的说说。")
                 return
             lines: list[str] = []
             for post in posts:
-                content = await self._generate_comment_text(event, post)
+                content = selection.comment_text or await self._generate_comment_text(event, post)
                 if not content.strip():
                     content = "挺有意思的。"
-                await self.controller.comment_post(
-                    hostuin=post.hostuin,
-                    fid=post.fid,
-                    content=content.strip(),
-                    appid=post.appid,
-                    busi_param=post.busi_param,
-                )
+                await self._post_service().comment_post(post, content)
                 if self.settings.like_when_comment:
-                    await self.controller.like_post(hostuin=post.hostuin, fid=post.fid, appid=post.appid)
+                    await self._post_service().like_post(post)
                 lines.append(f"已评论第 {post.local_id} 条：{truncate(content, 60)}")
         except QzoneBridgeError as exc:
             yield self._command_result(event, self._error_text(exc))
@@ -1698,7 +1562,7 @@ class QzoneStablePlugin(Star):
                 return
             lines: list[str] = []
             for post in posts:
-                payload = await self.controller.like_post(hostuin=post.hostuin, fid=post.fid, appid=post.appid)
+                payload = await self._post_service().like_post(post)
                 lines.append(format_like_result(payload))
         except QzoneBridgeError as exc:
             yield self._command_result(event, self._error_text(exc))
@@ -1955,9 +1819,10 @@ class QzoneStablePlugin(Star):
         text = "\n".join(
             [
                 "QQ 空间命令",
+                "序号从 1 开始；最新/0 表示最新一条，支持 1~3、@用户 2。",
                 "查看访客",
                 "看说说/查看说说 [@用户] [序号/范围]",
-                "评说说/评论说说/读说说 [@用户] [序号/范围]",
+                "评说说/评论说说/读说说 [@用户] [序号/范围] [评论内容]",
                 "赞说说 [@用户] [序号/范围]",
                 "发说说 <内容> [图片]",
                 "写说说/写稿 <主题> [图片]",
@@ -1981,6 +1846,7 @@ class QzoneStablePlugin(Star):
                 "llm_publish_feed",
                 "qzone_get_status",
                 "qzone_list_feed",
+                "qzone_view_post",
                 "qzone_detail_feed",
                 "qzone_publish_post",
                 "qzone_comment_post",
@@ -2147,34 +2013,28 @@ class QzoneStablePlugin(Star):
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
             hostuin = int(user_id or self._sender_id(event) or 0)
-            limit = self.settings.max_feed_limit if pos < 0 else min(max(pos + 1, 1), self.settings.max_feed_limit)
-            payload = await self.controller.list_feeds(hostuin=hostuin, limit=limit, scope="profile")
-            entries = self._to_feed_entries(payload)
-            if not entries:
+            selection = PostSelection(
+                target_uin=hostuin,
+                start=(pos + 1 if pos >= 0 else -1),
+                end=(pos + 1 if pos >= 0 else -1),
+                selector="index" if pos >= 0 else "last",
+            )
+            posts = await self._posts_for_selection(selection, with_detail=True, login_uin=self._self_id(event))
+            if not posts:
                 return "查询结果为空。"
-            entry = entries[pos] if 0 <= pos < len(entries) else entries[-1]
-            detail = await self.controller.detail_feed(hostuin=entry.hostuin, fid=entry.fid, appid=entry.appid)
-            entry_data = detail.get("entry")
-            detail_entry = FeedEntry(**entry_data) if isinstance(entry_data, dict) else entry
-            post = post_from_entry(detail_entry, detail=detail.get("raw"), local_id=pos)
+            post = posts[0]
             actions: list[str] = []
             if reply:
                 content = await self._generate_comment_text(event, post)
                 if not content.strip():
                     content = "挺有意思的。"
-                await self.controller.comment_post(
-                    hostuin=post.hostuin,
-                    fid=post.fid,
-                    content=content.strip(),
-                    appid=post.appid,
-                    busi_param=post.busi_param,
-                )
+                await self._post_service().comment_post(post, content.strip())
                 actions.append("已评论")
             if like:
-                await self.controller.like_post(hostuin=post.hostuin, fid=post.fid, appid=post.appid)
+                await self._post_service().like_post(post)
                 actions.append("已点赞")
             prefix = "，".join(actions)
-            return "\n".join(part for part in (prefix, post.detail_text(pos)) if part)
+            return "\n".join(part for part in (prefix, post.detail_text(post.local_id)) if part)
         except Exception as exc:
             logger.warning("llm_view_feed failed: %s", exc)
             return str(getattr(exc, "message", str(exc)))
@@ -2227,23 +2087,34 @@ class QzoneStablePlugin(Star):
         yield event.plain_result(format_status(payload))
 
     @filter.llm_tool(name="qzone_list_feed")
-    async def tool_list_feed(self, event: AstrMessageEvent, hostuin: int = 0, limit: int = 5, cursor: str = "", scope: str = ""):
+    async def tool_list_feed(
+        self,
+        event: AstrMessageEvent,
+        target_uin: int = 0,
+        limit: int = 5,
+        cursor: str = "",
+        scope: str = "auto",
+        hostuin: int = 0,
+    ):
         """获取 QQ 空间说说列表。
 
         Args:
-            hostuin (number): 目标 QQ 号，0 表示当前登录账号。
+            target_uin (number): 目标 QQ 号，0 表示当前登录账号或好友动态流。
             limit (number): 返回数量。
             cursor (string): 翻页游标。
-            scope (string): self ? profile?
+            scope (string): auto/self/profile。
+            hostuin (number): 兼容旧参数，优先级低于 target_uin。
         """
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
+            effective_hostuin = int(target_uin or hostuin or 0)
+            effective_scope = "" if scope == "auto" else scope
             payload = await self.controller.list_feeds(
-                hostuin=hostuin,
+                hostuin=effective_hostuin,
                 limit=self._limit(limit),
                 cursor=cursor,
-                scope=scope,
+                scope=effective_scope,
             )
         except QzoneBridgeError as exc:
             yield event.plain_result(self._error_text(exc))
@@ -2268,6 +2139,43 @@ class QzoneStablePlugin(Star):
             yield event.plain_result(self._error_text(exc))
             return
         yield event.plain_result(self._render_detail(payload))
+
+    @filter.llm_tool(name="qzone_view_post")
+    async def tool_view_post(
+        self,
+        event: AstrMessageEvent,
+        target_uin: int = 0,
+        selector: str = "latest",
+        detail: bool = True,
+        hostuin: int = 0,
+        fid: str = "",
+        appid: int = 311,
+    ):
+        """按自然选择器查看一条或多条 QQ 空间说说。
+
+        Args:
+            target_uin (number): 目标 QQ 号，0 表示当前登录账号或好友动态流。
+            selector (string): latest、最新、第2条、2、1~3 或 fid。
+            detail (boolean): 是否获取评论等详情。
+            hostuin (number): 兼容旧参数。
+            fid (string): 兼容旧参数。
+            appid (number): 兼容旧参数。
+        """
+        try:
+            await self._ensure_cookie_ready(event)
+            await self._ensure_daemon()
+            selection = selection_from_tool_args(
+                target_uin=target_uin,
+                selector=selector,
+                hostuin=hostuin,
+                fid=fid,
+                appid=appid,
+            )
+            posts = await self._posts_for_selection(selection, with_detail=detail, login_uin=self._self_id(event))
+        except QzoneBridgeError as exc:
+            yield event.plain_result(self._error_text(exc))
+            return
+        yield event.plain_result(self._format_posts(posts, detail=detail))
 
     @filter.llm_tool(name="qzone_publish_post")
     async def tool_publish_post(
@@ -2321,50 +2229,109 @@ class QzoneStablePlugin(Star):
     async def tool_comment_post(
         self,
         event: AstrMessageEvent,
-        hostuin: int,
-        fid: str,
-        content: str,
+        target_uin: int = 0,
+        selector: str = "latest",
+        content: str = "",
+        auto_generate: bool = True,
+        private: bool = False,
+        like_after_comment: bool = False,
+        hostuin: int = 0,
+        fid: str = "",
         confirm: bool = False,
         appid: int = 311,
-        private: bool = False,
+        latest: bool = False,
+        index: int = 0,
     ):
-        """评论一条说说。
+        """按自然选择器评论一条说说。
 
         Args:
-            hostuin (number): 目标 QQ 号。
-            fid (string): 说说 fid。
-            content (string): 评论内容。
-            confirm (boolean): 是否确认评论。
-            appid (number): 应用 id。
+            target_uin (number): 目标 QQ 号，0 表示当前登录账号或好友动态流。
+            selector (string): latest、最新、第2条、2、1~3 或 fid。
+            content (string): 评论内容，留空时可由 LLM 生成。
+            auto_generate (boolean): content 为空时是否自动生成评论。
             private (boolean): 是否私密评论。
+            like_after_comment (boolean): 评论后是否顺手点赞。
+            hostuin/fid/confirm/appid/latest/index: 兼容旧参数。
         """
+        arguments = {
+            "target_uin": target_uin,
+            "selector": selector,
+            "content": content,
+            "auto_generate": auto_generate,
+            "private": private,
+            "like_after_comment": like_after_comment,
+            "hostuin": hostuin,
+            "fid": fid,
+            "confirm": confirm,
+            "appid": appid,
+            "latest": latest,
+            "index": index,
+        }
         if not self._is_admin(event):
-            yield event.plain_result("只有管理员可以评论。")
-            return
-        if self.settings.preview_writes and not confirm:
-            yield event.plain_result(
-                f"评论预览: hostuin={hostuin}, fid={fid}, content={truncate(content, 120)}。确认后再发布。"
+            payload = {"ok": False, "tool": "qzone_comment_post", "public_reason": "没有权限"}
+            self._log_tool_call_result({**payload, "arguments": arguments})
+            text = await self._ask_llm_tool_reply(
+                event,
+                payload,
+                self._llm_error_fallback_text("没有权限"),
             )
+            yield event.plain_result(text)
             return
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
-            payload = await self.controller.comment_post(
+            selection = selection_from_tool_args(
+                target_uin=target_uin,
+                selector=selector,
                 hostuin=hostuin,
                 fid=fid,
-                content=content,
                 appid=appid,
-                private=private,
+                latest=latest,
+                index=index,
             )
+            posts = await self._posts_for_selection(
+                selection,
+                with_detail=auto_generate and not content.strip(),
+                login_uin=self._self_id(event),
+            )
+            if not posts:
+                raise QzoneBridgeError("没有找到可评论的说说")
+            results: list[dict[str, Any]] = []
+            for post in posts:
+                comment_text = content.strip()
+                if not comment_text and auto_generate:
+                    comment_text = await self._generate_comment_text(event, post)
+                if not comment_text:
+                    raise QzoneBridgeError("评论内容为空")
+                payload = await self._post_service().comment_post(post, comment_text, private=private)
+                results.append({"post": QzonePostService.post_payload(post), "comment": comment_text, "result": payload})
+                if like_after_comment:
+                    await self._post_service().like_post(post)
         except QzoneBridgeError as exc:
-            yield event.plain_result(self._error_text(exc))
+            log_payload = self._bridge_error_log_payload("qzone_comment_post", exc, arguments)
+            self._log_tool_call_result(log_payload)
+            text = await self._ask_llm_tool_reply(
+                event,
+                self._llm_error_payload("qzone_comment_post", exc),
+                self._llm_error_fallback_text(exc.message),
+            )
+            yield event.plain_result(text)
             return
-        yield event.plain_result(format_action_result("评论结果", payload))
+        log_payload = {"ok": True, "tool": "qzone_comment_post", "arguments": arguments, "result": results}
+        self._log_tool_call_result(log_payload)
+        text = await self._ask_llm_tool_reply(
+            event,
+            {"ok": True, "tool": "qzone_comment_post", "result": {"message": "评论发好了。", "count": len(results)}},
+            "评论发好了。",
+        )
+        yield event.plain_result(text)
 
     @filter.llm_tool(name="qzone_like_post")
     async def tool_like_post(
         self,
         event: AstrMessageEvent,
+        target_uin: int = 0,
+        selector: str = "latest",
         hostuin: int = 0,
         fid: str = "",
         confirm: bool = False,
@@ -2376,8 +2343,10 @@ class QzoneStablePlugin(Star):
         """点赞或取消点赞一条说说。
 
         Args:
-            hostuin (number): 目标 QQ 号，`0` 表示当前登录账号。
-            fid (string): 说说 fid，也可以用最近列表的序号。
+            target_uin (number): 目标 QQ 号，`0` 表示当前登录账号或好友动态流。
+            selector (string): latest、最新、第2条、2、1~3 或 fid。
+            hostuin (number): 兼容旧参数，目标 QQ 号。
+            fid (string): 兼容旧参数，说说 fid，也可以用最近列表的序号。
             confirm (boolean): 兼容旧参数，目前不会拦截执行。
             appid (number): 说说 appid，默认 `311`。
             unlike (boolean): 为 `true` 时取消点赞。
@@ -2385,6 +2354,8 @@ class QzoneStablePlugin(Star):
             index (number): 操作最近列表第 N 条，`1` 表示第一条。
         """
         arguments = {
+            "target_uin": target_uin,
+            "selector": selector,
             "hostuin": hostuin,
             "fid": fid,
             "confirm": confirm,
@@ -2419,14 +2390,35 @@ class QzoneStablePlugin(Star):
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
-            payload = await self.controller.like_post(
-                hostuin=hostuin,
-                fid=fid,
-                appid=appid,
-                unlike=unlike,
-                latest=latest,
-                index=index,
-            )
+            legacy_direct = bool(fid or latest or index)
+            if legacy_direct:
+                effective_hostuin = int(hostuin or target_uin or 0)
+                payload = await self.controller.like_post(
+                    hostuin=effective_hostuin,
+                    fid=fid,
+                    appid=appid,
+                    unlike=unlike,
+                    latest=latest,
+                    index=index,
+                )
+            else:
+                selection = selection_from_tool_args(
+                    target_uin=target_uin,
+                    selector=selector,
+                    hostuin=hostuin,
+                    appid=appid,
+                )
+                posts = await self._posts_for_selection(selection, login_uin=self._self_id(event))
+                if not posts:
+                    raise QzoneBridgeError("没有找到可点赞的说说")
+                payloads = [await self._post_service().like_post(post, unlike=unlike) for post in posts]
+                payload = payloads[0] if len(payloads) == 1 else {
+                    "action": "unlike" if unlike else "like",
+                    "liked": not unlike,
+                    "verified": all(item.get("verified", True) is not False for item in payloads),
+                    "summary": f"{len(payloads)} 条说说",
+                    "items": payloads,
+                }
         except QzoneBridgeError as exc:
             log_payload = self._bridge_error_log_payload("qzone_like_post", exc, arguments)
             self._log_tool_call_result(log_payload)

--- a/qzone_bridge/llm.py
+++ b/qzone_bridge/llm.py
@@ -1,0 +1,176 @@
+"""LLM adapter for Qzone writing, comments, and user-facing replies."""
+
+from __future__ import annotations
+
+import inspect
+import re
+from typing import Any
+
+from .social import QzoneComment, QzonePost
+from .utils import truncate
+
+
+class QzoneLLM:
+    def __init__(self, context: Any, settings: Any):
+        self.context = context
+        self.settings = settings
+
+    async def _maybe_await(self, value: Any) -> Any:
+        if inspect.isawaitable(value):
+            return await value
+        return value
+
+    @staticmethod
+    def text_from_response(response: Any) -> str:
+        if response is None:
+            return ""
+        if isinstance(response, str):
+            return response.strip()
+        for attr in ("completion_text", "text", "content", "message"):
+            value = getattr(response, attr, None)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        if isinstance(response, dict):
+            for key in ("completion_text", "text", "content", "message"):
+                value = response.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+        return ""
+
+    async def _provider_by_id(self, event: Any, provider_id: str = "") -> Any | None:
+        context = self.context
+        if context is None:
+            return None
+        if provider_id:
+            getter = getattr(context, "get_provider_by_id", None)
+            if callable(getter):
+                try:
+                    provider = await self._maybe_await(getter(provider_id))
+                except Exception:
+                    provider = None
+                if provider is not None:
+                    return provider
+        getter = getattr(context, "get_using_provider", None)
+        if not callable(getter):
+            return None
+
+        umo = getattr(event, "unified_msg_origin", None)
+        attempts: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        if umo is not None:
+            attempts.append(((), {"umo": umo}))
+            attempts.append(((umo,), {}))
+        attempts.append(((), {}))
+        for args, kwargs in attempts:
+            try:
+                provider = await self._maybe_await(getter(*args, **kwargs))
+            except TypeError:
+                continue
+            except Exception:
+                break
+            if provider is not None:
+                return provider
+        return None
+
+    async def current_provider_id(self, event: Any) -> Any | None:
+        getter = getattr(self.context, "get_current_chat_provider_id", None)
+        if not callable(getter):
+            return None
+        umo = getattr(event, "unified_msg_origin", None)
+        attempts: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        if umo is not None:
+            attempts.append(((), {"umo": umo}))
+            attempts.append(((umo,), {}))
+        attempts.append(((), {}))
+        for args, kwargs in attempts:
+            try:
+                provider_id = await self._maybe_await(getter(*args, **kwargs))
+            except TypeError:
+                continue
+            except Exception:
+                return None
+            if provider_id:
+                return provider_id
+        return None
+
+    async def generate_text(
+        self,
+        event: Any,
+        prompt: str,
+        *,
+        provider_id: str = "",
+        system_prompt: str = "",
+        prefer_current_provider: bool = False,
+    ) -> str:
+        provider = await self._provider_by_id(event, provider_id)
+        text_chat = getattr(provider, "text_chat", None)
+        if callable(text_chat):
+            attempts: list[dict[str, Any]] = [{"prompt": prompt}]
+            if system_prompt:
+                attempts.insert(0, {"prompt": prompt, "contexts": [], "system_prompt": system_prompt})
+                attempts.insert(1, {"prompt": prompt, "context": [], "system_prompt": system_prompt})
+            for kwargs in attempts:
+                try:
+                    response = await self._maybe_await(text_chat(**kwargs))
+                except TypeError:
+                    continue
+                return self.text_from_response(response)
+
+        generator = getattr(self.context, "llm_generate", None)
+        if callable(generator):
+            kwargs: dict[str, Any] = {"prompt": prompt}
+            if system_prompt:
+                kwargs["system_prompt"] = system_prompt
+            if provider_id:
+                kwargs["chat_provider_id"] = provider_id
+            elif prefer_current_provider:
+                current_provider_id = await self.current_provider_id(event)
+                if current_provider_id:
+                    kwargs["chat_provider_id"] = current_provider_id
+            try:
+                response = await self._maybe_await(generator(**kwargs))
+            except TypeError:
+                kwargs.pop("chat_provider_id", None)
+                response = await self._maybe_await(generator(**kwargs))
+            return self.text_from_response(response)
+        return ""
+
+    async def generate_post_text(self, event: Any, topic: str = "", *, history: str = "") -> str:
+        prompt = self.settings.post_prompt
+        if str(topic or "").strip():
+            prompt = f"{prompt}\n\n主题：{str(topic).strip()}"
+        if history:
+            prompt = f"{prompt}\n\n聊天记录参考：\n{truncate(history, 8000)}"
+        return await self.generate_text(event, prompt, provider_id=self.settings.post_provider_id)
+
+    def _comment_context(self, post: QzonePost) -> str:
+        lines = [f"说说内容：{post.summary or '(空)'}"]
+        if post.images:
+            lines.append("图片：" + "，".join(post.images[:6]))
+        visible_comments = [comment for comment in post.comments if comment.content][:8]
+        if visible_comments:
+            lines.append("已有评论：")
+            for comment in visible_comments:
+                name = comment.nickname or str(comment.uin or "用户")
+                lines.append(f"- {name}: {comment.content}")
+        return "\n".join(lines)
+
+    def _clean_short_reply(self, text: str) -> str:
+        cleaned = re.sub(r"[\s\u3000]+", "", str(text or "")).strip()
+        cleaned = cleaned.strip("\"'“”‘’")
+        cleaned = cleaned.rstrip("。.")
+        max_len = int(getattr(self.settings, "comment_max_length", 60) or 60)
+        return truncate(cleaned, max_len)
+
+    async def generate_comment_text(self, event: Any, post: QzonePost) -> str:
+        prompt = f"{self.settings.comment_prompt}\n\n{self._comment_context(post)}"
+        text = await self.generate_text(event, prompt, provider_id=self.settings.comment_provider_id)
+        return self._clean_short_reply(text)
+
+    async def generate_reply_text(self, event: Any, post: QzonePost, comment: QzoneComment) -> str:
+        prompt = (
+            f"{self.settings.reply_prompt}\n\n"
+            f"{self._comment_context(post)}\n"
+            f"要回复的评论：{comment.nickname or comment.uin}: {comment.content}"
+        )
+        text = await self.generate_text(event, prompt, provider_id=self.settings.reply_provider_id)
+        return self._clean_short_reply(text)

--- a/qzone_bridge/post_service.py
+++ b/qzone_bridge/post_service.py
@@ -1,0 +1,180 @@
+"""Business operations for viewing, commenting, and liking Qzone posts."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from typing import Any
+
+from .errors import QzoneParseError
+from .models import FeedEntry
+from .posts import PostStore
+from .selection import PostSelection
+from .social import QzoneComment, QzonePost, post_from_entry
+
+log = logging.getLogger(__name__)
+
+
+class QzonePostService:
+    def __init__(self, controller: Any, post_store: PostStore, *, max_feed_limit: int = 20):
+        self.controller = controller
+        self.post_store = post_store
+        self.max_feed_limit = max(1, int(max_feed_limit or 20))
+
+    def _to_feed_entries(self, payload: dict[str, Any]) -> list[FeedEntry]:
+        entries: list[FeedEntry] = []
+        for item in payload.get("items") or []:
+            if isinstance(item, FeedEntry):
+                entries.append(item)
+            elif isinstance(item, dict):
+                entries.append(FeedEntry(**item))
+        return entries
+
+    @staticmethod
+    def _comments_from_detail(detail_payload: dict[str, Any]) -> list[QzoneComment]:
+        comments: list[QzoneComment] = []
+        for item in detail_payload.get("comments") or []:
+            if not isinstance(item, dict):
+                continue
+            comments.append(
+                QzoneComment(
+                    commentid=str(item.get("commentid") or ""),
+                    uin=int(item.get("uin") or 0),
+                    nickname=str(item.get("nickname") or ""),
+                    content=str(item.get("content") or ""),
+                    created_at=int(item.get("created_at") or item.get("date") or 0),
+                    parent_id=str(item.get("parent_id") or ""),
+                )
+            )
+        return comments
+
+    async def _detail_post(self, entry: FeedEntry, *, local_id: int, required: bool) -> QzonePost:
+        detail_payload: dict[str, Any] | None = None
+        try:
+            detail_payload = await self.controller.detail_feed(
+                hostuin=entry.hostuin,
+                fid=entry.fid,
+                appid=entry.appid,
+            )
+            entry_data = detail_payload.get("entry")
+            if isinstance(entry_data, dict):
+                detail_entry = FeedEntry(**entry_data)
+                if detail_entry.fid == entry.fid and detail_entry.hostuin == entry.hostuin:
+                    entry = detail_entry
+        except Exception:
+            if required:
+                raise
+            log.debug("qzone detail fetch for post operation failed", exc_info=True)
+
+        post = post_from_entry(entry, detail=(detail_payload or {}).get("raw"), local_id=local_id)
+        if detail_payload and detail_payload.get("comments"):
+            post.comments = self._comments_from_detail(detail_payload)
+            post.comment_count = max(post.comment_count, len(post.comments))
+        return post
+
+    async def _post_from_fid(self, selection: PostSelection, *, with_detail: bool) -> QzonePost:
+        if not selection.target_uin or not selection.fid:
+            raise QzoneParseError("请同时提供 QQ 号和说说 fid。")
+        if with_detail:
+            detail_payload = await self.controller.detail_feed(
+                hostuin=selection.target_uin,
+                fid=selection.fid,
+                appid=selection.appid,
+            )
+            entry_data = detail_payload.get("entry")
+            entry = (
+                FeedEntry(**entry_data)
+                if isinstance(entry_data, dict)
+                else FeedEntry(
+                    hostuin=selection.target_uin,
+                    fid=selection.fid,
+                    appid=selection.appid,
+                    summary="",
+                )
+            )
+            post = post_from_entry(entry, detail=detail_payload.get("raw"), local_id=1)
+            post.comments = self._comments_from_detail(detail_payload)
+            post.comment_count = max(post.comment_count, len(post.comments))
+            self.post_store.upsert(post)
+            return post
+
+        post = QzonePost(
+            hostuin=selection.target_uin,
+            fid=selection.fid,
+            appid=selection.appid,
+            local_id=1,
+        )
+        self.post_store.upsert(post)
+        return post
+
+    async def resolve_posts(
+        self,
+        selection: PostSelection,
+        *,
+        with_detail: bool = False,
+        no_commented: bool = False,
+        no_self: bool = False,
+        login_uin: int = 0,
+    ) -> list[QzonePost]:
+        if selection.is_fid:
+            post = await self._post_from_fid(selection, with_detail=with_detail or no_commented)
+            if no_self and login_uin and post.hostuin == login_uin:
+                return []
+            if no_commented and login_uin and any(comment.uin == login_uin for comment in post.comments):
+                return []
+            return [post]
+
+        limit = self.max_feed_limit if selection.is_last else min(selection.limit, self.max_feed_limit)
+        payload = await self.controller.list_feeds(
+            hostuin=selection.target_uin,
+            limit=limit,
+            scope="profile" if selection.target_uin else "",
+        )
+        entries = self._to_feed_entries(payload)
+        if selection.is_last:
+            selected_entries = entries[-1:] if entries else []
+            local_start = len(entries)
+        else:
+            start_index = max(selection.start - 1, 0)
+            end_index = max(selection.end - 1, start_index)
+            selected_entries = entries[start_index : end_index + 1]
+            local_start = selection.start
+
+        posts: list[QzonePost] = []
+        for offset, entry in enumerate(selected_entries, start=local_start):
+            post = await self._detail_post(entry, local_id=offset, required=with_detail)
+            if no_self and login_uin and post.hostuin == login_uin:
+                continue
+            if no_commented and login_uin and any(comment.uin == login_uin for comment in post.comments):
+                continue
+            self.post_store.upsert(post)
+            posts.append(post)
+        return posts
+
+    async def comment_post(
+        self,
+        post: QzonePost,
+        content: str,
+        *,
+        private: bool = False,
+    ) -> dict[str, Any]:
+        if not str(content or "").strip():
+            raise QzoneParseError("评论内容不能为空。")
+        return await self.controller.comment_post(
+            hostuin=post.hostuin,
+            fid=post.fid,
+            content=str(content).strip(),
+            appid=post.appid,
+            private=private,
+            busi_param=post.busi_param,
+        )
+
+    async def like_post(self, post: QzonePost, *, unlike: bool = False) -> dict[str, Any]:
+        return await self.controller.like_post(hostuin=post.hostuin, fid=post.fid, appid=post.appid, unlike=unlike)
+
+    @staticmethod
+    def post_payload(post: QzonePost) -> dict[str, Any]:
+        payload = post.to_dict()
+        payload.pop("raw", None)
+        payload["comments"] = [asdict(comment) for comment in post.comments]
+        return payload

--- a/qzone_bridge/selection.py
+++ b/qzone_bridge/selection.py
@@ -1,0 +1,184 @@
+"""User-facing post target selection for Qzone operations."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+LATEST_ALIASES = {
+    "",
+    "0",
+    "1",
+    "latest",
+    "lastest",
+    "最新",
+    "最新一条",
+    "最近",
+    "第一条",
+    "第1条",
+    "第 1 条",
+}
+LAST_ALIASES = {"-1", "最后", "最后一条"}
+
+
+@dataclass(slots=True)
+class PostSelection:
+    target_uin: int = 0
+    start: int = 1
+    end: int = 1
+    selector: str = "latest"
+    fid: str = ""
+    appid: int = 311
+    comment_text: str = ""
+
+    @property
+    def is_fid(self) -> bool:
+        return bool(self.fid)
+
+    @property
+    def is_last(self) -> bool:
+        return self.start < 0 or self.end < 0
+
+    @property
+    def limit(self) -> int:
+        if self.is_fid or self.is_last:
+            return 1
+        return max(self.start, self.end, 1)
+
+
+def strip_command_prefix(text: str, command_names: tuple[str, ...] = ()) -> str:
+    value = str(text or "").strip()
+    value = re.sub(r"^(?:[!/／]\s*)", "", value).strip()
+    for name in sorted(command_names, key=len, reverse=True):
+        if value == name:
+            return ""
+        if value.startswith(name):
+            rest = value[len(name) :]
+            if not rest or rest[0].isspace() or rest[0] in {":", "："}:
+                return rest.lstrip(" \t:：")
+    return value
+
+
+def _extract_at_targets(text: str) -> tuple[list[int], str]:
+    targets: list[int] = []
+
+    def replace(match: re.Match[str]) -> str:
+        raw = match.group(1) or match.group(2)
+        if raw and raw.isdigit():
+            targets.append(int(raw))
+        return " "
+
+    cleaned = re.sub(r"\[CQ:at,qq=(\d+)[^\]]*\]|@(\d{5,})", replace, text, count=1)
+    return targets, cleaned.strip()
+
+
+def _parse_selector(token: str) -> tuple[int, int, str] | None:
+    value = str(token or "").strip()
+    value_lower = value.lower()
+    if value in LATEST_ALIASES or value_lower in LATEST_ALIASES:
+        return 1, 1, "latest"
+    if value in LAST_ALIASES:
+        return -1, -1, "last"
+
+    normalized = value.translate(str.maketrans("０１２３４５６７８９", "0123456789"))
+    ordinal = re.fullmatch(r"第\s*(\d+)\s*(?:条|條)?", normalized)
+    if ordinal:
+        index = max(1, int(ordinal.group(1)))
+        return index, index, "index"
+
+    match = re.fullmatch(r"(\d+)(?:\s*(?:~|～|-|－)\s*(\d+))?", normalized)
+    if not match:
+        return None
+    start = int(match.group(1))
+    end = int(match.group(2) if match.group(2) is not None else start)
+    if start <= 0:
+        return 1, 1, "latest"
+    if end <= 0:
+        end = start
+    if end < start:
+        start, end = end, start
+    return start, end, "range" if start != end else "index"
+
+
+def _looks_like_fid(value: str) -> bool:
+    text = str(value or "").strip()
+    if not text:
+        return False
+    if _parse_selector(text) is not None:
+        return False
+    return bool(re.fullmatch(r"[A-Za-z0-9_.:-]{6,}", text))
+
+
+def parse_post_selection(text: str, command_names: tuple[str, ...] = ()) -> PostSelection:
+    raw = strip_command_prefix(text, command_names)
+    at_targets, raw = _extract_at_targets(raw)
+    tokens = raw.split()
+
+    target_uin = at_targets[0] if at_targets else 0
+    if not target_uin and tokens and re.fullmatch(r"\d{5,}", tokens[0]):
+        target_uin = int(tokens.pop(0))
+
+    if tokens and target_uin and _looks_like_fid(tokens[0]):
+        fid = tokens.pop(0)
+        appid = 311
+        if tokens and tokens[0].isdigit():
+            appid = int(tokens.pop(0))
+        return PostSelection(
+            target_uin=target_uin,
+            fid=fid,
+            appid=appid,
+            selector="fid",
+            comment_text=" ".join(tokens).strip(),
+        )
+
+    start, end, selector = 1, 1, "latest"
+    if tokens:
+        parsed = _parse_selector(tokens[0])
+        if parsed is not None:
+            start, end, selector = parsed
+            tokens.pop(0)
+
+    return PostSelection(
+        target_uin=target_uin,
+        start=start,
+        end=end,
+        selector=selector,
+        comment_text=" ".join(tokens).strip(),
+    )
+
+
+def selection_from_tool_args(
+    *,
+    target_uin: int = 0,
+    selector: str = "latest",
+    hostuin: int = 0,
+    fid: str = "",
+    appid: int = 311,
+    latest: bool = False,
+    index: int = 0,
+) -> PostSelection:
+    effective_target = int(target_uin or hostuin or 0)
+    if fid and not latest and index <= 0:
+        return PostSelection(
+            target_uin=effective_target,
+            fid=str(fid),
+            appid=int(appid or 311),
+            selector="fid",
+        )
+    if latest:
+        return PostSelection(target_uin=effective_target, start=1, end=1, selector="latest")
+    if index > 0:
+        return PostSelection(target_uin=effective_target, start=int(index), end=int(index), selector="index")
+
+    parsed = _parse_selector(str(selector or "latest"))
+    if parsed is None:
+        if _looks_like_fid(str(selector or "")):
+            return PostSelection(
+                target_uin=effective_target,
+                fid=str(selector).strip(),
+                appid=int(appid or 311),
+                selector="fid",
+            )
+        parsed = (1, 1, "latest")
+    start, end, mode = parsed
+    return PostSelection(target_uin=effective_target, start=start, end=end, selector=mode)

--- a/qzone_bridge/settings.py
+++ b/qzone_bridge/settings.py
@@ -102,6 +102,7 @@ class PluginSettings:
     post_prompt: str = "找出一个你感兴趣的主题来写一段适合 QQ 空间的说说，简短、有个性、不要解释。"
     comment_provider_id: str = ""
     comment_prompt: str = "生成一句简短、直接、贴题的评论，不要解释。"
+    comment_max_length: int = 60
     reply_provider_id: str = ""
     reply_prompt: str = "这条帖子收到了一条评论，请自然回复此条评论，不要解释。"
     ignore_groups: list[str] = field(default_factory=list)
@@ -151,6 +152,7 @@ class PluginSettings:
             post_prompt=str(_nested(mapping, "llm", "post_prompt", cls.post_prompt) or cls.post_prompt),
             comment_provider_id=str(_nested(mapping, "llm", "comment_provider_id", "") or ""),
             comment_prompt=str(_nested(mapping, "llm", "comment_prompt", cls.comment_prompt) or cls.comment_prompt),
+            comment_max_length=int(_nested(mapping, "llm", "comment_max_length", 60) or 60),
             reply_provider_id=str(_nested(mapping, "llm", "reply_provider_id", "") or ""),
             reply_prompt=str(_nested(mapping, "llm", "reply_prompt", cls.reply_prompt) or cls.reply_prompt),
             ignore_groups=[str(item) for item in _as_list(_nested(mapping, "source", "ignore_groups", []))],

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,30 @@
+import asyncio
+import types
+import unittest
+from unittest.mock import AsyncMock
+
+from qzone_bridge.llm import QzoneLLM
+
+
+class QzoneLLMTests(unittest.TestCase):
+    def test_generate_text_awaits_async_provider_lookup(self):
+        provider = types.SimpleNamespace(
+            text_chat=AsyncMock(return_value=types.SimpleNamespace(completion_text="自然回复"))
+        )
+        context = types.SimpleNamespace(get_using_provider=AsyncMock(return_value=provider))
+        settings = types.SimpleNamespace()
+        llm = QzoneLLM(context, settings)
+
+        text = asyncio.run(llm.generate_text(None, "把结果说自然点", system_prompt="不要暴露内部字段"))
+
+        self.assertEqual(text, "自然回复")
+        context.get_using_provider.assert_awaited_once()
+        provider.text_chat.assert_awaited_once_with(
+            prompt="把结果说自然点",
+            contexts=[],
+            system_prompt="不要暴露内部字段",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -531,6 +531,76 @@ class MainPublishTests(unittest.TestCase):
             index=2,
         )
 
+    def test_llm_like_tool_accepts_semantic_selector(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin._context = types.SimpleNamespace(
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="第 2 条已经点好了。")),
+        )
+        entries = [
+            module.FeedEntry(hostuin=123456, fid="fid-1", appid=311, summary="one"),
+            module.FeedEntry(hostuin=123456, fid="fid-2", appid=311, summary="two", busi_param={"ugc": 1}),
+        ]
+        plugin.controller.list_feeds = AsyncMock(return_value={"items": [asdict(item) for item in entries]})
+        plugin.controller.like_post = AsyncMock(
+            return_value={
+                "action": "like",
+                "liked": True,
+                "verified": True,
+                "already": False,
+                "summary": "two",
+            }
+        )
+        event = Event([])
+
+        results = asyncio.run(
+            collect_async_generator(
+                plugin.tool_like_post(event, target_uin=123456, selector="2")
+            )
+        )
+
+        plugin.controller.list_feeds.assert_awaited_once()
+        plugin.controller.like_post.assert_awaited_once_with(
+            hostuin=123456,
+            fid="fid-2",
+            appid=311,
+            unlike=False,
+        )
+        self.assertEqual(results[0], "第 2 条已经点好了。")
+
+    def test_llm_like_tool_uses_target_uin_for_legacy_fid(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin._context = types.SimpleNamespace(
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="这条已经点好了。")),
+        )
+        plugin.controller.like_post = AsyncMock(
+            return_value={
+                "action": "like",
+                "liked": True,
+                "verified": True,
+                "already": False,
+                "summary": "hello",
+            }
+        )
+        event = Event([])
+
+        results = asyncio.run(
+            collect_async_generator(
+                plugin.tool_like_post(event, target_uin=123456, fid="fid-1")
+            )
+        )
+
+        plugin.controller.like_post.assert_awaited_once_with(
+            hostuin=123456,
+            fid="fid-1",
+            appid=311,
+            unlike=False,
+            latest=False,
+            index=0,
+        )
+        self.assertEqual(results[0], "这条已经点好了。")
+
     def test_llm_like_tool_ignores_preview_confirmation(self):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
@@ -700,7 +770,7 @@ class MainPublishTests(unittest.TestCase):
         self.assertNotIn("raw", results[0])
         self.assertFalse(results[0].lstrip().startswith("{"))
 
-    def test_target_range_parser_supports_at_and_zero_based_range(self):
+    def test_target_range_parser_supports_at_and_one_based_range(self):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         event = Event([], message_str="看说说 @123456 2~4")
@@ -725,7 +795,7 @@ class MainPublishTests(unittest.TestCase):
                 "raw": {},
             }
         )
-        event = Event([], message_str="看说说 1")
+        event = Event([], message_str="看说说 2")
 
         results = asyncio.run(collect_async_generator(plugin.view_feed(event)))
 
@@ -754,6 +824,68 @@ class MainPublishTests(unittest.TestCase):
 
         plugin.controller.comment_post.assert_awaited_once()
         self.assertEqual(plugin.controller.comment_post.await_args.kwargs["busi_param"], {"ugc": 1})
+
+    def test_llm_comment_tool_generates_comment_from_semantic_selector(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin.settings.preview_writes = True
+        plugin._context = types.SimpleNamespace(
+            llm_generate=AsyncMock(
+                side_effect=[
+                    types.SimpleNamespace(completion_text="真不错"),
+                    types.SimpleNamespace(completion_text="评论好了。"),
+                ]
+            ),
+        )
+        entries = [
+            module.FeedEntry(hostuin=123456, fid="fid-1", appid=311, summary="one"),
+            module.FeedEntry(hostuin=123456, fid="fid-2", appid=311, summary="two"),
+        ]
+        plugin.controller.list_feeds = AsyncMock(return_value={"items": [asdict(item) for item in entries]})
+        plugin.controller.detail_feed = AsyncMock(
+            return_value={
+                "entry": asdict(entries[1]),
+                "comments": [{"commentid": "c1", "uin": 9988, "nickname": "Alice", "content": "nice"}],
+                "raw": {},
+            }
+        )
+        plugin.controller.comment_post = AsyncMock(return_value={"commentid": "c2", "message": "ok"})
+        event = Event([])
+
+        results = asyncio.run(
+            collect_async_generator(
+                plugin.tool_comment_post(event, target_uin=123456, selector="2", content="")
+            )
+        )
+
+        plugin.controller.comment_post.assert_awaited_once_with(
+            hostuin=123456,
+            fid="fid-2",
+            content="真不错",
+            appid=311,
+            private=False,
+            busi_param={},
+        )
+        first_prompt = plugin._context.llm_generate.await_args_list[0].kwargs["prompt"]
+        self.assertIn("说说内容：two", first_prompt)
+        self.assertIn("Alice: nice", first_prompt)
+        self.assertNotIn("fid-2", first_prompt)
+        self.assertEqual(results[0], "评论好了。")
+
+    def test_comment_feed_uses_explicit_comment_text_without_llm(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        entry = module.FeedEntry(hostuin=123456, fid="fid-1", appid=311, summary="hello")
+        plugin.controller.list_feeds = AsyncMock(return_value={"items": [asdict(entry)]})
+        plugin.controller.detail_feed = AsyncMock(return_value={"entry": asdict(entry), "comments": [], "raw": {}})
+        plugin.controller.comment_post = AsyncMock(return_value={"commentid": "c1"})
+        plugin._generate_comment_text = AsyncMock(return_value="should-not-use")
+        event = Event([], message_str="评说说 1 写得真好")
+
+        asyncio.run(collect_async_generator(plugin.comment_feed(event)))
+
+        plugin._generate_comment_text.assert_not_awaited()
+        self.assertEqual(plugin.controller.comment_post.await_args.kwargs["content"], "写得真好")
 
     def test_contribution_approve_publishes_draft(self):
         module = self.load_main_module()

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,0 +1,53 @@
+import unittest
+
+from qzone_bridge.selection import parse_post_selection, selection_from_tool_args
+
+
+class PostSelectionTests(unittest.TestCase):
+    def test_latest_aliases_select_first_post(self):
+        selection = parse_post_selection("看说说 最新", ("看说说",))
+
+        self.assertEqual(selection.target_uin, 0)
+        self.assertEqual((selection.start, selection.end), (1, 1))
+        self.assertEqual(selection.selector, "latest")
+
+    def test_chinese_ordinal_and_plain_number_are_one_based(self):
+        ordinal = parse_post_selection("看说说 第2条", ("看说说",))
+        plain = parse_post_selection("赞说说 2", ("赞说说",))
+
+        self.assertEqual((ordinal.start, ordinal.end), (2, 2))
+        self.assertEqual((plain.start, plain.end), (2, 2))
+
+    def test_range_at_target_and_comment_text_are_preserved(self):
+        selection = parse_post_selection("评说说 @123456 1~3 写得真好", ("评说说",))
+
+        self.assertEqual(selection.target_uin, 123456)
+        self.assertEqual((selection.start, selection.end), (1, 3))
+        self.assertEqual(selection.comment_text, "写得真好")
+
+    def test_zero_keeps_legacy_latest_behavior(self):
+        selection = parse_post_selection("看说说 0", ("看说说",))
+
+        self.assertEqual((selection.start, selection.end), (1, 1))
+        self.assertEqual(selection.selector, "latest")
+
+    def test_hostuin_fid_compatibility(self):
+        selection = parse_post_selection(
+            "看说说 3112333596 1c7182b96589046ad3380900",
+            ("看说说",),
+        )
+
+        self.assertEqual(selection.target_uin, 3112333596)
+        self.assertEqual(selection.fid, "1c7182b96589046ad3380900")
+        self.assertEqual(selection.selector, "fid")
+
+    def test_tool_selector_keeps_legacy_fid_and_new_selector(self):
+        legacy = selection_from_tool_args(hostuin=123456, fid="fid-1", appid=311)
+        semantic = selection_from_tool_args(target_uin=123456, selector="第2条")
+
+        self.assertEqual((legacy.target_uin, legacy.fid, legacy.selector), (123456, "fid-1", "fid"))
+        self.assertEqual((semantic.target_uin, semantic.start, semantic.end), (123456, 2, 2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Split Qzone post targeting, post action orchestration, and LLM generation into dedicated modules.
- Add semantic selectors for view/comment/like operations while preserving legacy hostuin/fid/latest/index inputs.
- Route comment and like tool replies through sanitized natural-language LLM prompts without exposing internal fields.
- Add comment length configuration and update README/help text.

## Validation
- python -m unittest tests.test_llm tests.test_selection tests.test_main_publish
- python -m unittest tests.test_daemon_lifecycle tests.test_controller_bind tests.test_media
- python -m unittest discover -s tests
- python -m pytest --collect-only -q
- python -m py_compile main.py qzone_bridge/*.py