### PR TITLE
[codex] Fix Qzone comment tool schema docs

### DIFF
--- a/main.py
+++ b/main.py
@@ -2251,7 +2251,12 @@ class QzoneStablePlugin(Star):
             auto_generate (boolean): content 为空时是否自动生成评论。
             private (boolean): 是否私密评论。
             like_after_comment (boolean): 评论后是否顺手点赞。
-            hostuin/fid/confirm/appid/latest/index: 兼容旧参数。
+            hostuin (number): 兼容旧参数，目标 QQ 号。
+            fid (string): 兼容旧参数，说说 fid。
+            confirm (boolean): 兼容旧参数，目前不会拦截执行。
+            appid (number): 兼容旧参数，说说 appid，默认 311。
+            latest (boolean): 兼容旧参数，为 true 时操作最新一条说说。
+            index (number): 兼容旧参数，操作最近列表第 N 条。
         """
         arguments = {
             "target_uin": target_uin,

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.util
+import inspect
 import json
 import sys
 import tempfile
@@ -871,6 +872,15 @@ class MainPublishTests(unittest.TestCase):
         self.assertIn("Alice: nice", first_prompt)
         self.assertNotIn("fid-2", first_prompt)
         self.assertEqual(results[0], "评论好了。")
+
+    def test_llm_comment_tool_docstring_keeps_compat_args_separately_typed(self):
+        module = self.load_main_module()
+
+        doc = inspect.getdoc(module.QzoneStablePlugin.tool_comment_post) or ""
+
+        self.assertNotIn("hostuin/fid/confirm/appid/latest/index", doc)
+        for name in ("hostuin", "fid", "confirm", "appid", "latest", "index"):
+            self.assertRegex(doc, rf"(?m)^\s*{name}\s+\([^)]+\):")
 
     def test_comment_feed_uses_explicit_comment_text_without_llm(self):
         module = self.load_main_module()


### PR DESCRIPTION
## Summary
- Split qzone_comment_post compatibility Args into individually typed docstring entries.
- Add a regression test so AstrBot LLM tool schema parsing does not see hostuin/fid/confirm/appid/latest/index as one untyped parameter.

## Root Cause
AstrBot reads LLM tool Args docs while building function tool schemas. The previous docstring grouped legacy parameters as hostuin/fid/confirm/appid/latest/index, which was parsed as a single parameter name without a type annotation and caused plugin reload to fail.

## Validation
- python -m unittest tests.test_llm tests.test_selection tests.test_main_publish
- python -m unittest tests.test_daemon_lifecycle tests.test_controller_bind tests.test_media
- python -m unittest discover -s tests
- python -m pytest --collect-only -q
- python -m py_compile main.py qzone_bridge/*.py via PowerShell-expanded file list
- git diff --check