### PR TITLE
[codex] Optimize Qzone publish card render

### DIFF
--- a/main.py
+++ b/main.py
@@ -182,7 +182,14 @@ from qzone_bridge.onebot_cookie import fetch_cookie_text
 from qzone_bridge.parser import normalize_uin, parse_cookie_text
 from qzone_bridge.post_service import QzonePostService
 from qzone_bridge.posts import PostStore
-from qzone_bridge.publish_renderer import RenderProfile, profile_from_event, render_publish_result_image
+from qzone_bridge.publish_renderer import (
+    RenderProfile,
+    cached_avatar_source,
+    preload_publish_render_assets,
+    preload_static_render_assets,
+    profile_from_event,
+    render_publish_result_image,
+)
 from qzone_bridge.render import (
     format_action_result,
     format_feed_detail,
@@ -235,12 +242,14 @@ class QzoneStablePlugin(Star):
         self._capture_onebot_client_from_context()
         self._daemon_warmup_task: asyncio.Task | None = None
         self._scheduled_tasks: list[asyncio.Task] = []
-        self._publisher_profile_cache: tuple[int, float, Any] | None = None
+        self._publisher_profile_cache: tuple[int, RenderProfile] | None = None
+        self._publisher_profile_preload_task: asyncio.Task | None = None
         self.drafts = DraftStore(self.data_dir / "drafts.json")
         self.posts = PostStore(self.data_dir / "posts.json")
         self.llm = QzoneLLM(self._context, self.settings)
         self._pillowmd_style: Any | None = None
         self._pillowmd_style_dir = ""
+        preload_static_render_assets()
 
     def _sender_id(self, event: AstrMessageEvent) -> int:
         try:
@@ -314,64 +323,132 @@ class QzoneStablePlugin(Star):
             return image_result(str(image_path))
         return self._command_result(event, text)
 
-    async def _publisher_render_profile(self, event: AstrMessageEvent) -> Any:
-        profile = profile_from_event(event)
-        status: dict[str, Any] = {}
-        try:
-            status = await self.controller.get_status(probe_daemon=False)
-        except QzoneBridgeError:
-            status = {}
+    def _render_asset_dir(self) -> Path:
+        return self.data_dir / "render_assets"
 
-        login_uin = int(status.get("login_uin") or 0)
+    @staticmethod
+    def _clone_render_profile(profile: RenderProfile, *, time_text: str = "") -> RenderProfile:
+        return RenderProfile(
+            nickname=profile.nickname,
+            user_id=profile.user_id,
+            avatar_source=profile.avatar_source,
+            time_text=time_text or profile.time_text,
+        )
+
+    @staticmethod
+    def _qlogo_url(uin: int, size: int) -> str:
+        return f"https://q1.qlogo.cn/g?b=qq&nk={uin}&s={size}"
+
+    def _publisher_avatar_sources(
+        self,
+        login_uin: int,
+        *,
+        primary: str = "",
+        onebot_avatar: str = "",
+    ) -> tuple[str, ...]:
+        candidates = [
+            primary,
+            onebot_avatar,
+            self._qlogo_url(login_uin, 640),
+            self._qlogo_url(login_uin, 140),
+            self._qlogo_url(login_uin, 100),
+        ]
+        result: list[str] = []
+        for source in candidates:
+            source = str(source or "").strip()
+            if source and source not in result:
+                result.append(source)
+        return tuple(result)
+
+    def _cached_publisher_profile(self, login_uin: int, *, time_text: str) -> RenderProfile | None:
+        cached = self._publisher_profile_cache
+        if cached is None:
+            return None
+        cached_uin, cached_profile = cached
+        if cached_uin != login_uin:
+            return None
+        return self._clone_render_profile(cached_profile, time_text=time_text)
+
+    async def _publisher_render_profile(
+        self,
+        event: AstrMessageEvent | None = None,
+        *,
+        status: dict[str, Any] | None = None,
+        allow_network: bool = False,
+    ) -> RenderProfile:
+        profile = profile_from_event(event) if event is not None else RenderProfile(time_text=time.strftime("%H:%M"))
+        if status is None:
+            try:
+                status = await self.controller.get_status(probe_daemon=False)
+            except QzoneBridgeError:
+                status = {}
+
+        login_uin = int((status or {}).get("login_uin") or 0)
         if not login_uin:
             return profile
 
-        now = time.monotonic()
-        cached = self._publisher_profile_cache
+        cached = self._cached_publisher_profile(login_uin, time_text=profile.time_text)
         if cached is not None:
-            cached_uin, expires_at, cached_profile = cached
-            if cached_uin == login_uin and expires_at > now:
-                return RenderProfile(
-                    nickname=cached_profile.nickname,
-                    user_id=cached_profile.user_id,
-                    avatar_source=cached_profile.avatar_source,
-                    time_text=profile.time_text,
-                )
+            return cached
 
         nickname = str(
-            status.get("login_nickname")
-            or status.get("nickname")
-            or status.get("publisher_nickname")
+            (status or {}).get("login_nickname")
+            or (status or {}).get("nickname")
+            or (status or {}).get("publisher_nickname")
             or ""
         ).strip()
-        avatar_source = str(status.get("login_avatar") or status.get("avatar") or "").strip()
-        if not avatar_source:
-            avatar_source = f"https://q1.qlogo.cn/g?b=qq&nk={login_uin}&s=100"
+        avatar_source = str((status or {}).get("login_avatar") or (status or {}).get("avatar") or "").strip()
+        onebot_avatar = ""
+        if allow_network:
+            bot = self._capture_onebot_client(event)
+            if bot is not None:
+                try:
+                    fetched = await asyncio.wait_for(self._fetch_onebot_user_info(bot, login_uin), timeout=1.2)
+                except Exception:
+                    fetched = {}
+                if fetched:
+                    nickname = nickname or str(fetched.get("nickname") or fetched.get("name") or "").strip()
+                    onebot_avatar = str(fetched.get("avatar") or fetched.get("avatar_url") or "").strip()
+                    avatar_source = onebot_avatar or avatar_source
 
-        bot = self._capture_onebot_client(event)
-        if bot is not None:
-            try:
-                fetched = await asyncio.wait_for(self._fetch_onebot_user_info(bot, login_uin), timeout=0.35)
-            except Exception:
-                fetched = {}
-            if fetched:
-                nickname = nickname or str(fetched.get("nickname") or fetched.get("name") or "").strip()
-                avatar_source = str(fetched.get("avatar") or fetched.get("avatar_url") or avatar_source).strip()
-
-        profile.user_id = str(login_uin)
-        profile.nickname = nickname or str(login_uin)
-        profile.avatar_source = avatar_source
-        self._publisher_profile_cache = (
-            login_uin,
-            now + 10 * 60,
-            RenderProfile(
-                nickname=profile.nickname,
-                user_id=profile.user_id,
-                avatar_source=profile.avatar_source,
-                time_text="",
-            ),
+        fallback_name = "" if profile.nickname == "QQ Space" else profile.nickname
+        base_profile = RenderProfile(
+            nickname=nickname or fallback_name or str(login_uin),
+            user_id=str(login_uin),
+            avatar_source=avatar_source or self._qlogo_url(login_uin, 640),
+            time_text=profile.time_text,
         )
-        return profile
+        cached_avatar = cached_avatar_source(self._render_asset_dir(), base_profile)
+        if cached_avatar:
+            cached_profile = RenderProfile(
+                nickname=base_profile.nickname,
+                user_id=base_profile.user_id,
+                avatar_source=cached_avatar,
+                time_text="",
+            )
+            self._publisher_profile_cache = (login_uin, cached_profile)
+            return self._clone_render_profile(cached_profile, time_text=profile.time_text)
+
+        if not allow_network:
+            base_profile.avatar_source = ""
+            return base_profile
+
+        sources = self._publisher_avatar_sources(login_uin, primary=base_profile.avatar_source, onebot_avatar=onebot_avatar)
+        preloaded = await asyncio.to_thread(
+            preload_publish_render_assets,
+            base_profile,
+            self._render_asset_dir(),
+            avatar_sources=sources,
+            remote_timeout=max(float(self.settings.render_remote_timeout or 0), 2.5),
+        )
+        cached_profile = RenderProfile(
+            nickname=preloaded.nickname or str(login_uin),
+            user_id=preloaded.user_id or str(login_uin),
+            avatar_source=preloaded.avatar_source,
+            time_text="",
+        )
+        self._publisher_profile_cache = (login_uin, cached_profile)
+        return self._clone_render_profile(cached_profile, time_text=profile.time_text)
 
     async def _fetch_onebot_user_info(self, bot: Any, uin: int) -> dict[str, Any]:
         for method_name, kwargs in (
@@ -399,10 +476,34 @@ class QzoneStablePlugin(Star):
                 return result
         return {}
 
+    def _schedule_publish_render_asset_preload(
+        self,
+        trigger: str,
+        *,
+        event: AstrMessageEvent | None = None,
+        status: dict[str, Any] | None = None,
+    ) -> None:
+        if not self.settings.render_publish_result:
+            return
+        login_uin = int((status or {}).get("login_uin") or 0)
+        if login_uin and self._cached_publisher_profile(login_uin, time_text="") is not None:
+            return
+        task = self._publisher_profile_preload_task
+        if task is not None and not task.done():
+            return
+
+        async def runner() -> None:
+            try:
+                await self._publisher_render_profile(event, status=status, allow_network=True)
+            except Exception:
+                logger.debug("qzone publish render asset preload on %s failed", trigger, exc_info=True)
+
+        self._publisher_profile_preload_task = asyncio.create_task(runner())
+
     def _schedule_publisher_profile(self, event: AstrMessageEvent) -> asyncio.Task | None:
         if not self.settings.render_publish_result:
             return None
-        return asyncio.create_task(self._publisher_render_profile(event))
+        return asyncio.create_task(self._publisher_render_profile(event, allow_network=False))
 
     async def _publish_result(
         self,
@@ -522,9 +623,12 @@ class QzoneStablePlugin(Star):
             and not bool(status.get("needs_rebind"))
         )
         if not should_start:
+            self._schedule_publish_render_asset_preload("status", status=status)
             return status
         try:
-            return await self.controller.ensure_running()
+            recovered = await self.controller.ensure_running()
+            self._schedule_publish_render_asset_preload("status recovery", status=recovered)
+            return recovered
         except QzoneBridgeError as exc:
             try:
                 detail_text = json.dumps(_redact_for_log(exc.detail), ensure_ascii=False, default=str)
@@ -533,6 +637,7 @@ class QzoneStablePlugin(Star):
             logger.warning("qzone daemon status recovery failed: %s detail=%s", exc.message, detail_text)
             fallback = await self.controller.get_status(probe_daemon=False)
             fallback["daemon_start_error"] = self._status_error_payload(exc)
+            self._schedule_publish_render_asset_preload("status fallback", status=fallback)
             return fallback
 
 
@@ -1516,8 +1621,11 @@ class QzoneStablePlugin(Star):
         except QzoneBridgeError:
             status = {}
         if not force and status and int(status.get("cookie_count") or 0) > 0 and not bool(status.get("needs_rebind")):
+            self._schedule_publish_render_asset_preload("cookie ready", event=event, status=status)
             return status
-        return await self._auto_bind_cookie(event, force=force, source=source)
+        payload = await self._auto_bind_cookie(event, force=force, source=source)
+        self._schedule_publish_render_asset_preload("cookie bind", event=event, status=payload)
+        return payload
 
     async def _bootstrap_auto_bind(self, trigger: str) -> None:
         client = self._capture_onebot_client_from_context()
@@ -1541,6 +1649,7 @@ class QzoneStablePlugin(Star):
             return
         if int(status.get("cookie_count") or 0) <= 0 or bool(status.get("needs_rebind")):
             return
+        self._schedule_publish_render_asset_preload("daemon prewarm", status=status)
         self._schedule_daemon_warmup(trigger)
 
     def _schedule_daemon_warmup(self, trigger: str) -> None:
@@ -1563,7 +1672,8 @@ class QzoneStablePlugin(Star):
     async def initialize(self):
         if self.settings.cookies_str:
             try:
-                await self.controller.bind_cookie_local(self.settings.cookies_str, source="config")
+                payload = await self.controller.bind_cookie_local(self.settings.cookies_str, source="config")
+                self._schedule_publish_render_asset_preload("config bind", status=payload)
             except QzoneBridgeError as exc:
                 logger.warning("qzone config cookie bind failed: %s", exc)
         self._start_scheduled_tasks()
@@ -1990,6 +2100,7 @@ class QzoneStablePlugin(Star):
             logger.warning("qzone bind failed: %s", exc)
             yield self._command_result(event, self._error_text(exc))
             return
+        self._schedule_publish_render_asset_preload("manual bind", event=event, status=payload)
         self._schedule_daemon_warmup("manual bind")
         try:
             payload = await self._status_with_recovery()
@@ -2008,6 +2119,7 @@ class QzoneStablePlugin(Star):
             logger.warning("qzone autobind failed: %s", exc)
             yield self._command_result(event, self._error_text(exc))
             return
+        self._schedule_publish_render_asset_preload("autobind", event=event, status=payload)
         self._schedule_daemon_warmup("autobind")
         try:
             payload = await self._status_with_recovery()
@@ -2707,6 +2819,10 @@ class QzoneStablePlugin(Star):
         if self._scheduled_tasks:
             await asyncio.gather(*self._scheduled_tasks, return_exceptions=True)
             self._scheduled_tasks.clear()
+        if self._publisher_profile_preload_task is not None:
+            self._publisher_profile_preload_task.cancel()
+            await asyncio.gather(self._publisher_profile_preload_task, return_exceptions=True)
+            self._publisher_profile_preload_task = None
         try:
             await self.controller.close()
         except Exception as exc:

--- a/qzone_bridge/publish_renderer.py
+++ b/qzone_bridge/publish_renderer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 from concurrent.futures import ThreadPoolExecutor
+import hashlib
 import io
 import math
 import os
@@ -27,8 +28,9 @@ WHITE = (255, 255, 255)
 TEXT = (24, 24, 24)
 MUTED = (126, 132, 139)
 LINE = (226, 226, 226)
-ACTION = (142, 142, 142)
+ACTION = (24, 24, 24)
 CARD_BG = (250, 250, 250)
+COMMENT_BG = (247, 247, 247)
 FILE_COLORS = {
     ".pdf": (216, 74, 64),
     ".doc": (64, 112, 205),
@@ -48,7 +50,7 @@ FILE_COLORS = {
     ".md": (112, 121, 130),
 }
 FONT_CACHE: dict[tuple[int, bool], ImageFont.ImageFont] = {}
-FAST_RESAMPLE = Image.Resampling.BILINEAR
+QUALITY_RESAMPLE = Image.Resampling.LANCZOS
 PREVIEW_EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="qzone-render")
 _THREAD_LOCAL = threading.local()
 _BYTES_CACHE: dict[str, tuple[float, bytes]] = {}
@@ -58,6 +60,7 @@ _BYTES_CACHE_MAX_ITEMS = 64
 _BYTES_CACHE_MAX_ITEM_SIZE = 4 * 1024 * 1024
 _LAST_PRUNE_AT = 0.0
 _PRUNE_INTERVAL_SECONDS = 60.0
+_ACTION_STRIP_CACHE: dict[tuple[int, int, tuple[int, int, int]], Image.Image] = {}
 
 
 @dataclass(slots=True)
@@ -73,6 +76,77 @@ class _ImagePreview:
     media: PostMedia
     image: Image.Image | None
     failed: bool = False
+
+
+def preload_static_render_assets() -> None:
+    """Warm fonts and cached action glyphs before the first publish render."""
+
+    for size, bold in ((28, True), (24, False), (20, False), (18, False), (17, False), (34, True)):
+        _font(size, bold=bold)
+    _action_strip()
+
+
+def preload_publish_render_assets(
+    profile: RenderProfile,
+    cache_dir: Path,
+    *,
+    avatar_sources: list[str] | tuple[str, ...] = (),
+    remote_timeout: float = 2.5,
+) -> RenderProfile:
+    """Resolve render assets to local cached files so publish rendering does no profile I/O."""
+
+    preload_static_render_assets()
+    resolved = RenderProfile(
+        nickname=profile.nickname,
+        user_id=profile.user_id,
+        avatar_source=profile.avatar_source,
+        time_text=profile.time_text,
+    )
+    cache_path = _avatar_cache_path(cache_dir, profile)
+    if cache_path.is_file():
+        resolved.avatar_source = str(cache_path)
+        return resolved
+
+    seen: set[str] = set()
+    sources = [profile.avatar_source, *avatar_sources]
+    for source in sources:
+        source = str(source or "").strip()
+        if not source or source in seen:
+            continue
+        seen.add(source)
+        preview = _load_image_preview(
+            PostMedia(kind="image", source=source, name="avatar"),
+            remote_timeout=remote_timeout,
+        )
+        if preview.image is None:
+            continue
+        try:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            avatar = preview.image.copy()
+            avatar.thumbnail((1024, 1024), QUALITY_RESAMPLE)
+            avatar.save(cache_path, "PNG", optimize=False, compress_level=1)
+        except OSError:
+            continue
+        resolved.avatar_source = str(cache_path)
+        return resolved
+
+    resolved.avatar_source = ""
+    return resolved
+
+
+def cached_avatar_source(cache_dir: Path, profile: RenderProfile) -> str:
+    cache_path = _avatar_cache_path(cache_dir, profile)
+    return str(cache_path) if cache_path.is_file() else ""
+
+
+def _avatar_cache_path(cache_dir: Path, profile: RenderProfile) -> Path:
+    user_id = re.sub(r"\D+", "", str(profile.user_id or ""))
+    if user_id:
+        stem = f"avatar_{user_id}"
+    else:
+        seed = f"{profile.nickname}|{profile.avatar_source}".encode("utf-8", "ignore")
+        stem = "avatar_" + hashlib.sha1(seed).hexdigest()[:16]
+    return cache_dir / f"{stem}.png"
 
 
 def profile_from_event(event: Any) -> RenderProfile:
@@ -192,7 +266,7 @@ def render_publish_result_image(
     if attachment_height:
         y += attachment_height + 18
     actions_y = y + 6
-    comment_y = actions_y + 54
+    comment_y = actions_y + 58
     height = max(240, comment_y + 56 + 22)
 
     image = Image.new("RGB", (width, height), WHITE)
@@ -213,8 +287,8 @@ def render_publish_result_image(
         y += attachment_height + 18
 
     actions_y = y + 6
-    _draw_actions(draw, width, actions_y)
-    comment_y = actions_y + 54
+    _draw_actions(draw, image, width, actions_y)
+    comment_y = actions_y + 58
     _draw_comment_box(draw, margin, comment_y, content_width, 52, meta_font)
 
     path = output_dir / f"publish_result_{int(time.time())}_{uuid.uuid4().hex[:10]}.png"
@@ -353,7 +427,7 @@ def _load_image_preview(media: PostMedia, *, remote_timeout: float) -> _ImagePre
                 preview = base
             else:
                 preview = preview.copy()
-            preview.thumbnail((900, 900), FAST_RESAMPLE)
+            preview.thumbnail((1200, 1200), QUALITY_RESAMPLE)
             return _ImagePreview(media=media, image=preview, failed=False)
     except (OSError, UnidentifiedImageError):
         return _ImagePreview(media=media, image=None, failed=True)
@@ -569,7 +643,7 @@ def _draw_avatar(
     mask_draw = ImageDraw.Draw(mask)
     mask_draw.ellipse((0, 0, size - 1, size - 1), fill=255)
     if preview and preview.image:
-        avatar = ImageOps.fit(preview.image, (size, size), method=FAST_RESAMPLE)
+        avatar = ImageOps.fit(preview.image, (size, size), method=QUALITY_RESAMPLE)
         image.paste(avatar, (x, y), mask)
         return
 
@@ -637,9 +711,9 @@ def _draw_preview_tile(
 ) -> None:
     if preview.image is not None:
         if crop:
-            rendered = ImageOps.fit(preview.image, (width, height), method=FAST_RESAMPLE)
+            rendered = ImageOps.fit(preview.image, (width, height), method=QUALITY_RESAMPLE)
         else:
-            rendered = ImageOps.contain(preview.image, (width, height), method=FAST_RESAMPLE)
+            rendered = ImageOps.contain(preview.image, (width, height), method=QUALITY_RESAMPLE)
             width, height = rendered.size
         image.paste(rendered, (x, y))
         return
@@ -738,39 +812,58 @@ def _format_size(size: int) -> str:
     return ""
 
 
-def _draw_actions(draw: ImageDraw.ImageDraw, width: int, y: int) -> None:
-    spacing = 120
-    start_x = width - 294
-    _draw_like_icon(draw, start_x, y + 4)
-    _draw_comment_icon(draw, start_x + spacing, y + 4)
-    _draw_share_icon(draw, start_x + spacing * 2, y + 4)
+def _draw_actions(draw: ImageDraw.ImageDraw, image: Image.Image, width: int, y: int) -> None:
+    strip = _action_strip()
+    start_x = max(22, width - strip.width - 22)
+    image.paste(strip, (start_x, y), strip)
+
+
+def _action_strip() -> Image.Image:
+    spacing = 118
+    icon_w = 54
+    height = 52
+    key = (spacing, icon_w, ACTION)
+    cached = _ACTION_STRIP_CACHE.get(key)
+    if cached is not None:
+        return cached
+    strip = Image.new("RGBA", (spacing * 2 + icon_w, height), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(strip)
+    _draw_like_icon(draw, 0, 4)
+    _draw_comment_icon(draw, spacing, 4)
+    _draw_share_icon(draw, spacing * 2, 4)
+    _ACTION_STRIP_CACHE[key] = strip
+    return strip
 
 
 def _draw_like_icon(draw: ImageDraw.ImageDraw, x: int, y: int) -> None:
-    draw.rounded_rectangle((x + 4, y + 14, x + 12, y + 34), radius=2, fill=ACTION)
+    line = 4
+    draw.rounded_rectangle((x + 6, y + 21, x + 17, y + 43), radius=2, outline=ACTION, width=line)
     points = [
-        (x + 14, y + 34),
-        (x + 14, y + 15),
-        (x + 22, y + 4),
+        (x + 17, y + 42),
+        (x + 17, y + 22),
+        (x + 24, y + 15),
         (x + 27, y + 6),
-        (x + 25, y + 17),
-        (x + 36, y + 17),
-        (x + 39, y + 21),
-        (x + 34, y + 34),
+        (x + 32, y + 5),
+        (x + 35, y + 9),
+        (x + 34, y + 20),
+        (x + 45, y + 20),
+        (x + 48, y + 24),
+        (x + 43, y + 42),
+        (x + 17, y + 42),
     ]
-    draw.polygon(points, fill=ACTION)
+    draw.line(points, fill=ACTION, width=line, joint="curve")
 
 
 def _draw_comment_icon(draw: ImageDraw.ImageDraw, x: int, y: int) -> None:
-    draw.rounded_rectangle((x + 4, y + 8, x + 34, y + 30), radius=4, fill=ACTION)
-    draw.polygon([(x + 14, y + 30), (x + 14, y + 38), (x + 23, y + 30)], fill=ACTION)
-    for offset in (11, 19, 27):
-        draw.ellipse((x + offset, y + 17, x + offset + 4, y + 21), fill=WHITE)
+    line = 4
+    draw.ellipse((x + 7, y + 6, x + 44, y + 39), outline=ACTION, width=line)
+    draw.line([(x + 34, y + 33), (x + 44, y + 43), (x + 28, y + 38)], fill=ACTION, width=line, joint="curve")
 
 
 def _draw_share_icon(draw: ImageDraw.ImageDraw, x: int, y: int) -> None:
-    draw.line([(x + 6, y + 34), (x + 19, y + 22), (x + 29, y + 22)], fill=ACTION, width=5, joint="curve")
-    draw.polygon([(x + 27, y + 9), (x + 45, y + 22), (x + 27, y + 35)], fill=ACTION)
+    line = 4
+    draw.line([(x + 7, y + 40), (x + 20, y + 28), (x + 35, y + 25)], fill=ACTION, width=line, joint="curve")
+    draw.line([(x + 31, y + 10), (x + 49, y + 24), (x + 31, y + 38)], fill=ACTION, width=line, joint="curve")
 
 
 def _draw_comment_box(
@@ -781,14 +874,14 @@ def _draw_comment_box(
     height: int,
     font: ImageFont.ImageFont,
 ) -> None:
-    draw.rectangle((x, y, x + width, y + height), outline=LINE, width=1)
-    _safe_text(draw, (x + 16, y + 14), "\u8bc4\u8bba", font, MUTED)
-    camera_x = x + width - 48
+    radius = max(10, height // 2)
+    draw.rounded_rectangle((x, y, x + width, y + height), radius=radius, fill=COMMENT_BG, outline=LINE, width=1)
+    _safe_text(draw, (x + 20, y + 14), "\u8bc4\u8bba", font, MUTED)
+    camera_x = x + width - 52
     camera_y = y + 13
-    draw.rounded_rectangle((camera_x, camera_y + 8, camera_x + 28, camera_y + 26), radius=3, fill=ACTION)
-    draw.rectangle((camera_x + 8, camera_y + 4, camera_x + 20, camera_y + 10), fill=ACTION)
-    draw.ellipse((camera_x + 9, camera_y + 12, camera_x + 19, camera_y + 22), fill=WHITE)
-    draw.ellipse((camera_x + 12, camera_y + 15, camera_x + 16, camera_y + 19), fill=ACTION)
+    draw.rounded_rectangle((camera_x, camera_y + 8, camera_x + 30, camera_y + 26), radius=4, outline=ACTION, width=2)
+    draw.rectangle((camera_x + 9, camera_y + 4, camera_x + 21, camera_y + 10), outline=ACTION, width=2)
+    draw.ellipse((camera_x + 10, camera_y + 12, camera_x + 20, camera_y + 22), outline=ACTION, width=2)
 
 
 def _prune_output_dir(output_dir: Path, *, keep: int = 128, max_age_seconds: int = 3 * 24 * 3600) -> None:

--- a/tests/test_main_publish.py
+++ b/tests/test_main_publish.py
@@ -168,6 +168,7 @@ class MainPublishTests(unittest.TestCase):
             get_status=AsyncMock(return_value={"login_uin": 0}),
             publish_post=AsyncMock(return_value={"fid": "fid-1", "message": "ok"}),
         )
+        plugin._schedule_publish_render_asset_preload = lambda *args, **kwargs: None
         return plugin
 
     def test_legacy_qzone_group_subcommands_stay_registered(self):
@@ -368,20 +369,23 @@ class MainPublishTests(unittest.TestCase):
         )
         self.assertTrue(Path(results[0]["image"]).exists())
 
-    def test_qzone_post_renders_logged_in_qzone_publisher(self):
+    def test_qzone_post_uses_preloaded_qzone_publisher_profile(self):
         module = self.load_main_module()
         plugin = self.make_plugin(module)
         plugin.controller.get_status = AsyncMock(return_value={"login_uin": 123456})
+        cached_avatar = plugin.data_dir / "render_assets" / "avatar_123456.png"
+        cached_avatar.parent.mkdir(parents=True, exist_ok=True)
+        cached_avatar.write_bytes(b"png")
+        plugin._publisher_profile_cache = (
+            123456,
+            module.RenderProfile(nickname="QzoneOwner", user_id="123456", avatar_source=str(cached_avatar)),
+        )
         fake_image = plugin.data_dir / "rendered.png"
         fake_image.write_bytes(b"png")
         captured = {}
 
-        async def get_stranger_info(**kwargs):
-            self.assertEqual(kwargs["user_id"], 123456)
-            return {"nickname": "QzoneOwner"}
-
         event = Event([Plain("/qzone post hello")])
-        event.bot = types.SimpleNamespace(get_stranger_info=get_stranger_info)
+        event.bot = types.SimpleNamespace(get_stranger_info=AsyncMock(return_value={"nickname": "NetworkName"}))
 
         def fake_render(post, output_dir, **kwargs):
             captured.update(kwargs)
@@ -393,7 +397,8 @@ class MainPublishTests(unittest.TestCase):
         self.assertEqual(results, [{"image": str(fake_image)}])
         self.assertEqual(captured["profile"].nickname, "QzoneOwner")
         self.assertEqual(captured["profile"].user_id, "123456")
-        self.assertIn("123456", captured["profile"].avatar_source)
+        self.assertEqual(captured["profile"].avatar_source, str(cached_avatar))
+        event.bot.get_stranger_info.assert_not_awaited()
 
     def test_llm_list_feed_hides_cursor_and_internal_ids(self):
         module = self.load_main_module()

--- a/tests/test_publish_renderer.py
+++ b/tests/test_publish_renderer.py
@@ -8,7 +8,14 @@ from unittest.mock import patch
 from PIL import Image, ImageChops, ImageDraw
 
 from qzone_bridge.media import PostMedia, PostPayload
-from qzone_bridge.publish_renderer import ACTION, RenderProfile, _draw_share_icon, render_publish_result_image
+from qzone_bridge.publish_renderer import (
+    ACTION,
+    RenderProfile,
+    _draw_share_icon,
+    cached_avatar_source,
+    preload_publish_render_assets,
+    render_publish_result_image,
+)
 
 
 class PublishRendererTests(unittest.TestCase):
@@ -77,6 +84,42 @@ class PublishRendererTests(unittest.TestCase):
                 self.assertEqual(image.format, "PNG")
                 self.assertEqual(image.width, 700)
 
+    def test_preload_profile_avatar_writes_local_cache_once(self):
+        with tempfile.TemporaryDirectory() as temp:
+            temp_path = Path(temp)
+            profile = RenderProfile(
+                nickname="Coconut",
+                user_id="123456",
+                avatar_source="https://example.test/avatar-a.png",
+            )
+            calls = 0
+
+            def fake_read(source, *, max_bytes, remote_timeout):
+                nonlocal calls
+                calls += 1
+                image = Image.new("RGB", (512, 512), (120, 180, 210))
+                buffer = io.BytesIO()
+                image.save(buffer, format="PNG")
+                buffer.seek(0)
+                return buffer.read()
+
+            with patch("qzone_bridge.publish_renderer._read_source_bytes", side_effect=fake_read):
+                resolved = preload_publish_render_assets(profile, temp_path, remote_timeout=0.01)
+                second = preload_publish_render_assets(
+                    RenderProfile(
+                        nickname="Coconut",
+                        user_id="123456",
+                        avatar_source="https://example.test/avatar-b.png",
+                    ),
+                    temp_path,
+                    remote_timeout=0.01,
+                )
+
+            self.assertEqual(calls, 1)
+            self.assertTrue(Path(resolved.avatar_source).exists())
+            self.assertEqual(second.avatar_source, resolved.avatar_source)
+            self.assertEqual(cached_avatar_source(temp_path, profile), resolved.avatar_source)
+
     def test_result_fid_does_not_add_footer(self):
         with tempfile.TemporaryDirectory() as temp:
             temp_path = Path(temp)
@@ -109,8 +152,8 @@ class PublishRendererTests(unittest.TestCase):
         bbox = mask.getbbox()
         self.assertIsNotNone(bbox)
         self.assertGreater(bbox[2] - bbox[0], 28)
-        self.assertLessEqual(bbox[2], 56)
-        self.assertLessEqual(bbox[3], 46)
+        self.assertLessEqual(bbox[2], 64)
+        self.assertLessEqual(bbox[3], 52)
         self.assertIn(ACTION, image.getdata())
 
     def test_render_loads_multiple_previews_concurrently(self):


### PR DESCRIPTION
## Summary
- Preload static publish-render assets and cache the logged-in Qzone avatar as a local PNG after login/bind/warmup.
- Render publish cards from cached profile assets so posting no longer waits on avatar/profile network fetches.
- Refresh the action glyphs to match the provided outline style, round the comment bar, and switch image/avatar scaling to higher-quality resampling.
- Add regression coverage for avatar cache reuse and publish-time no-network profile rendering.

## Validation
- python -m py_compile main.py qzone_bridge\\publish_renderer.py
- python -m pytest tests/test_publish_renderer.py tests/test_main_publish.py
- python -m pytest

Full suite: 175 passed.