### PR TITLE
[codex] Refactor Qzone LLM persona flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@
 
 `qzone_view_post`、`qzone_comment_post`、`qzone_like_post` 优先使用 `target_uin` + `selector`，其中 `selector` 可写 `latest`、`最新`、`第2条`、`2`、`1~3` 或真实 `fid`。旧的 `hostuin/fid/appid/latest/index` 仍保留兼容。
 
+LLM 生成说说、评论和工具结果回复时，会强制走当前 AstrBot 会话 provider/人设；如果模型误输出 `qzone_publish_post(...)`、JSON、参数或“发布预览/发布结果”这类工具化文本，插件会先抽取真正正文并过滤内部字段。旧版 `llm_view_feed` / `llm_publish_feed` 仍可用，但已经收口为兼容壳：用户原话是评论/点赞时会直接接上动作，最终回复交给 LLM 用自然中文组织。
+
 `qzone_like_post` 会继续区分“请求已被 QQ 空间接受”和“读回校验暂未同步”，不会因为 QQ 空间显示滞后把成功操作误报成失败；用户可见回复会交给 LLM 组织成自然语言，避免泄露 raw JSON、fid、cursor、status_code 等内部字段。
 
 ## 配置

--- a/main.py
+++ b/main.py
@@ -39,7 +39,18 @@ LLM_REPLY_FORBIDDEN_TERMS = (
     "result:",
     "[TOOL_",
     "TOOL_",
+    "qzone_",
     "qzone_like_post",
+    "qzone_comment_post",
+    "qzone_publish_post",
+    "qzone_view_post",
+    "JSON",
+    "json",
+    "Markdown",
+    "markdown",
+    "字段",
+    "fid",
+    "hostuin",
     "status_code",
     "diagnostic",
     "API",
@@ -969,6 +980,107 @@ class QzoneStablePlugin(Star):
         if detail:
             return "\n\n".join(post.detail_text(post.local_id) for post in posts)
         return "\n\n".join(post.brief(post.local_id) for post in posts)
+
+    def _event_text_has_comment_intent(self, event: AstrMessageEvent) -> bool:
+        text = self._event_text(event)
+        if not text:
+            return False
+        if re.search(r"(不要|别|先别|不用|无需).{0,4}(评论|评|回复)", text):
+            return False
+        if re.search(r"(评论区|评论列表|看.{0,6}评论|看看.{0,6}评论|查看.{0,6}评论|读.{0,6}评论)", text):
+            return False
+        return bool(
+            re.search(
+                r"(评说说|评论说说|帮.{0,8}评论|给.{0,8}评论|评论一下|评一下|评一评|"
+                r"留个言|留句话|回一句|回评|回复评论)",
+                text,
+            )
+        )
+
+    def _event_text_has_like_intent(self, event: AstrMessageEvent) -> bool:
+        text = self._event_text(event)
+        if not text:
+            return False
+        if re.search(r"(不要|别|先别|不用|无需).{0,4}(赞|点赞)", text):
+            return False
+        if re.search(r"(点赞数|赞数|谁点赞|谁赞|看.{0,6}赞|看看.{0,6}赞|查看.{0,6}赞)", text):
+            return False
+        return bool(re.search(r"(赞说说|帮.{0,8}点赞|给.{0,8}点赞|点个赞|点赞一下|赞一下)", text))
+
+    async def _comment_posts_for_tool(
+        self,
+        event: AstrMessageEvent,
+        posts: list[QzonePost],
+        *,
+        content: str = "",
+        auto_generate: bool = True,
+        private: bool = False,
+        like_after_comment: bool = False,
+    ) -> list[dict[str, Any]]:
+        if not posts:
+            raise QzoneBridgeError("没有找到可评论的说说")
+        results: list[dict[str, Any]] = []
+        for post in posts:
+            comment_text = content.strip()
+            if not comment_text and auto_generate:
+                comment_text = await self._generate_comment_text(event, post)
+            if not comment_text:
+                raise QzoneBridgeError("评论内容为空")
+            payload = await self._post_service().comment_post(post, comment_text, private=private)
+            item: dict[str, Any] = {
+                "post": QzonePostService.post_payload(post),
+                "comment": comment_text,
+                "result": payload,
+            }
+            if like_after_comment:
+                item["like_result"] = await self._post_service().like_post(post)
+            results.append(item)
+        return results
+
+    async def _ask_llm_view_reply(
+        self,
+        event: AstrMessageEvent,
+        posts: list[QzonePost],
+        *,
+        detail: bool,
+        fallback: str,
+    ) -> str:
+        if not posts:
+            return fallback
+        lines = ["下面是刚才查到的 QQ 空间说说内容，只能用这些可见信息回复用户："]
+        for post in posts[:5]:
+            index = post.local_id or 1
+            lines.append(f"第 {index} 条：{truncate(post.summary or '(空)', 220)}")
+            if detail and post.images:
+                lines.append(f"图片：{len(post.images[:9])} 张")
+            if detail and post.comments:
+                lines.append("评论：")
+                for comment in post.comments[:5]:
+                    name = comment.nickname or str(comment.uin or "用户")
+                    if comment.content:
+                        lines.append(f"- {name}: {truncate(comment.content, 80)}")
+        prompt = (
+            "\n".join(lines)
+            + "\n\n请沿用当前 AstrBot 人格和当前聊天语气，把这些内容自然告诉用户。"
+            "保留“第 N 条”这种可见编号，方便用户继续说“评论第 N 条”或“赞第 N 条”。"
+            "不要输出 JSON、Markdown 代码块、工具名、字段名、fid、hostuin、参数或内部流程。"
+        )
+        payload = {"ok": True, "tool": "qzone_view_post", "result": {"message": fallback}}
+        try:
+            text = await self._llm_adapter().generate_text(
+                event,
+                prompt,
+                system_prompt="沿用当前聊天角色和语气。你只负责把查看到的说说变成自然中文回复。",
+                prefer_current_provider=True,
+            )
+        except Exception as exc:
+            logger.debug("qzone llm view reply failed: %s", exc)
+        else:
+            if self._llm_tool_reply_is_safe(text, payload):
+                return text
+            if text:
+                logger.warning("discarded unsafe qzone llm view reply: %s", truncate(text, 300))
+        return fallback
 
     @staticmethod
     def _format_visitors(payload: dict[str, Any]) -> str:
@@ -2008,11 +2120,17 @@ class QzoneStablePlugin(Star):
         like: bool = False,
         reply: bool = False,
     ):
-        """查看、点赞、评论某位用户 QQ 空间的一条说说。"""
+        """旧版兼容工具：查看某位用户 QQ 空间的一条说说。
+
+        新流程中，点赞请优先使用 qzone_like_post；评论请优先使用 qzone_comment_post。
+        如果用户原话已经明确要评论或点赞，本兼容工具会直接完成对应动作。
+        """
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
             hostuin = int(user_id or self._sender_id(event) or 0)
+            wants_comment = bool(reply or self._event_text_has_comment_intent(event))
+            wants_like = bool(like or self._event_text_has_like_intent(event))
             selection = PostSelection(
                 target_uin=hostuin,
                 start=(pos + 1 if pos >= 0 else -1),
@@ -2023,21 +2141,48 @@ class QzoneStablePlugin(Star):
             if not posts:
                 return "查询结果为空。"
             post = posts[0]
-            actions: list[str] = []
-            if reply:
-                content = await self._generate_comment_text(event, post)
-                if not content.strip():
-                    content = "挺有意思的。"
-                await self._post_service().comment_post(post, content.strip())
-                actions.append("已评论")
-            if like:
-                await self._post_service().like_post(post)
-                actions.append("已点赞")
-            prefix = "，".join(actions)
-            return "\n".join(part for part in (prefix, post.detail_text(post.local_id)) if part)
+            results: list[dict[str, Any]] = []
+            if wants_comment:
+                results.extend(
+                    await self._comment_posts_for_tool(
+                        event,
+                        [post],
+                        auto_generate=True,
+                        private=False,
+                        like_after_comment=wants_like,
+                    )
+                )
+            elif wants_like:
+                result = await self._post_service().like_post(post)
+                results.append({"action": "like", "result": result})
+            if results:
+                tool = "qzone_comment_post" if wants_comment else "qzone_like_post"
+                payload = {
+                    "ok": True,
+                    "tool": tool,
+                    "result": {
+                        "message": "评论发好了。" if wants_comment else "点赞点好了。",
+                        "summary": truncate(post.summary or "", 80),
+                        "count": len(results),
+                    },
+                }
+                self._log_tool_call_result({**payload, "arguments": {"user_id": user_id, "pos": pos}})
+                return await self._ask_llm_tool_reply(
+                    event,
+                    payload,
+                    "评论好了。" if wants_comment else "点好了。",
+                )
+            fallback = post.detail_text(post.local_id)
+            return await self._ask_llm_view_reply(event, [post], detail=True, fallback=fallback)
         except Exception as exc:
             logger.warning("llm_view_feed failed: %s", exc)
-            return str(getattr(exc, "message", str(exc)))
+            if isinstance(exc, QzoneBridgeError):
+                payload = self._llm_error_payload("llm_view_feed", exc)
+                fallback = self._llm_error_fallback_text(exc.message)
+            else:
+                payload = {"ok": False, "public_reason": _public_error_reason(str(exc))}
+                fallback = self._llm_error_fallback_text(str(exc))
+            return await self._ask_llm_tool_reply(event, payload, fallback)
 
     @filter.llm_tool()
     async def llm_publish_feed(
@@ -2048,7 +2193,11 @@ class QzoneStablePlugin(Star):
     ):
         """发布一条 QQ 空间说说。"""
         if not self._is_admin(event):
-            return "只有管理员可以发说说。"
+            return await self._ask_llm_tool_reply(
+                event,
+                {"ok": False, "tool": "qzone_publish_post", "public_reason": "没有权限"},
+                self._llm_error_fallback_text("没有权限"),
+            )
         post = collect_post_payload(
             event,
             fallback_content=text,
@@ -2066,8 +2215,28 @@ class QzoneStablePlugin(Star):
                 content_sanitized=True,
             )
         except QzoneBridgeError as exc:
-            return self._error_text(exc)
-        return f"已发布说说到 QQ 空间：\n{post.content}\n{format_action_result('发布结果', payload)}"
+            llm_payload = self._llm_error_payload("qzone_publish_post", exc)
+            return await self._ask_llm_tool_reply(
+                event,
+                llm_payload,
+                self._llm_error_fallback_text(exc.message),
+            )
+        log_payload = {
+            "ok": True,
+            "tool": "qzone_publish_post",
+            "arguments": {"text": truncate(post.content, 120), "media_count": len(post.media)},
+            "result": payload,
+        }
+        self._log_tool_call_result(log_payload)
+        return await self._ask_llm_tool_reply(
+            event,
+            {
+                "ok": True,
+                "tool": "qzone_publish_post",
+                "result": {"message": "说说发好了。", "summary": truncate(post.content, 80)},
+            },
+            "发好了。",
+        )
 
     @filter.llm_tool(name="qzone_get_status")
     async def tool_get_status(self, event: AstrMessageEvent):
@@ -2172,10 +2341,66 @@ class QzoneStablePlugin(Star):
                 appid=appid,
             )
             posts = await self._posts_for_selection(selection, with_detail=detail, login_uin=self._self_id(event))
+            wants_comment = self._event_text_has_comment_intent(event)
+            wants_like = self._event_text_has_like_intent(event)
+            if wants_comment or wants_like:
+                if not self._is_admin(event):
+                    payload = {
+                        "ok": False,
+                        "tool": "qzone_comment_post" if wants_comment else "qzone_like_post",
+                        "public_reason": "没有权限",
+                    }
+                    text = await self._ask_llm_tool_reply(
+                        event,
+                        payload,
+                        self._llm_error_fallback_text("没有权限"),
+                    )
+                    yield event.plain_result(text)
+                    return
+                if wants_comment:
+                    if not detail:
+                        posts = await self._posts_for_selection(selection, with_detail=True, login_uin=self._self_id(event))
+                    results = await self._comment_posts_for_tool(
+                        event,
+                        posts,
+                        auto_generate=True,
+                        private=False,
+                        like_after_comment=wants_like,
+                    )
+                    payload = {
+                        "ok": True,
+                        "tool": "qzone_comment_post",
+                        "result": {"message": "评论发好了。", "count": len(results)},
+                    }
+                    self._log_tool_call_result({**payload, "arguments": {"target_uin": target_uin, "selector": selector}})
+                    text = await self._ask_llm_tool_reply(event, payload, "评论发好了。")
+                    yield event.plain_result(text)
+                    return
+                like_payloads = [await self._post_service().like_post(post) for post in posts]
+                payload = {
+                    "ok": True,
+                    "tool": "qzone_like_post",
+                    "result": (
+                        like_payloads[0]
+                        if len(like_payloads) == 1
+                        else {"message": f"{len(like_payloads)} 条说说点好了。", "count": len(like_payloads)}
+                    ),
+                }
+                self._log_tool_call_result({**payload, "arguments": {"target_uin": target_uin, "selector": selector}})
+                text = await self._ask_llm_tool_reply(event, self._llm_like_payload(payload["result"]), "点好了。")
+                yield event.plain_result(text)
+                return
         except QzoneBridgeError as exc:
-            yield event.plain_result(self._error_text(exc))
+            text = await self._ask_llm_tool_reply(
+                event,
+                self._llm_error_payload("qzone_view_post", exc),
+                self._llm_error_fallback_text(exc.message),
+            )
+            yield event.plain_result(text)
             return
-        yield event.plain_result(self._format_posts(posts, detail=detail))
+        fallback = self._format_posts(posts, detail=detail)
+        text = await self._ask_llm_view_reply(event, posts, detail=detail, fallback=fallback)
+        yield event.plain_result(text)
 
     @filter.llm_tool(name="qzone_publish_post")
     async def tool_publish_post(
@@ -2194,7 +2419,12 @@ class QzoneStablePlugin(Star):
             sync_weibo (boolean): 是否同步到微博。
         """
         if not self._is_admin(event):
-            yield event.plain_result("只有管理员可以发说说。")
+            text = await self._ask_llm_tool_reply(
+                event,
+                {"ok": False, "tool": "qzone_publish_post", "public_reason": "没有权限"},
+                self._llm_error_fallback_text("没有权限"),
+            )
+            yield event.plain_result(text)
             return
         post = collect_post_payload(
             event,
@@ -2206,12 +2436,19 @@ class QzoneStablePlugin(Star):
         if self.settings.preview_writes and not confirm:
             draft = truncate(post.content or "空内容", 120)
             suffix = f"，附带 {len(post.media)} 个媒体" if post.media else ""
-            yield event.plain_result(f"发布预览: {draft}{suffix}。确认后再发布。")
+            text = await self._ask_llm_tool_reply(
+                event,
+                {
+                    "ok": True,
+                    "tool": "qzone_publish_post",
+                    "result": {"message": f"这条还在预览里：{draft}{suffix}"},
+                },
+                f"这条先给你留在预览里：{draft}{suffix}。",
+            )
+            yield event.plain_result(text)
             return
-        profile_task: asyncio.Task | None = None
         try:
             await self._ensure_cookie_ready(event)
-            profile_task = self._schedule_publisher_profile(event)
             payload = await self.controller.publish_post(
                 content=post.content,
                 sync_weibo=sync_weibo,
@@ -2219,11 +2456,30 @@ class QzoneStablePlugin(Star):
                 content_sanitized=True,
             )
         except QzoneBridgeError as exc:
-            if profile_task is not None:
-                profile_task.cancel()
-            yield event.plain_result(self._error_text(exc))
+            text = await self._ask_llm_tool_reply(
+                event,
+                self._llm_error_payload("qzone_publish_post", exc),
+                self._llm_error_fallback_text(exc.message),
+            )
+            yield event.plain_result(text)
             return
-        yield await self._publish_result(event, post, payload, profile_task=profile_task)
+        log_payload = {
+            "ok": True,
+            "tool": "qzone_publish_post",
+            "arguments": {"content": truncate(post.content, 120), "media_count": len(post.media)},
+            "result": payload,
+        }
+        self._log_tool_call_result(log_payload)
+        text = await self._ask_llm_tool_reply(
+            event,
+            {
+                "ok": True,
+                "tool": "qzone_publish_post",
+                "result": {"message": "说说发好了。", "summary": truncate(post.content, 80)},
+            },
+            "发好了。",
+        )
+        yield event.plain_result(text)
 
     @filter.llm_tool(name="qzone_comment_post")
     async def tool_comment_post(
@@ -2299,19 +2555,14 @@ class QzoneStablePlugin(Star):
                 with_detail=auto_generate and not content.strip(),
                 login_uin=self._self_id(event),
             )
-            if not posts:
-                raise QzoneBridgeError("没有找到可评论的说说")
-            results: list[dict[str, Any]] = []
-            for post in posts:
-                comment_text = content.strip()
-                if not comment_text and auto_generate:
-                    comment_text = await self._generate_comment_text(event, post)
-                if not comment_text:
-                    raise QzoneBridgeError("评论内容为空")
-                payload = await self._post_service().comment_post(post, comment_text, private=private)
-                results.append({"post": QzonePostService.post_payload(post), "comment": comment_text, "result": payload})
-                if like_after_comment:
-                    await self._post_service().like_post(post)
+            results = await self._comment_posts_for_tool(
+                event,
+                posts,
+                content=content,
+                auto_generate=auto_generate,
+                private=private,
+                like_after_comment=like_after_comment,
+            )
         except QzoneBridgeError as exc:
             log_payload = self._bridge_error_log_payload("qzone_comment_post", exc, arguments)
             self._log_tool_call_result(log_payload)

--- a/qzone_bridge/llm.py
+++ b/qzone_bridge/llm.py
@@ -3,11 +3,62 @@
 from __future__ import annotations
 
 import inspect
+import json
 import re
 from typing import Any
 
 from .social import QzoneComment, QzonePost
 from .utils import truncate
+
+
+PERSONA_SYSTEM_PROMPT = (
+    "沿用当前 AstrBot 人格和当前聊天语气。"
+    "只输出用户真正要拿去使用的最终文本，不要输出工具调用、JSON、参数、解释或执行说明。"
+)
+
+POST_OUTPUT_RULES = (
+    "生成要求：\n"
+    "- 沿用当前 AstrBot 人格和当前聊天语气。\n"
+    "- 只输出最终可发布的说说正文。\n"
+    "- 不要输出 qzone_publish_post、/qzone、函数调用、JSON、Markdown 代码块、字段名、参数或解释。\n"
+    "- 不要写“发布预览”“确认后发布”“已发布”等执行状态。\n"
+)
+
+COMMENT_OUTPUT_RULES = (
+    "生成要求：\n"
+    "- 沿用当前 AstrBot 人格和当前聊天语气。\n"
+    "- 只输出最终评论内容，一句就好。\n"
+    "- 不要输出 qzone_comment_post、函数调用、JSON、Markdown 代码块、字段名、参数或解释。\n"
+)
+
+INSTRUCTION_MARKERS = (
+    "qzone_",
+    "llm_",
+    "/qzone",
+    "hostuin",
+    "target_uin",
+    "selector",
+    "appid",
+    "confirm",
+    "auto_generate",
+    "private=",
+    "sync_weibo",
+    "status_code",
+    "raw",
+    "fid=",
+    '"fid"',
+    "'fid'",
+    "发布预览",
+    "发布结果",
+    "评论结果",
+    "函数调用",
+    "工具",
+    "指令",
+    "命令",
+    "参数",
+    "json",
+    "markdown",
+)
 
 
 class QzoneLLM:
@@ -134,13 +185,112 @@ class QzoneLLM:
             return self.text_from_response(response)
         return ""
 
+    @staticmethod
+    def _strip_code_fence(text: str) -> str:
+        value = str(text or "").strip()
+        match = re.fullmatch(r"```(?:\w+)?\s*(.*?)\s*```", value, flags=re.DOTALL)
+        if match:
+            return match.group(1).strip()
+        return value
+
+    @staticmethod
+    def _unquote(value: str) -> str:
+        text = str(value or "").strip()
+        if len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"', "“", "”", "‘", "’"}:
+            return text[1:-1].strip()
+        return text.strip("\"'“”‘’")
+
+    @classmethod
+    def _extract_json_field(cls, text: str, fields: tuple[str, ...]) -> str:
+        try:
+            payload = json.loads(text)
+        except Exception:
+            return ""
+        candidates: list[Any] = []
+        if isinstance(payload, dict):
+            candidates.append(payload)
+        elif isinstance(payload, list):
+            candidates.extend(item for item in payload if isinstance(item, dict))
+        for item in candidates:
+            for field in fields:
+                value = item.get(field)
+                if isinstance(value, str) and value.strip():
+                    return cls._unquote(value)
+        return ""
+
+    @classmethod
+    def _extract_assignment_field(cls, text: str, fields: tuple[str, ...]) -> str:
+        field_pattern = "|".join(re.escape(field) for field in fields)
+        quoted = re.search(
+            rf"\b(?:{field_pattern})\s*=\s*([\"'])(?P<value>(?:\\.|(?!\1).)*)\1",
+            text,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        if quoted:
+            return quoted.group("value").replace(r"\"", '"').replace(r"\'", "'").strip()
+        labelled = re.search(
+            rf"^\s*(?:{field_pattern}|说说正文|正文|内容|评论)\s*[:：]\s*(?P<value>.+)$",
+            text,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        if labelled:
+            return cls._unquote(labelled.group("value"))
+        return ""
+
+    @classmethod
+    def _remove_generation_chatter(cls, text: str) -> str:
+        value = cls._unquote(cls._strip_code_fence(text))
+        value = re.sub(r"^\s*[-*]\s*", "", value)
+        value = re.sub(r"^\s*\d+[.)、]\s*", "", value)
+        value = re.sub(r"^\s*(?:说说正文|正文|内容|文案|稿件|评论)\s*[:：]\s*", "", value)
+        value = re.sub(
+            r"^\s*(?:好的|好呀|可以|行|收到|没问题)[，,。\s]*(?:我来|我给你|给你|帮你)?"
+            r"(?:写|发|发布|生成|评论|回一句)?(?:一条|一下)?(?:说说|评论|文案)?\s*[:：]\s*",
+            "",
+            value,
+        )
+        value = re.sub(r"\s+", " ", value).strip()
+        return cls._unquote(value)
+
+    @staticmethod
+    def _looks_instruction_like(text: str) -> bool:
+        lowered = str(text or "").lower()
+        return any(marker.lower() in lowered for marker in INSTRUCTION_MARKERS)
+
+    @classmethod
+    def _clean_generated_text(
+        cls,
+        text: str,
+        *,
+        fields: tuple[str, ...] = ("content", "text", "message"),
+        fallback: str = "",
+    ) -> str:
+        raw = cls._strip_code_fence(text)
+        extracted = cls._extract_json_field(raw, fields) or cls._extract_assignment_field(raw, fields)
+        candidate = extracted or raw
+        candidate = cls._remove_generation_chatter(candidate)
+        if cls._looks_instruction_like(candidate):
+            candidate = ""
+        if not candidate and fallback:
+            fallback_candidate = cls._remove_generation_chatter(fallback)
+            if not cls._looks_instruction_like(fallback_candidate):
+                candidate = fallback_candidate
+        return candidate.strip()
+
     async def generate_post_text(self, event: Any, topic: str = "", *, history: str = "") -> str:
-        prompt = self.settings.post_prompt
+        prompt = f"{self.settings.post_prompt}\n\n{POST_OUTPUT_RULES}"
         if str(topic or "").strip():
             prompt = f"{prompt}\n\n主题：{str(topic).strip()}"
         if history:
             prompt = f"{prompt}\n\n聊天记录参考：\n{truncate(history, 8000)}"
-        return await self.generate_text(event, prompt, provider_id=self.settings.post_provider_id)
+        text = await self.generate_text(
+            event,
+            prompt,
+            provider_id=self.settings.post_provider_id,
+            system_prompt=PERSONA_SYSTEM_PROMPT,
+            prefer_current_provider=True,
+        )
+        return self._clean_generated_text(text, fallback=str(topic or ""))
 
     def _comment_context(self, post: QzonePost) -> str:
         lines = [f"说说内容：{post.summary or '(空)'}"]
@@ -162,15 +312,29 @@ class QzoneLLM:
         return truncate(cleaned, max_len)
 
     async def generate_comment_text(self, event: Any, post: QzonePost) -> str:
-        prompt = f"{self.settings.comment_prompt}\n\n{self._comment_context(post)}"
-        text = await self.generate_text(event, prompt, provider_id=self.settings.comment_provider_id)
-        return self._clean_short_reply(text)
+        prompt = f"{self.settings.comment_prompt}\n\n{COMMENT_OUTPUT_RULES}\n\n{self._comment_context(post)}"
+        text = await self.generate_text(
+            event,
+            prompt,
+            provider_id=self.settings.comment_provider_id,
+            system_prompt=PERSONA_SYSTEM_PROMPT,
+            prefer_current_provider=True,
+        )
+        cleaned = self._clean_generated_text(text, fields=("content", "comment", "text", "message"))
+        return self._clean_short_reply(cleaned)
 
     async def generate_reply_text(self, event: Any, post: QzonePost, comment: QzoneComment) -> str:
         prompt = (
-            f"{self.settings.reply_prompt}\n\n"
+            f"{self.settings.reply_prompt}\n\n{COMMENT_OUTPUT_RULES}\n\n"
             f"{self._comment_context(post)}\n"
             f"要回复的评论：{comment.nickname or comment.uin}: {comment.content}"
         )
-        text = await self.generate_text(event, prompt, provider_id=self.settings.reply_provider_id)
-        return self._clean_short_reply(text)
+        text = await self.generate_text(
+            event,
+            prompt,
+            provider_id=self.settings.reply_provider_id,
+            system_prompt=PERSONA_SYSTEM_PROMPT,
+            prefer_current_provider=True,
+        )
+        cleaned = self._clean_generated_text(text, fields=("content", "comment", "reply", "text", "message"))
+        return self._clean_short_reply(cleaned)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import AsyncMock
 
 from qzone_bridge.llm import QzoneLLM
+from qzone_bridge.social import QzoneComment, QzonePost
 
 
 class QzoneLLMTests(unittest.TestCase):
@@ -24,6 +25,64 @@ class QzoneLLMTests(unittest.TestCase):
             contexts=[],
             system_prompt="不要暴露内部字段",
         )
+
+    def test_generate_post_text_extracts_content_from_tool_like_output(self):
+        context = types.SimpleNamespace(
+            get_current_chat_provider_id=AsyncMock(return_value="persona-provider"),
+            llm_generate=AsyncMock(
+                return_value=types.SimpleNamespace(
+                    completion_text='qzone_publish_post(content="今晚想把风留在窗边", confirm=true)'
+                )
+            ),
+        )
+        settings = types.SimpleNamespace(
+            post_prompt="写一条像我本人的 QQ 空间说说。",
+            post_provider_id="",
+        )
+        llm = QzoneLLM(context, settings)
+
+        text = asyncio.run(llm.generate_post_text(types.SimpleNamespace(), "夜风"))
+
+        self.assertEqual(text, "今晚想把风留在窗边")
+        kwargs = context.llm_generate.await_args.kwargs
+        self.assertEqual(kwargs["chat_provider_id"], "persona-provider")
+        self.assertIn("沿用当前 AstrBot 人格", kwargs["system_prompt"])
+        self.assertIn("只输出最终可发布的说说正文", kwargs["prompt"])
+        self.assertNotIn("qzone_publish_post", text)
+        self.assertNotIn("confirm", text)
+
+    def test_generate_comment_text_extracts_comment_from_tool_like_output(self):
+        context = types.SimpleNamespace(
+            get_current_chat_provider_id=AsyncMock(return_value="persona-provider"),
+            llm_generate=AsyncMock(
+                return_value=types.SimpleNamespace(
+                    completion_text='qzone_comment_post(target_uin=1, selector="latest", content="太会拍了")'
+                )
+            ),
+        )
+        settings = types.SimpleNamespace(
+            comment_prompt="生成一句自然评论。",
+            comment_provider_id="",
+            comment_max_length=60,
+        )
+        llm = QzoneLLM(context, settings)
+        post = QzonePost(
+            hostuin=123456,
+            fid="secret-fid",
+            summary="夕阳落在操场边",
+            images=["https://example.com/a.jpg"],
+            comments=[QzoneComment(commentid="c1", nickname="Alice", content="好看")],
+        )
+
+        text = asyncio.run(llm.generate_comment_text(types.SimpleNamespace(), post))
+
+        self.assertEqual(text, "太会拍了")
+        prompt = context.llm_generate.await_args.kwargs["prompt"]
+        self.assertIn("说说内容：夕阳落在操场边", prompt)
+        self.assertIn("Alice: 好看", prompt)
+        self.assertNotIn("secret-fid", prompt)
+        self.assertNotIn("qzone_comment_post", text)
+        self.assertNotIn("selector", text)
 
 
 if __name__ == "__main__":

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -427,6 +427,39 @@ class MainPublishTests(unittest.TestCase):
         self.assertNotIn("has_more", results[0])
         self.assertNotIn("fid=", results[0])
 
+    def test_llm_view_post_uses_persona_reply_and_keeps_visible_numbering(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin._context = types.SimpleNamespace(
+            get_current_chat_provider_id=AsyncMock(return_value="provider-1"),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="第 2 条是：two，Alice 也回了 nice。")),
+        )
+        entries = [
+            module.FeedEntry(hostuin=123456, fid="fid-1", appid=311, summary="one"),
+            module.FeedEntry(hostuin=123456, fid="fid-2", appid=311, summary="two"),
+        ]
+        plugin.controller.list_feeds = AsyncMock(return_value={"items": [asdict(item) for item in entries]})
+        plugin.controller.detail_feed = AsyncMock(
+            return_value={
+                "entry": asdict(entries[1]),
+                "comments": [{"commentid": "c1", "uin": 9988, "nickname": "Alice", "content": "nice"}],
+                "raw": {},
+            }
+        )
+        event = Event([])
+
+        results = asyncio.run(
+            collect_async_generator(plugin.tool_view_post(event, target_uin=123456, selector="2", detail=True))
+        )
+
+        self.assertEqual(results[0], "第 2 条是：two，Alice 也回了 nice。")
+        prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
+        self.assertIn("第 2 条", prompt)
+        self.assertIn("two", prompt)
+        self.assertIn("Alice: nice", prompt)
+        self.assertNotIn("fid-2", prompt)
+        self.assertNotIn("fid-2", results[0])
+
     def test_llm_like_tool_asks_llm_for_natural_result_reply(self):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
@@ -1058,6 +1091,178 @@ class MainPublishTests(unittest.TestCase):
         self.assertIn("聊天记录参考", prompt)
         self.assertIn("Alice: 今天真热", prompt)
         self.assertNotIn("跳过我", prompt)
+
+    def test_write_feed_saves_clean_draft_when_model_returns_tool_call(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin.drafts = module.DraftStore(plugin.data_dir / "drafts.json")
+        plugin._context = types.SimpleNamespace(
+            get_current_chat_provider_id=AsyncMock(return_value="provider-1"),
+            llm_generate=AsyncMock(
+                return_value=types.SimpleNamespace(
+                    completion_text='qzone_publish_post(content="把晚风装进口袋", confirm=true)'
+                )
+            ),
+        )
+        event = Event([Plain("写说说 晚风")], message_str="写说说 晚风")
+
+        asyncio.run(collect_async_generator(plugin.write_feed(event)))
+
+        drafts = plugin.drafts.list(status="pending")
+        self.assertEqual(len(drafts), 1)
+        self.assertEqual(drafts[0].content, "把晚风装进口袋")
+        prompt = plugin._context.llm_generate.await_args.kwargs["prompt"]
+        self.assertIn("只输出最终可发布的说说正文", prompt)
+        self.assertNotIn("qzone_publish_post", drafts[0].content)
+
+    def test_legacy_llm_publish_feed_uses_persona_reply_without_action_dump(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin._context = types.SimpleNamespace(
+            get_current_chat_provider_id=AsyncMock(return_value="provider-1"),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="发好啦，刚刚那句挺顺的。")),
+        )
+        event = Event([])
+
+        result = asyncio.run(plugin.llm_publish_feed(event, text="hello", get_image=False))
+
+        plugin.controller.publish_post.assert_awaited_once()
+        self.assertEqual(result, "发好啦，刚刚那句挺顺的。")
+        self.assertNotIn("发布结果", result)
+        self.assertNotIn("fid", result)
+        self.assertFalse(result.lstrip().startswith("{"))
+
+    def test_semantic_publish_tool_uses_persona_reply_without_render_dump(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin._context = types.SimpleNamespace(
+            get_current_chat_provider_id=AsyncMock(return_value="provider-1"),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="发好了，这条很像你。")),
+        )
+        event = Event([])
+
+        results = asyncio.run(
+            collect_async_generator(plugin.tool_publish_post(event, content="hello", confirm=True))
+        )
+
+        plugin.controller.publish_post.assert_awaited_once()
+        self.assertEqual(results[0], "发好了，这条很像你。")
+        self.assertNotIn("发布结果", results[0])
+        self.assertNotIn("fid", results[0])
+        self.assertFalse(str(results[0]).lstrip().startswith("{"))
+
+    def test_legacy_llm_view_feed_comments_when_user_intent_is_comment(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin._context = types.SimpleNamespace(
+            get_current_chat_provider_id=AsyncMock(return_value="provider-1"),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="评论好了，这句接得挺自然。")),
+        )
+        entries = [
+            module.FeedEntry(hostuin=123456, fid="fid-1", appid=311, summary="one"),
+            module.FeedEntry(hostuin=123456, fid="fid-2", appid=311, summary="two"),
+        ]
+        plugin.controller.list_feeds = AsyncMock(return_value={"items": [asdict(item) for item in entries]})
+        plugin.controller.detail_feed = AsyncMock(return_value={"entry": asdict(entries[1]), "comments": [], "raw": {}})
+        plugin.controller.comment_post = AsyncMock(return_value={"commentid": "c2", "message": "ok"})
+        plugin._generate_comment_text = AsyncMock(return_value="真不错")
+        event = Event([], message_str="帮我评论 123456 的第二条说说")
+
+        result = asyncio.run(plugin.llm_view_feed(event, user_id="123456", pos=1, reply=False))
+
+        plugin.controller.comment_post.assert_awaited_once_with(
+            hostuin=123456,
+            fid="fid-2",
+            content="真不错",
+            appid=311,
+            private=False,
+            busi_param={},
+        )
+        self.assertEqual(result, "评论好了，这句接得挺自然。")
+        self.assertNotIn("fid-2", result)
+        self.assertNotIn("qzone_comment_post", result)
+
+    def test_semantic_view_tool_comments_when_user_intent_is_comment(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin._context = types.SimpleNamespace(
+            get_current_chat_provider_id=AsyncMock(return_value="provider-1"),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="评论接上了。")),
+        )
+        entries = [
+            module.FeedEntry(hostuin=123456, fid="fid-1", appid=311, summary="one"),
+            module.FeedEntry(hostuin=123456, fid="fid-2", appid=311, summary="two"),
+        ]
+        plugin.controller.list_feeds = AsyncMock(return_value={"items": [asdict(item) for item in entries]})
+        plugin.controller.detail_feed = AsyncMock(return_value={"entry": asdict(entries[1]), "comments": [], "raw": {}})
+        plugin.controller.comment_post = AsyncMock(return_value={"commentid": "c2", "message": "ok"})
+        plugin._generate_comment_text = AsyncMock(return_value="真不错")
+        event = Event([], message_str="帮我评论第二条说说")
+
+        results = asyncio.run(
+            collect_async_generator(plugin.tool_view_post(event, target_uin=123456, selector="2", detail=True))
+        )
+
+        plugin.controller.comment_post.assert_awaited_once_with(
+            hostuin=123456,
+            fid="fid-2",
+            content="真不错",
+            appid=311,
+            private=False,
+            busi_param={},
+        )
+        self.assertEqual(results[0], "评论接上了。")
+        self.assertNotIn("fid-2", results[0])
+        self.assertNotIn("qzone_comment_post", results[0])
+
+    def test_semantic_view_tool_does_not_comment_when_user_only_wants_comments_shown(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin._context = types.SimpleNamespace(
+            get_current_chat_provider_id=AsyncMock(return_value="provider-1"),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="第 2 条下面 Alice 说 nice。")),
+        )
+        entries = [
+            module.FeedEntry(hostuin=123456, fid="fid-1", appid=311, summary="one"),
+            module.FeedEntry(hostuin=123456, fid="fid-2", appid=311, summary="two"),
+        ]
+        plugin.controller.list_feeds = AsyncMock(return_value={"items": [asdict(item) for item in entries]})
+        plugin.controller.detail_feed = AsyncMock(
+            return_value={
+                "entry": asdict(entries[1]),
+                "comments": [{"commentid": "c1", "uin": 9988, "nickname": "Alice", "content": "nice"}],
+                "raw": {},
+            }
+        )
+        plugin.controller.comment_post = AsyncMock(return_value={"commentid": "c2", "message": "ok"})
+        event = Event([], message_str="帮我看看第二条说说的评论区")
+
+        results = asyncio.run(
+            collect_async_generator(plugin.tool_view_post(event, target_uin=123456, selector="2", detail=True))
+        )
+
+        plugin.controller.comment_post.assert_not_awaited()
+        self.assertEqual(results[0], "第 2 条下面 Alice 说 nice。")
+
+    def test_semantic_view_tool_does_not_like_when_user_only_wants_like_count(self):
+        module = self.load_main_module()
+        plugin = self.make_plugin(module)
+        plugin._context = types.SimpleNamespace(
+            get_current_chat_provider_id=AsyncMock(return_value="provider-1"),
+            llm_generate=AsyncMock(return_value=types.SimpleNamespace(completion_text="第 1 条现在有 3 个赞。")),
+        )
+        entry = module.FeedEntry(hostuin=123456, fid="fid-1", appid=311, summary="one", like_count=3)
+        plugin.controller.list_feeds = AsyncMock(return_value={"items": [asdict(entry)]})
+        plugin.controller.detail_feed = AsyncMock(return_value={"entry": asdict(entry), "comments": [], "raw": {}})
+        plugin.controller.like_post = AsyncMock(return_value={"action": "like", "liked": True})
+        event = Event([], message_str="帮我看看第一条说说的点赞数")
+
+        results = asyncio.run(
+            collect_async_generator(plugin.tool_view_post(event, target_uin=123456, selector="1", detail=True))
+        )
+
+        plugin.controller.like_post.assert_not_awaited()
+        self.assertEqual(results[0], "第 1 条现在有 3 个赞。")
 
     def test_llm_like_tool_strips_tool_error_prefix_and_rejects_unsafe_error_reply(self):
         module = self.load_main_module()


### PR DESCRIPTION
﻿## Summary
- force Qzone LLM writing/comment generation through the active AstrBot persona and sanitize tool-call/JSON-like model output before it reaches drafts or comments
- route legacy and semantic Qzone LLM tools through natural provider-backed replies instead of fixed action dumps
- make view tools continue into comment/like actions only for explicit action intent, with conservative guards for "show comments" and "like count" requests

## Root Cause
- legacy `llm_view_feed` and `llm_publish_feed` still competed with the newer semantic tools and returned fixed/tool-like text
- generated post/comment text was accepted verbatim, so model-produced function-call shells could become user-visible drafts
- view tools did not bridge explicit comment intent, while broad intent matching risked turning read-only requests into write actions

## Validation
- `python -m pytest -q`
- `python -m unittest discover -s tests`
- `python -m pytest --collect-only -q`
- `python -m py_compile main.py qzone_bridge/*.py` via PowerShell-expanded file list
