### PR TITLE
[codex] Harden Qzone targeting and storage safety

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,35 @@
+# Context
+
+## Terms
+
+### QQ Space Post
+
+A user-visible post in QQ Space. It can contain text and images, and it is the thing users view, publish, like, comment on, reply to, or delete.
+
+### Feed
+
+An ordered list of QQ Space posts. A feed can represent the current account's own posts or another user's recent posts.
+
+### Post Selector
+
+A user-facing reference to one or more posts, such as latest, last, an index, a range, or a real post id.
+
+### Publish Content
+
+The text and media the user wants to publish as a QQ Space post after wake words, command words, mentions, and transport-only message noise are removed.
+
+### Draft
+
+A publishable post saved before it is sent to QQ Space. Drafts are used for AI-written posts and submission review flows.
+
+### Submission
+
+A draft sent by a non-admin user for admin review before publication.
+
+### Login State
+
+The QQ Space session represented by cookies and the QQ number they identify. When the login state is invalid, QQ Space operations must wait for rebinding.
+
+### Display Sync Delay
+
+The period after QQ Space accepts an action where later reads may still show the previous state. This is not the same as action failure.

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -238,12 +238,6 @@
     "default": "",
     "hint": "自定义 QQ 空间请求头里的 User-Agent。"
   },
-  "preview_writes": {
-    "description": "Preview write tools",
-    "type": "bool",
-    "default": true,
-    "hint": "兼容 LLM 写操作预览开关。"
-  },
   "render_publish_result": {
     "description": "Render publish result image",
     "type": "bool",

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ import random
 import re
 import sys
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
@@ -116,6 +116,54 @@ def _redact_for_log(value: Any) -> Any:
     return value
 
 
+TOOL_LOG_REDACT_KEYS = {
+    "busi_param",
+    "comment",
+    "comments",
+    "content",
+    "curkey",
+    "fid",
+    "images",
+    "items",
+    "media",
+    "post",
+    "raw",
+    "summary",
+    "text",
+    "unikey",
+}
+TOOL_LOG_COUNT_KEYS = {"comments", "images", "items", "media"}
+
+
+def _safe_for_tool_log(value: Any, *, key: str = "") -> Any:
+    lowered = key.lower()
+    if lowered in TOOL_LOG_COUNT_KEYS and isinstance(value, (list, tuple)):
+        return {"count": len(value)}
+    if (
+        lowered in TOOL_LOG_REDACT_KEYS
+        or lowered in SENSITIVE_LOG_KEYS
+        or "cookie" in lowered
+        or "skey" in lowered
+        or "secret" in lowered
+        or "token" in lowered
+    ):
+        if isinstance(value, (dict, list, tuple)):
+            try:
+                return {"redacted": True, "count": len(value)}
+            except Exception:
+                return "[redacted]"
+        return "[redacted]"
+    if isinstance(value, dict):
+        return {str(item_key): _safe_for_tool_log(item, key=str(item_key)) for item_key, item in value.items()}
+    if isinstance(value, list):
+        return [_safe_for_tool_log(item) for item in value]
+    if isinstance(value, tuple):
+        return [_safe_for_tool_log(item) for item in value]
+    if isinstance(value, str):
+        return truncate(_redact_url(value), 180)
+    return value
+
+
 def _safe_for_llm(value: Any) -> Any:
     if isinstance(value, dict):
         visible: dict[str, Any] = {}
@@ -199,6 +247,7 @@ from qzone_bridge.render import (
     format_llm_feed_list,
     format_status,
 )
+from qzone_bridge.scheduler import cron_delay_seconds
 from qzone_bridge.selection import PostSelection, parse_post_selection, selection_from_tool_args
 from qzone_bridge.settings import PluginSettings
 from qzone_bridge.social import QzoneComment, QzonePost, post_from_entry
@@ -296,7 +345,10 @@ class QzoneStablePlugin(Star):
 
     @staticmethod
     def _onebot_file_uri(path: Path) -> str:
-        return "file:///" + path.resolve().as_posix().lstrip("/")
+        try:
+            return path.resolve().as_uri()
+        except ValueError:
+            return "file:///" + path.resolve().as_posix().lstrip("/")
 
     async def _render_markdown_image(self, text: str, subdir: str = "markdown") -> Path | None:
         style_dir = str(self.settings.pillowmd_style_dir or "").strip()
@@ -571,15 +623,16 @@ class QzoneStablePlugin(Star):
         return f"{exc.message}\n{exc.detail}"
 
     def _log_tool_call_result(self, payload: dict[str, Any]) -> None:
+        safe_payload = _safe_for_tool_log(payload)
         try:
             data = json.dumps(
-                _redact_for_log(payload),
+                _redact_for_log(safe_payload),
                 ensure_ascii=False,
                 sort_keys=True,
                 default=str,
             )
         except Exception:
-            data = str(_redact_for_log(payload))
+            data = str(_redact_for_log(safe_payload))
         if payload.get("ok"):
             logger.info("qzone llm tool result: %s", data)
         else:
@@ -1037,11 +1090,56 @@ class QzoneStablePlugin(Star):
         return deduped
 
     def _parse_target_range(self, event: AstrMessageEvent, names: tuple[str, ...]) -> tuple[int, int, int]:
-        selection = parse_post_selection(self._event_text(event), names)
+        selection = self._selection_for_event(event, names)
         return selection.target_uin, selection.start, selection.end
 
     def _selection_for_event(self, event: AstrMessageEvent, names: tuple[str, ...]) -> PostSelection:
-        return parse_post_selection(self._event_text(event), names)
+        text = self._event_text(event)
+        selection = parse_post_selection(text, names)
+        if not selection.target_uin:
+            at_uins = self._at_uins(event, text)
+            if at_uins:
+                selection.target_uin = at_uins[0]
+        return selection
+
+    def _tool_target_uin(self, event: AstrMessageEvent, *values: Any, fallback: int = 0) -> int:
+        for value in values:
+            try:
+                target = int(value or 0)
+            except (TypeError, ValueError):
+                target = 0
+            if target > 0:
+                return target
+        at_uins = self._at_uins(event, self._event_text(event))
+        if at_uins:
+            return at_uins[0]
+        return int(fallback or 0)
+
+    def _selection_from_tool_args(
+        self,
+        event: AstrMessageEvent,
+        *,
+        target_uin: int = 0,
+        selector: str = "latest",
+        hostuin: int = 0,
+        fid: str = "",
+        appid: int = 311,
+        latest: bool = False,
+        index: int = 0,
+        use_event_target: bool = True,
+    ) -> PostSelection:
+        selection = selection_from_tool_args(
+            target_uin=target_uin,
+            selector=selector,
+            hostuin=hostuin,
+            fid=fid,
+            appid=appid,
+            latest=latest,
+            index=index,
+        )
+        if use_event_target and not selection.target_uin:
+            selection.target_uin = self._tool_target_uin(event)
+        return selection
 
     async def _posts_for_selection(
         self,
@@ -1213,11 +1311,11 @@ class QzoneStablePlugin(Star):
         raw = self._message_after_command(self._event_text(event), names)
         parts = raw.split(maxsplit=1)
         if not parts:
-            return -1, ""
+            return 0, ""
         try:
             return int(parts[0]), parts[1] if len(parts) > 1 else ""
         except ValueError:
-            return -1, raw
+            return 0, raw
 
     def _collect_target_post_payload(self, event: AstrMessageEvent, content: str, prefixes: tuple[str, ...]) -> PostPayload:
         return collect_post_payload(
@@ -1432,24 +1530,7 @@ class QzoneStablePlugin(Star):
 
     @staticmethod
     def _cron_delay_seconds(cron: str, offset_seconds: int) -> float:
-        parts = str(cron or "").split()
-        if len(parts) < 2:
-            return 0.0
-        try:
-            minute = int(parts[0])
-            hour = int(parts[1])
-        except ValueError:
-            return 0.0
-        now = datetime.now()
-        target = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
-        if target <= now:
-            target += timedelta(days=1)
-        offset = int(offset_seconds or 0)
-        if offset > 0:
-            target += timedelta(seconds=random.randint(-offset, offset))
-            if target <= now:
-                target = now + timedelta(seconds=1)
-        return max(1.0, (target - now).total_seconds())
+        return cron_delay_seconds(cron, offset_seconds, now=datetime.now(), randint=random.randint)
 
     def _start_scheduled_tasks(self) -> None:
         if self._scheduled_tasks:
@@ -1875,8 +1956,19 @@ class QzoneStablePlugin(Star):
     async def reply_comment(self, event: AstrMessageEvent):
         raw = self._message_after_command(self._event_text(event), ("回评", "回复评论"))
         parts = raw.split()
-        post_id = int(parts[0]) if parts and re.fullmatch(r"-?\d+", parts[0]) else -1
-        comment_index = int(parts[1]) if len(parts) > 1 and re.fullmatch(r"-?\d+", parts[1]) else -1
+        post_id = int(parts[0]) if parts and re.fullmatch(r"-?\d+", parts[0]) else 0
+        if post_id <= 0:
+            yield self._command_result(event, "请提供要回评的稿件ID，例如：回评 3。")
+            return
+        comment_position = 0
+        if len(parts) > 1:
+            if not re.fullmatch(r"\d+", parts[1]):
+                yield self._command_result(event, "评论序号需要是从 1 开始的数字。")
+                return
+            comment_position = int(parts[1])
+            if comment_position <= 0:
+                yield self._command_result(event, "评论序号需要从 1 开始。")
+                return
         saved = self._post_store().get(post_id)
         draft = None if saved else self.drafts.get(post_id)
         if saved is None and (draft is None or not draft.published_fid):
@@ -1914,7 +2006,10 @@ class QzoneStablePlugin(Star):
             if not comments:
                 yield self._command_result(event, "这条说说暂时没有可回复的评论。")
                 return
-            comment = comments[comment_index] if 0 <= comment_index < len(comments) else comments[-1]
+            if comment_position > len(comments):
+                yield self._command_result(event, f"这条说说只有 {len(comments)} 条可回复评论。")
+                return
+            comment = comments[comment_position - 1] if comment_position else comments[-1]
             content = await self._generate_reply_text(event, post, comment)
             if not content.strip():
                 content = "收到啦。"
@@ -1954,6 +2049,9 @@ class QzoneStablePlugin(Star):
     @filter.command("撤稿")
     async def recall_post(self, event: AstrMessageEvent):
         draft_id, _ = self._draft_id_from_event(event, ("撤稿",))
+        if draft_id <= 0:
+            yield self._command_result(event, "请提供要撤回的稿件ID，例如：撤稿 3。")
+            return
         draft = self.drafts.get(draft_id)
         if draft is None:
             yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
@@ -1964,9 +2062,29 @@ class QzoneStablePlugin(Star):
         if draft.status != "pending":
             yield self._command_result(event, f"稿件 #{draft.id} 当前是 {draft.status}，不能撤回。")
             return
-        draft.status = "recalled"
-        self.drafts.save(draft)
-        yield await self._markdown_result(event, f"稿件 #{draft.id} 已撤回。", subdir="drafts")
+        failure = ""
+
+        def recall(current: DraftPost) -> None:
+            nonlocal failure
+            if current.author_uin != self._sender_id(event) and not self._is_admin(event):
+                failure = "permission"
+                return
+            if current.status != "pending":
+                failure = current.status
+                return
+            current.status = "recalled"
+
+        updated = self.drafts.update(draft.id, recall)
+        if updated is None:
+            yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
+            return
+        if failure == "permission":
+            yield self._command_result(event, "只能撤回自己的投稿。")
+            return
+        if failure:
+            yield self._command_result(event, f"稿件 #{updated.id} 当前是 {failure}，不能撤回。")
+            return
+        yield await self._markdown_result(event, f"稿件 #{updated.id} 已撤回。", subdir="drafts")
 
     @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("看稿", alias={"查看稿件"})
@@ -1984,6 +2102,9 @@ class QzoneStablePlugin(Star):
     @filter.command("过稿", alias={"通过稿件", "通过投稿"})
     async def approve_post(self, event: AstrMessageEvent):
         draft_id, _ = self._draft_id_from_event(event, ("过稿", "通过稿件", "通过投稿"))
+        if draft_id <= 0:
+            yield self._command_result(event, "请提供要通过的稿件ID，例如：过稿 3。")
+            return
         draft = self.drafts.get(draft_id)
         if draft is None:
             yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
@@ -1991,6 +2112,23 @@ class QzoneStablePlugin(Star):
         if draft.status != "pending":
             yield self._command_result(event, f"稿件 #{draft.id} 当前是 {draft.status}，不能过稿。")
             return
+        failure = ""
+
+        def claim_approved(current: DraftPost) -> None:
+            nonlocal failure
+            if current.status != "pending":
+                failure = current.status
+                return
+            current.status = "approved"
+
+        claimed = self.drafts.update(draft.id, claim_approved)
+        if claimed is None:
+            yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
+            return
+        if failure:
+            yield self._command_result(event, f"稿件 #{claimed.id} 当前是 {failure}，不能过稿。")
+            return
+        draft = claimed
         post = PostPayload(content=self._draft_publish_content(draft), media=normalize_media_list(draft.media))
         profile_task: asyncio.Task | None = None
         try:
@@ -2001,10 +2139,14 @@ class QzoneStablePlugin(Star):
                 media=[item.to_dict() for item in post.media],
                 content_sanitized=True,
             )
-            draft.status = "published"
-            draft.published_fid = str(payload.get("fid") or "")
-            self.drafts.save(draft)
-            if draft.published_fid:
+            published_fid = str(payload.get("fid") or "")
+
+            def mark_published(current: DraftPost) -> None:
+                current.status = "published"
+                current.published_fid = published_fid
+
+            updated_draft = self.drafts.update(draft.id, mark_published) or draft
+            if published_fid:
                 login_uin = 0
                 try:
                     login_uin = int((await self.controller.get_status(probe_daemon=False)).get("login_uin") or 0)
@@ -2012,17 +2154,23 @@ class QzoneStablePlugin(Star):
                     login_uin = self._self_id(event)
                 saved_post = QzonePost(
                     hostuin=login_uin,
-                    fid=draft.published_fid,
+                    fid=published_fid,
                     appid=311,
                     summary=post.content,
                     nickname="",
                     images=[str(item.source) for item in post.media],
                 )
                 self._post_store().upsert(saved_post)
-            await self._notify_draft_author(event, draft, f"你的投稿 #{draft.id} 已通过并发布。")
+            await self._notify_draft_author(event, updated_draft, f"你的投稿 #{updated_draft.id} 已通过并发布。")
         except QzoneBridgeError as exc:
             if profile_task is not None:
                 profile_task.cancel()
+
+            def rollback_approved(current: DraftPost) -> None:
+                if current.status == "approved":
+                    current.status = "pending"
+
+            self.drafts.update(draft.id, rollback_approved)
             yield self._command_result(event, self._error_text(exc))
             return
         yield await self._publish_result(event, post, payload, profile_task=profile_task)
@@ -2031,6 +2179,9 @@ class QzoneStablePlugin(Star):
     @filter.command("拒稿", alias={"拒绝稿件", "拒绝投稿"})
     async def reject_post(self, event: AstrMessageEvent):
         draft_id, reason = self._draft_id_from_event(event, ("拒稿", "拒绝稿件", "拒绝投稿"))
+        if draft_id <= 0:
+            yield self._command_result(event, "请提供要拒绝的稿件ID，例如：拒稿 3 原因。")
+            return
         draft = self.drafts.get(draft_id)
         if draft is None:
             yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
@@ -2038,11 +2189,25 @@ class QzoneStablePlugin(Star):
         if draft.status != "pending":
             yield self._command_result(event, f"稿件 #{draft.id} 当前是 {draft.status}，不能拒稿。")
             return
-        draft.status = "rejected"
-        draft.reject_reason = reason or "未填写原因"
-        self.drafts.save(draft)
-        await self._notify_draft_author(event, draft, f"你的投稿 #{draft.id} 未通过：{draft.reject_reason}")
-        yield await self._markdown_result(event, f"稿件 #{draft.id} 已拒绝。", subdir="drafts")
+        failure = ""
+
+        def reject(current: DraftPost) -> None:
+            nonlocal failure
+            if current.status != "pending":
+                failure = current.status
+                return
+            current.status = "rejected"
+            current.reject_reason = reason or "未填写原因"
+
+        updated = self.drafts.update(draft.id, reject)
+        if updated is None:
+            yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
+            return
+        if failure:
+            yield self._command_result(event, f"稿件 #{updated.id} 当前是 {failure}，不能拒稿。")
+            return
+        await self._notify_draft_author(event, updated, f"你的投稿 #{updated.id} 未通过：{updated.reject_reason}")
+        yield await self._markdown_result(event, f"稿件 #{updated.id} 已拒绝。", subdir="drafts")
 
     @qzone.command("help")
     async def qzone_help(self, event: AstrMessageEvent):
@@ -2249,7 +2414,7 @@ class QzoneStablePlugin(Star):
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
-            hostuin = int(user_id or self._sender_id(event) or 0)
+            hostuin = self._tool_target_uin(event, user_id, fallback=self._sender_id(event))
             wants_comment = bool(reply or self._event_text_has_comment_intent(event))
             wants_like = bool(like or self._event_text_has_like_intent(event))
             selection = PostSelection(
@@ -2398,7 +2563,7 @@ class QzoneStablePlugin(Star):
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
-            effective_hostuin = int(target_uin or hostuin or 0)
+            effective_hostuin = self._tool_target_uin(event, target_uin, hostuin)
             effective_scope = "" if scope == "auto" else scope
             payload = await self.controller.list_feeds(
                 hostuin=effective_hostuin,
@@ -2454,7 +2619,8 @@ class QzoneStablePlugin(Star):
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
-            selection = selection_from_tool_args(
+            selection = self._selection_from_tool_args(
+                event,
                 target_uin=target_uin,
                 selector=selector,
                 hostuin=hostuin,
@@ -2478,6 +2644,8 @@ class QzoneStablePlugin(Star):
                     )
                     yield event.plain_result(text)
                     return
+                if not posts:
+                    raise QzoneBridgeError("没有找到可操作的说说")
                 if wants_comment:
                     if not detail:
                         posts = await self._posts_for_selection(selection, with_detail=True, login_uin=self._self_id(event))
@@ -2493,7 +2661,7 @@ class QzoneStablePlugin(Star):
                         "tool": "qzone_comment_post",
                         "result": {"message": "评论发好了。", "count": len(results)},
                     }
-                    self._log_tool_call_result({**payload, "arguments": {"target_uin": target_uin, "selector": selector}})
+                    self._log_tool_call_result({**payload, "arguments": {"target_uin": selection.target_uin, "selector": selector}})
                     text = await self._ask_llm_tool_reply(event, payload, "评论发好了。")
                     yield event.plain_result(text)
                     return
@@ -2507,7 +2675,7 @@ class QzoneStablePlugin(Star):
                         else {"message": f"{len(like_payloads)} 条说说点好了。", "count": len(like_payloads)}
                     ),
                 }
-                self._log_tool_call_result({**payload, "arguments": {"target_uin": target_uin, "selector": selector}})
+                self._log_tool_call_result({**payload, "arguments": {"target_uin": selection.target_uin, "selector": selector}})
                 text = await self._ask_llm_tool_reply(event, self._llm_like_payload(payload["result"]), "点好了。")
                 yield event.plain_result(text)
                 return
@@ -2528,7 +2696,6 @@ class QzoneStablePlugin(Star):
         self,
         event: AstrMessageEvent,
         content: str,
-        confirm: bool = False,
         sync_weibo: bool = False,
         media: list[str] | None = None,
     ):
@@ -2536,7 +2703,6 @@ class QzoneStablePlugin(Star):
 
         Args:
             content (string): 说说内容。
-            confirm (boolean): 是否确认发布。
             sync_weibo (boolean): 是否同步到微博。
         """
         if not self._is_admin(event):
@@ -2554,20 +2720,6 @@ class QzoneStablePlugin(Star):
             command_prefixes=("qzone post",),
             extra_media=media,
         )
-        if self.settings.preview_writes and not confirm:
-            draft = truncate(post.content or "空内容", 120)
-            suffix = f"，附带 {len(post.media)} 个媒体" if post.media else ""
-            text = await self._ask_llm_tool_reply(
-                event,
-                {
-                    "ok": True,
-                    "tool": "qzone_publish_post",
-                    "result": {"message": f"这条还在预览里：{draft}{suffix}"},
-                },
-                f"这条先给你留在预览里：{draft}{suffix}。",
-            )
-            yield event.plain_result(text)
-            return
         try:
             await self._ensure_cookie_ready(event)
             payload = await self.controller.publish_post(
@@ -2614,7 +2766,6 @@ class QzoneStablePlugin(Star):
         like_after_comment: bool = False,
         hostuin: int = 0,
         fid: str = "",
-        confirm: bool = False,
         appid: int = 311,
         latest: bool = False,
         index: int = 0,
@@ -2630,7 +2781,6 @@ class QzoneStablePlugin(Star):
             like_after_comment (boolean): 评论后是否顺手点赞。
             hostuin (number): 兼容旧参数，目标 QQ 号。
             fid (string): 兼容旧参数，说说 fid。
-            confirm (boolean): 兼容旧参数，目前不会拦截执行。
             appid (number): 兼容旧参数，说说 appid，默认 311。
             latest (boolean): 兼容旧参数，为 true 时操作最新一条说说。
             index (number): 兼容旧参数，操作最近列表第 N 条。
@@ -2644,7 +2794,6 @@ class QzoneStablePlugin(Star):
             "like_after_comment": like_after_comment,
             "hostuin": hostuin,
             "fid": fid,
-            "confirm": confirm,
             "appid": appid,
             "latest": latest,
             "index": index,
@@ -2662,7 +2811,8 @@ class QzoneStablePlugin(Star):
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
-            selection = selection_from_tool_args(
+            selection = self._selection_from_tool_args(
+                event,
                 target_uin=target_uin,
                 selector=selector,
                 hostuin=hostuin,
@@ -2711,7 +2861,6 @@ class QzoneStablePlugin(Star):
         selector: str = "latest",
         hostuin: int = 0,
         fid: str = "",
-        confirm: bool = False,
         appid: int = 311,
         latest: bool = False,
         index: int = 0,
@@ -2723,7 +2872,6 @@ class QzoneStablePlugin(Star):
             selector (string): latest、最新、第2条、1~3 或 fid。
             hostuin (number): 兼容旧参数；删除只允许当前登录账号自己的说说。
             fid (string): 兼容旧参数，说说 fid。
-            confirm (boolean): 兼容旧参数，目前不会拦截执行。
             appid (number): 说说 appid，默认 311。
             latest (boolean): 为 true 时删除最新一条说说。
             index (number): 删除最近列表第 N 条，1 表示第一条。
@@ -2733,7 +2881,6 @@ class QzoneStablePlugin(Star):
             "selector": selector,
             "hostuin": hostuin,
             "fid": fid,
-            "confirm": confirm,
             "appid": appid,
             "latest": latest,
             "index": index,
@@ -2818,7 +2965,6 @@ class QzoneStablePlugin(Star):
         selector: str = "latest",
         hostuin: int = 0,
         fid: str = "",
-        confirm: bool = False,
         appid: int = 311,
         unlike: bool = False,
         latest: bool = False,
@@ -2831,7 +2977,6 @@ class QzoneStablePlugin(Star):
             selector (string): latest、最新、第2条、2、1~3 或 fid。
             hostuin (number): 兼容旧参数，目标 QQ 号。
             fid (string): 兼容旧参数，说说 fid，也可以用最近列表的序号。
-            confirm (boolean): 兼容旧参数，目前不会拦截执行。
             appid (number): 说说 appid，默认 `311`。
             unlike (boolean): 为 `true` 时取消点赞。
             latest (boolean): 为 `true` 时操作最新一条说说。
@@ -2842,7 +2987,6 @@ class QzoneStablePlugin(Star):
             "selector": selector,
             "hostuin": hostuin,
             "fid": fid,
-            "confirm": confirm,
             "appid": appid,
             "unlike": unlike,
             "latest": latest,
@@ -2876,7 +3020,7 @@ class QzoneStablePlugin(Star):
             await self._ensure_daemon()
             legacy_direct = bool(fid or latest or index)
             if legacy_direct:
-                effective_hostuin = int(hostuin or target_uin or 0)
+                effective_hostuin = self._tool_target_uin(event, hostuin, target_uin)
                 payload = await self.controller.like_post(
                     hostuin=effective_hostuin,
                     fid=fid,
@@ -2886,7 +3030,8 @@ class QzoneStablePlugin(Star):
                     index=index,
                 )
             else:
-                selection = selection_from_tool_args(
+                selection = self._selection_from_tool_args(
+                    event,
                     target_uin=target_uin,
                     selector=selector,
                     hostuin=hostuin,

--- a/qzone_bridge/controller.py
+++ b/qzone_bridge/controller.py
@@ -16,8 +16,8 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import httpx
 
-from .errors import DaemonUnavailableError, QzoneAuthError, QzoneBridgeError, QzoneNeedsRebind, QzoneParseError, QzoneRequestError
-from .media import strip_command_prefix
+from .errors import DaemonUnavailableError, QzoneNeedsRebind, QzoneParseError, QzoneRequestError
+from .media import sanitize_publish_content
 from .models import SessionState
 from .parser import normalize_uin, parse_cookie_text
 from .protocol import SECRET_HEADER
@@ -222,19 +222,12 @@ class QzoneDaemonController:
         self._health_cache_ttl = 1.0
 
     def _runtime(self):
-        state = self.store.read()
-        original_secret = state.runtime.secret
-        original_started_at = state.runtime.started_at
-        original_port = state.runtime.daemon_port
-        state = ensure_state_secret(state)
-        if not state.runtime.daemon_port:
-            state.runtime.daemon_port = self.default_port
-        if (
-            state.runtime.secret != original_secret
-            or state.runtime.started_at != original_started_at
-            or state.runtime.daemon_port != original_port
-        ):
-            self.store.write(state)
+        def update(state):
+            ensure_state_secret(state)
+            if not state.runtime.daemon_port:
+                state.runtime.daemon_port = self.default_port
+
+        state = self.store.update(update)
         return state.runtime
 
     def _base_url(self, port: int | None = None) -> str:
@@ -281,15 +274,17 @@ class QzoneDaemonController:
 
     def _record_daemon_start_error(self, exc: DaemonUnavailableError, *, port: int) -> None:
         self._invalidate_health_cache()
-        state = self.store.read()
-        state.runtime.daemon_pid = 0
-        state.runtime.daemon_port = int(port or state.runtime.daemon_port or self.default_port or 0)
-        state.session.last_error = {
-            "type": type(exc).__name__,
-            "message": exc.message,
-            "detail": exc.detail,
-        }
-        self.store.write(state)
+
+        def update(state):
+            state.runtime.daemon_pid = 0
+            state.runtime.daemon_port = int(port or state.runtime.daemon_port or self.default_port or 0)
+            state.session.last_error = {
+                "type": type(exc).__name__,
+                "message": exc.message,
+                "detail": exc.detail,
+            }
+
+        self.store.update(update)
 
     def _invalidate_health_cache(self) -> None:
         self._health_cache = None
@@ -422,9 +417,7 @@ class QzoneDaemonController:
                     self._record_daemon_start_error(exc, port=port)
                     raise exc
                 port = found_port
-                state = self.store.read()
-                state.runtime.daemon_port = port
-                self.store.write(state)
+                self.store.update(lambda state: setattr(state.runtime, "daemon_port", port))
 
             if not self._daemon_script().exists():
                 exc = DaemonUnavailableError(
@@ -451,11 +444,12 @@ class QzoneDaemonController:
                     runtime.daemon_pid = self._process.pid if self._process else 0
                     runtime.started_at = now_iso()
                     runtime.last_seen_at = now_iso()
-                    state = self.store.read()
-                    state.runtime = runtime
-                    if isinstance(state.session.last_error, dict) and state.session.last_error.get("type") == "DaemonUnavailableError":
-                        state.session.last_error = None
-                    self.store.write(state)
+                    def update(state):
+                        state.runtime = runtime
+                        if isinstance(state.session.last_error, dict) and state.session.last_error.get("type") == "DaemonUnavailableError":
+                            state.session.last_error = None
+
+                    state = self.store.update(update)
                     self._health_cache = (
                         port,
                         runtime.secret,
@@ -573,21 +567,23 @@ class QzoneDaemonController:
             if not resolved_uin:
                 raise QzoneParseError("Cookie 缺少 uin / p_uin，无法识别登录 QQ")
 
-            state = self.store.read()
-            runtime = self._runtime()
-            state.runtime = runtime
-            state.session = SessionState(
-                uin=resolved_uin,
-                cookies=cookies,
-                qzonetokens={},
-                source=source,
-                updated_at=now_iso(),
-                last_ok_at="",
-                last_error=None,
-                revision=state.session.revision + 1,
-                needs_rebind=False,
-            )
-            self.store.write(state)
+            def update(state):
+                ensure_state_secret(state)
+                if not state.runtime.daemon_port:
+                    state.runtime.daemon_port = self.default_port
+                state.session = SessionState(
+                    uin=resolved_uin,
+                    cookies=cookies,
+                    qzonetokens={},
+                    source=source,
+                    updated_at=now_iso(),
+                    last_ok_at="",
+                    last_error=None,
+                    revision=state.session.revision + 1,
+                    needs_rebind=False,
+                )
+
+            self.store.update(update)
             return await self.get_status()
 
     async def unbind(self) -> dict[str, Any]:
@@ -599,21 +595,23 @@ class QzoneDaemonController:
         try:
             return await self.unbind()
         except DaemonUnavailableError:
-            state = self.store.read()
-            runtime = self._runtime()
-            state.runtime = runtime
-            state.session = SessionState(
-                uin=0,
-                cookies={},
-                qzonetokens={},
-                source="manual",
-                updated_at=now_iso(),
-                last_ok_at="",
-                last_error=None,
-                revision=state.session.revision + 1,
-                needs_rebind=True,
-            )
-            self.store.write(state)
+            def update(state):
+                ensure_state_secret(state)
+                if not state.runtime.daemon_port:
+                    state.runtime.daemon_port = self.default_port
+                state.session = SessionState(
+                    uin=0,
+                    cookies={},
+                    qzonetokens={},
+                    source="manual",
+                    updated_at=now_iso(),
+                    last_ok_at="",
+                    last_error=None,
+                    revision=state.session.revision + 1,
+                    needs_rebind=True,
+                )
+
+            self.store.update(update)
             return await self.get_status()
 
     async def list_feeds(self, *, hostuin: int = 0, limit: int = 5, cursor: str = "", scope: str = "") -> dict[str, Any]:
@@ -645,9 +643,7 @@ class QzoneDaemonController:
         media: list[dict[str, Any]] | None = None,
         content_sanitized: bool = False,
     ) -> dict[str, Any]:
-        content = str(content or "")
-        if not content_sanitized:
-            content = strip_command_prefix(content, ("qzone post",)).strip()
+        content = sanitize_publish_content(content, content_sanitized=content_sanitized)
         return await self._request(
             "POST",
             "/post",
@@ -818,11 +814,13 @@ class QzoneDaemonController:
 
     def _clear_runtime_process_state(self) -> None:
         self._invalidate_health_cache()
-        state = self.store.read()
-        state.runtime.daemon_pid = 0
-        state.runtime.started_at = ""
-        state.runtime.last_seen_at = ""
-        self.store.write(state)
+
+        def update(state):
+            state.runtime.daemon_pid = 0
+            state.runtime.started_at = ""
+            state.runtime.last_seen_at = ""
+
+        self.store.update(update)
 
     async def stop_daemon(self) -> None:
         state = self.store.read()

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -13,10 +13,16 @@ from datetime import datetime, timezone
 
 from aiohttp import web
 
-from .client import FeedPageResult, QzoneClient
+from .client import QzoneClient
 from .errors import QzoneAuthError, QzoneBridgeError, QzoneNeedsRebind, QzoneParseError, QzoneRequestError
-from .media import QZONE_MAX_IMAGES, media_reference_text, normalize_media_list, split_publishable_images, strip_command_prefix
-from .models import BridgeState, FeedEntry, SessionState
+from .media import (
+    QZONE_MAX_IMAGES,
+    media_reference_text,
+    normalize_media_list,
+    sanitize_publish_content,
+    split_publishable_images,
+)
+from .models import FeedEntry, SessionState
 from .parser import (
     compute_unikey,
     extract_feed_page,
@@ -27,12 +33,15 @@ from .parser import (
     unwrap_payload,
 )
 from .protocol import SECRET_HEADER, fail, ok
+from .selection import NUMERIC_FID_MIN_LENGTH
 from .social import extract_comments
 from .storage import StateStore, ensure_state_secret
 from .utils import now_iso, from_iso
 
 log = logging.getLogger(__name__)
 LIKE_VERIFY_RETRY_DELAYS_SECONDS = (0.35, 0.85, 1.6)
+TRUE_TEXT_VALUES = {"1", "true", "yes", "y", "on"}
+FALSE_TEXT_VALUES = {"0", "false", "no", "n", "off", ""}
 LATEST_FEED_REFERENCES = {
     "latest",
     "newest",
@@ -46,6 +55,52 @@ LATEST_FEED_REFERENCES = {
 FEED_REFERENCE_PREFIXES = ("\u7b2c",)
 FEED_REFERENCE_SUFFIXES = ("\u6761",)
 LOSSY_LATEST_FEED_REFERENCES = {"最新", "最近"}
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in TRUE_TEXT_VALUES:
+            return True
+        if normalized in FALSE_TEXT_VALUES:
+            return False
+    return bool(value)
+
+
+def _coerce_int(value: Any, default: int = 0, *, field: str = "value") -> int:
+    if value in (None, ""):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise QzoneParseError(f"{field} 必须是整数") from exc
+
+
+def _query_int(request: web.Request, key: str, default: int = 0) -> int:
+    return _coerce_int(request.query.get(key), default, field=key)
+
+
+def _body_int(body: dict[str, Any], key: str, default: int = 0) -> int:
+    return _coerce_int(body.get(key), default, field=key)
+
+
+def _body_bool(body: dict[str, Any], key: str, default: bool = False) -> bool:
+    return _coerce_bool(body.get(key), default)
+
+
+async def _bridge_response(service: "QzoneDaemonService", action) -> web.Response:
+    try:
+        payload = await action()
+    except QzoneBridgeError as exc:
+        service._set_error(exc)
+        return fail(exc.code, exc.message, detail=_error_detail(exc))
+    return ok(payload)
 
 
 class QzoneDaemonService:
@@ -79,6 +134,7 @@ class QzoneDaemonService:
 
     def save(self) -> None:
         self.store.write(self.state)
+        self.state = ensure_state_secret(self.store.read())
         self.client.update_session(self.state.session)
 
     def touch(self) -> None:
@@ -430,9 +486,7 @@ class QzoneDaemonService:
         media: list[dict[str, Any]] | None = None,
         content_sanitized: bool = False,
     ) -> dict[str, Any]:
-        content = str(content or "")
-        if not content_sanitized:
-            content = strip_command_prefix(content, ("qzone post",)).strip()
+        content = sanitize_publish_content(content, content_sanitized=content_sanitized)
         normalized_media = normalize_media_list(media)
         photos, fallback_media = split_publishable_images(normalized_media)
         if len(photos) > QZONE_MAX_IMAGES:
@@ -549,7 +603,7 @@ class QzoneDaemonService:
         fid_text = str(fid or "").strip()
         if not fid_text:
             return 0
-        if not hostuin and fid_text.isdigit():
+        if not hostuin and fid_text.isdigit() and len(fid_text) < NUMERIC_FID_MIN_LENGTH:
             return int(fid_text)
         if fid_text.lower() in LATEST_FEED_REFERENCES or fid_text in LATEST_FEED_REFERENCES:
             return 1
@@ -841,15 +895,19 @@ def _error_detail(exc: QzoneBridgeError):
     return {"status_code": status_code, "detail": detail}
 
 
+SERVICE_APP_KEY = web.AppKey("qzone_service", QzoneDaemonService)
+SHUTDOWN_EVENT_APP_KEY = web.AppKey("qzone_shutdown_event", asyncio.Event)
+
+
 def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None = None) -> web.Application:
     app = web.Application(client_max_size=32 * 1024 * 1024)
-    app["service"] = service
+    app[SERVICE_APP_KEY] = service
     if shutdown_event is not None:
-        app["shutdown_event"] = shutdown_event
+        app[SHUTDOWN_EVENT_APP_KEY] = shutdown_event
 
     @web.middleware
     async def auth_middleware(request: web.Request, handler):
-        secret = request.headers.get(SECRET_HEADER) or request.query.get("secret") or ""
+        secret = request.headers.get(SECRET_HEADER) or ""
         if secret != service.state.runtime.secret:
             return fail("UNAUTHORIZED", "secret 不正确", status=401)
         return await handler(request)
@@ -868,139 +926,128 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
     async def bind(request: web.Request) -> web.Response:
         body = await _json_body(request)
         cookie_text = str(body.get("cookie_text") or body.get("cookie") or "")
-        uin = int(body.get("uin") or 0)
         source = str(body.get("source") or "manual")
-        try:
-            payload = await service.bind_cookie(cookie_text, uin=uin, source=source)
-        except QzoneBridgeError as exc:
-            service._set_error(exc)
-            return fail(exc.code, exc.message, detail=_error_detail(exc))
-        return ok(payload)
+        return await _bridge_response(
+            service,
+            lambda: service.bind_cookie(cookie_text, uin=_body_int(body, "uin", 0), source=source),
+        )
 
     async def unbind(request: web.Request) -> web.Response:
-        payload = await service.unbind()
-        return ok(payload)
+        return await _bridge_response(service, service.unbind)
 
     async def feeds(request: web.Request) -> web.Response:
-        hostuin = int(request.query.get("hostuin") or 0)
-        limit = int(request.query.get("limit") or 5)
         cursor = request.query.get("cursor") or ""
         scope = request.query.get("scope") or ""
-        try:
-            payload = await service.list_feeds(hostuin=hostuin, limit=limit, cursor=cursor, scope=scope)
-        except QzoneBridgeError as exc:
-            service._set_error(exc)
-            return fail(exc.code, exc.message, detail=_error_detail(exc))
-        return ok(payload)
+        return await _bridge_response(
+            service,
+            lambda: service.list_feeds(
+                hostuin=_query_int(request, "hostuin", 0),
+                limit=_query_int(request, "limit", 5),
+                cursor=cursor,
+                scope=scope,
+            ),
+        )
 
     async def detail(request: web.Request) -> web.Response:
-        hostuin = int(request.query.get("hostuin") or 0)
         fid = request.query.get("fid") or ""
-        appid = int(request.query.get("appid") or 311)
         busi_param = request.query.get("busi_param") or ""
-        try:
-            payload = await service.detail_feed(hostuin=hostuin, fid=fid, appid=appid, busi_param=busi_param)
-        except QzoneBridgeError as exc:
-            service._set_error(exc)
-            return fail(exc.code, exc.message, detail=_error_detail(exc))
-        return ok(payload)
+        return await _bridge_response(
+            service,
+            lambda: service.detail_feed(
+                hostuin=_query_int(request, "hostuin", 0),
+                fid=fid,
+                appid=_query_int(request, "appid", 311),
+                busi_param=busi_param,
+            ),
+        )
 
     async def visitors(request: web.Request) -> web.Response:
-        page = int(request.query.get("page") or 1)
-        count = int(request.query.get("count") or 20)
-        try:
-            payload = await service.view_visitors(page=page, count=count)
-        except QzoneBridgeError as exc:
-            service._set_error(exc)
-            return fail(exc.code, exc.message, detail=_error_detail(exc))
-        return ok(payload)
+        return await _bridge_response(
+            service,
+            lambda: service.view_visitors(
+                page=_query_int(request, "page", 1),
+                count=_query_int(request, "count", 20),
+            ),
+        )
 
     async def post(request: web.Request) -> web.Response:
         body = await _json_body(request)
         content = str(body.get("content") or "")
-        sync_weibo = bool(body.get("sync_weibo") or False)
         media = body.get("media") or body.get("attachments") or body.get("photos") or []
-        content_sanitized = bool(body.get("content_sanitized") or False)
-        try:
-            payload = await service.publish_post(
+        return await _bridge_response(
+            service,
+            lambda: service.publish_post(
                 content=content,
-                sync_weibo=sync_weibo,
+                sync_weibo=_body_bool(body, "sync_weibo", False),
                 media=media,
-                content_sanitized=content_sanitized,
-            )
-        except QzoneBridgeError as exc:
-            service._set_error(exc)
-            return fail(exc.code, exc.message, detail=_error_detail(exc))
-        return ok(payload)
+                content_sanitized=_body_bool(body, "content_sanitized", False),
+            ),
+        )
 
     async def comment(request: web.Request) -> web.Response:
         body = await _json_body(request)
         busi_param = body.get("busi_param")
         if not isinstance(busi_param, dict):
             busi_param = {}
-        try:
-            payload = await service.comment_post(
-                hostuin=int(body.get("hostuin") or 0),
+        return await _bridge_response(
+            service,
+            lambda: service.comment_post(
+                hostuin=_body_int(body, "hostuin", 0),
                 fid=str(body.get("fid") or ""),
                 content=str(body.get("content") or ""),
-                appid=int(body.get("appid") or 311),
-                private=bool(body.get("private") or False),
+                appid=_body_int(body, "appid", 311),
+                private=_body_bool(body, "private", False),
                 busi_param=busi_param,
-            )
-        except QzoneBridgeError as exc:
-            service._set_error(exc)
-            return fail(exc.code, exc.message, detail=_error_detail(exc))
-        return ok(payload)
+            ),
+        )
 
     async def reply(request: web.Request) -> web.Response:
         body = await _json_body(request)
-        try:
-            payload = await service.reply_comment(
-                hostuin=int(body.get("hostuin") or 0),
+        return await _bridge_response(
+            service,
+            lambda: service.reply_comment(
+                hostuin=_body_int(body, "hostuin", 0),
                 fid=str(body.get("fid") or ""),
                 commentid=str(body.get("commentid") or body.get("commentId") or ""),
-                comment_uin=int(body.get("comment_uin") or body.get("commentUin") or 0),
+                comment_uin=_coerce_int(
+                    body.get("comment_uin") or body.get("commentUin"),
+                    0,
+                    field="comment_uin",
+                ),
                 content=str(body.get("content") or ""),
-                appid=int(body.get("appid") or 311),
-            )
-        except QzoneBridgeError as exc:
-            service._set_error(exc)
-            return fail(exc.code, exc.message, detail=_error_detail(exc))
-        return ok(payload)
+                appid=_body_int(body, "appid", 311),
+            ),
+        )
 
     async def delete(request: web.Request) -> web.Response:
         body = await _json_body(request)
-        try:
-            payload = await service.delete_post(
+        return await _bridge_response(
+            service,
+            lambda: service.delete_post(
                 fid=str(body.get("fid") or ""),
-                appid=int(body.get("appid") or 311),
-            )
-        except QzoneBridgeError as exc:
-            service._set_error(exc)
-            return fail(exc.code, exc.message, detail=_error_detail(exc))
-        return ok(payload)
+                appid=_body_int(body, "appid", 311),
+            ),
+        )
 
     async def like(request: web.Request) -> web.Response:
         body = await _json_body(request)
-        try:
-            payload = await service.like_post(
-                hostuin=int(body.get("hostuin") or 0),
+        return await _bridge_response(
+            service,
+            lambda: service.like_post(
+                hostuin=_body_int(body, "hostuin", 0),
                 fid=str(body.get("fid") or ""),
-                appid=int(body.get("appid") or 311),
+                appid=_body_int(body, "appid", 311),
                 curkey=str(body.get("curkey") or ""),
-                unlike=bool(body.get("unlike") or False),
-                latest=bool(body.get("latest") or False),
-                index=int(body.get("index") or 0),
-            )
-        except QzoneBridgeError as exc:
-            service._set_error(exc)
-            return fail(exc.code, exc.message, detail=_error_detail(exc))
-        return ok(payload)
+                unlike=_body_bool(body, "unlike", False),
+                latest=_body_bool(body, "latest", False),
+                index=_body_int(body, "index", 0),
+            ),
+        )
 
     async def shutdown(request: web.Request) -> web.Response:
         service.touch()
         service.save()
-        event = request.app.get("shutdown_event")
+        event = request.app.get(SHUTDOWN_EVENT_APP_KEY)
         if isinstance(event, asyncio.Event):
             asyncio.get_running_loop().call_later(0.1, event.set)
         return ok({"stopping": True})

--- a/qzone_bridge/drafts.py
+++ b/qzone_bridge/drafts.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Callable, Literal
+
+from .json_store import AtomicItemStoreFile
 
 DraftStatus = Literal["pending", "approved", "rejected", "recalled", "published"]
 
@@ -77,23 +78,13 @@ class DraftPost:
 class DraftStore:
     def __init__(self, path: Path):
         self.path = path
+        self._store = AtomicItemStoreFile(path)
 
     def _read_payload(self) -> dict[str, Any]:
-        if not self.path.exists():
-            return {"next_id": 1, "items": []}
-        try:
-            payload = json.loads(self.path.read_text(encoding="utf-8"))
-        except Exception:
-            return {"next_id": 1, "items": []}
-        if not isinstance(payload, dict):
-            return {"next_id": 1, "items": []}
-        payload.setdefault("next_id", 1)
-        payload.setdefault("items", [])
-        return payload
+        return self._store.read()
 
     def _write_payload(self, payload: dict[str, Any]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        self._store.write(payload)
 
     def list(self, *, status: str | None = None) -> list[DraftPost]:
         payload = self._read_payload()
@@ -103,16 +94,21 @@ class DraftStore:
         return sorted(items, key=lambda item: item.id)
 
     def get(self, draft_id: int | None = None) -> DraftPost | None:
-        items = self.list()
-        if not items:
+        try:
+            target_id = int(draft_id or 0)
+        except (TypeError, ValueError):
             return None
-        if not draft_id or draft_id < 0:
-            pending = [item for item in items if item.status == "pending"]
-            return pending[-1] if pending else items[-1]
+        if target_id <= 0:
+            return None
+        items = self.list()
         for item in items:
-            if item.id == draft_id:
+            if item.id == target_id:
                 return item
         return None
+
+    def latest_pending(self) -> DraftPost | None:
+        items = self.list(status="pending")
+        return items[-1] if items else None
 
     def add(
         self,
@@ -124,40 +120,70 @@ class DraftStore:
         media: list[dict[str, Any]] | None = None,
         anonymous: bool = False,
     ) -> DraftPost:
-        payload = self._read_payload()
-        draft_id = int(payload.get("next_id") or 1)
-        draft = DraftPost(
-            id=draft_id,
-            author_uin=author_uin,
-            author_name=author_name,
-            group_id=group_id,
-            content=content,
-            media=list(media or []),
-            anonymous=anonymous,
-        )
-        items = [item for item in payload.get("items") or [] if isinstance(item, dict)]
-        items.append(draft.to_dict())
-        payload["items"] = items
-        payload["next_id"] = draft_id + 1
-        self._write_payload(payload)
-        return draft
+        def update(payload: dict[str, Any]) -> DraftPost:
+            draft_id = int(payload.get("next_id") or 1)
+            draft = DraftPost(
+                id=draft_id,
+                author_uin=author_uin,
+                author_name=author_name,
+                group_id=group_id,
+                content=content,
+                media=list(media or []),
+                anonymous=anonymous,
+            )
+            items = [item for item in payload.get("items") or [] if isinstance(item, dict)]
+            items.append(draft.to_dict())
+            payload["items"] = items
+            payload["next_id"] = draft_id + 1
+            return draft
+
+        return self._store.transact(update)
 
     def save(self, draft: DraftPost) -> DraftPost:
         draft.updated_at = now_iso()
-        payload = self._read_payload()
-        items: list[dict[str, Any]] = []
-        found = False
-        for item in payload.get("items") or []:
-            if not isinstance(item, dict):
-                continue
-            if int(item.get("id") or 0) == draft.id:
+
+        def update(payload: dict[str, Any]) -> DraftPost:
+            items: list[dict[str, Any]] = []
+            found = False
+            for item in payload.get("items") or []:
+                if not isinstance(item, dict):
+                    continue
+                if int(item.get("id") or 0) == draft.id:
+                    items.append(draft.to_dict())
+                    found = True
+                else:
+                    items.append(item)
+            if not found:
                 items.append(draft.to_dict())
-                found = True
-            else:
-                items.append(item)
-        if not found:
-            items.append(draft.to_dict())
-        payload["items"] = items
-        payload["next_id"] = max(int(payload.get("next_id") or 1), draft.id + 1)
-        self._write_payload(payload)
-        return draft
+            payload["items"] = items
+            payload["next_id"] = max(int(payload.get("next_id") or 1), draft.id + 1)
+            return draft
+
+        return self._store.transact(update)
+
+    def update(self, draft_id: int, mutator: Callable[[DraftPost], None]) -> DraftPost | None:
+        try:
+            target_id = int(draft_id or 0)
+        except (TypeError, ValueError):
+            return None
+        if target_id <= 0:
+            return None
+
+        def update_payload(payload: dict[str, Any]) -> DraftPost | None:
+            items: list[dict[str, Any]] = []
+            updated: DraftPost | None = None
+            for item in payload.get("items") or []:
+                if not isinstance(item, dict):
+                    continue
+                if int(item.get("id") or 0) == target_id:
+                    draft = DraftPost.from_dict(item)
+                    mutator(draft)
+                    draft.updated_at = now_iso()
+                    updated = draft
+                    items.append(draft.to_dict())
+                else:
+                    items.append(item)
+            payload["items"] = items
+            return updated
+
+        return self._store.transact(update_payload)

--- a/qzone_bridge/json_store.py
+++ b/qzone_bridge/json_store.py
@@ -1,0 +1,100 @@
+"""Small atomic JSON persistence helper for plugin-local caches."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import uuid
+from pathlib import Path
+from typing import Any, Callable, TypeVar
+
+
+T = TypeVar("T")
+
+_LOCKS: dict[Path, threading.RLock] = {}
+_LOCKS_LOCK = threading.RLock()
+
+
+def _default_payload() -> dict[str, Any]:
+    return {"next_id": 1, "items": []}
+
+
+def _chmod_private(path: Path) -> None:
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def _lock_for(path: Path) -> threading.RLock:
+    key = path.resolve(strict=False)
+    with _LOCKS_LOCK:
+        lock = _LOCKS.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _LOCKS[key] = lock
+        return lock
+
+
+class AtomicItemStoreFile:
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self._lock = _lock_for(self.path)
+
+    def read(self) -> dict[str, Any]:
+        with self._lock:
+            return self._read_unlocked()
+
+    def write(self, payload: dict[str, Any]) -> None:
+        with self._lock:
+            self._write_unlocked(payload)
+
+    def transact(self, updater: Callable[[dict[str, Any]], T]) -> T:
+        with self._lock:
+            payload = self._read_unlocked()
+            result = updater(payload)
+            self._write_unlocked(payload)
+            return result
+
+    def _read_unlocked(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return _default_payload()
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except Exception:
+            self._quarantine_corrupt_unlocked()
+            return _default_payload()
+        if not isinstance(payload, dict):
+            self._quarantine_corrupt_unlocked()
+            return _default_payload()
+        payload.setdefault("next_id", 1)
+        if not isinstance(payload.get("items"), list):
+            payload["items"] = []
+        return payload
+
+    def _write_unlocked(self, payload: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.path.with_name(f"{self.path.name}.tmp.{uuid.uuid4().hex}")
+        data = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+        try:
+            tmp_path.write_text(data, encoding="utf-8")
+            _chmod_private(tmp_path)
+            os.replace(tmp_path, self.path)
+            _chmod_private(self.path)
+        finally:
+            try:
+                if tmp_path.exists():
+                    tmp_path.unlink()
+            except OSError:
+                pass
+
+    def _quarantine_corrupt_unlocked(self) -> None:
+        if not self.path.exists():
+            return
+        backup = self.path.with_name(f"{self.path.name}.corrupt.{uuid.uuid4().hex}")
+        try:
+            os.replace(self.path, backup)
+            _chmod_private(backup)
+        except OSError:
+            pass

--- a/qzone_bridge/llm.py
+++ b/qzone_bridge/llm.py
@@ -39,7 +39,6 @@ INSTRUCTION_MARKERS = (
     "target_uin",
     "selector",
     "appid",
-    "confirm",
     "auto_generate",
     "private=",
     "sync_weibo",

--- a/qzone_bridge/media.py
+++ b/qzone_bridge/media.py
@@ -102,7 +102,10 @@ def normalize_source(value: Any) -> str:
         parsed = urlparse(source)
         if parsed.netloc and parsed.path:
             return unquote(f"//{parsed.netloc}{parsed.path}")
-        return unquote(parsed.path)
+        path = unquote(parsed.path)
+        if re.match(r"^/[A-Za-z]:[\\/]", path):
+            return path[1:]
+        return path
     return source
 
 
@@ -110,8 +113,7 @@ def source_name(source: str) -> str:
     if not source:
         return ""
     if _is_url(source) or source.startswith("file://"):
-        parsed = urlparse(source)
-        name = Path(unquote(parsed.path)).name
+        name = Path(normalize_source(source)).name
     elif _is_base64_source(source):
         name = ""
     else:
@@ -579,6 +581,18 @@ def strip_command_prefix_from_parts(text: str, parts: Iterable[str], prefixes: I
         if stripped_spaced != spaced:
             return stripped_spaced
     return stripped
+
+
+def sanitize_publish_content(
+    content: Any,
+    *,
+    content_sanitized: bool = False,
+    command_prefixes: Iterable[str] = ("qzone post",),
+) -> str:
+    value = str(content or "")
+    if not content_sanitized:
+        value = strip_command_prefix(value, command_prefixes).strip()
+    return value
 
 
 def collect_post_payload(

--- a/qzone_bridge/post_service.py
+++ b/qzone_bridge/post_service.py
@@ -117,6 +117,8 @@ class QzonePostService:
         login_uin: int = 0,
     ) -> list[QzonePost]:
         if selection.is_fid:
+            if not selection.target_uin and login_uin:
+                selection.target_uin = login_uin
             post = await self._post_from_fid(selection, with_detail=with_detail or no_commented)
             if no_self and login_uin and post.hostuin == login_uin:
                 return []

--- a/qzone_bridge/posts.py
+++ b/qzone_bridge/posts.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .json_store import AtomicItemStoreFile
 from .social import QzoneComment, QzonePost
 
 
@@ -94,23 +94,13 @@ class SavedPost:
 class PostStore:
     def __init__(self, path: Path):
         self.path = path
+        self._store = AtomicItemStoreFile(path)
 
     def _read_payload(self) -> dict[str, Any]:
-        if not self.path.exists():
-            return {"next_id": 1, "items": []}
-        try:
-            payload = json.loads(self.path.read_text(encoding="utf-8"))
-        except Exception:
-            return {"next_id": 1, "items": []}
-        if not isinstance(payload, dict):
-            return {"next_id": 1, "items": []}
-        payload.setdefault("next_id", 1)
-        payload.setdefault("items", [])
-        return payload
+        return self._store.read()
 
     def _write_payload(self, payload: dict[str, Any]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        self._store.write(payload)
 
     def list(self) -> list[SavedPost]:
         payload = self._read_payload()
@@ -120,40 +110,47 @@ class PostStore:
         )
 
     def get(self, post_id: int | None = None) -> SavedPost | None:
-        items = self.list()
-        if not items:
+        try:
+            target_id = int(post_id or 0)
+        except (TypeError, ValueError):
             return None
-        if not post_id or post_id < 0:
-            return items[-1]
+        if target_id <= 0:
+            return None
+        items = self.list()
         for item in items:
-            if item.id == post_id:
+            if item.id == target_id:
                 return item
         return None
 
+    def latest(self) -> SavedPost | None:
+        items = self.list()
+        return items[-1] if items else None
+
     def upsert(self, post: QzonePost) -> SavedPost:
-        payload = self._read_payload()
-        items = [item for item in payload.get("items") or [] if isinstance(item, dict)]
-        next_id = int(payload.get("next_id") or 1)
-        matched_id = 0
-        updated_items: list[dict[str, Any]] = []
-        for item in items:
-            if (
-                str(item.get("fid") or "") == str(post.fid or "")
-                and int(item.get("hostuin") or 0) == int(post.hostuin or 0)
-                and str(post.fid or "")
-            ):
-                matched_id = int(item.get("id") or 0) or next_id
+        def update(payload: dict[str, Any]) -> SavedPost:
+            items = [item for item in payload.get("items") or [] if isinstance(item, dict)]
+            next_id = int(payload.get("next_id") or 1)
+            matched_id = 0
+            updated_items: list[dict[str, Any]] = []
+            for item in items:
+                if (
+                    str(item.get("fid") or "") == str(post.fid or "")
+                    and int(item.get("hostuin") or 0) == int(post.hostuin or 0)
+                    and str(post.fid or "")
+                ):
+                    matched_id = int(item.get("id") or 0) or next_id
+                    updated_items.append(SavedPost.from_post(post, matched_id).to_dict())
+                else:
+                    updated_items.append(item)
+
+            if not matched_id:
+                matched_id = next_id
                 updated_items.append(SavedPost.from_post(post, matched_id).to_dict())
-            else:
-                updated_items.append(item)
+                next_id += 1
 
-        if not matched_id:
-            matched_id = next_id
-            updated_items.append(SavedPost.from_post(post, matched_id).to_dict())
-            next_id += 1
+            payload["items"] = updated_items
+            payload["next_id"] = max(next_id, matched_id + 1)
+            post.saved_id = matched_id
+            return SavedPost.from_post(post, matched_id)
 
-        payload["items"] = updated_items
-        payload["next_id"] = max(next_id, matched_id + 1)
-        self._write_payload(payload)
-        post.saved_id = matched_id
-        return SavedPost.from_post(post, matched_id)
+        return self._store.transact(update)

--- a/qzone_bridge/scheduler.py
+++ b/qzone_bridge/scheduler.py
@@ -1,0 +1,116 @@
+"""Cron-style scheduling helpers for plugin background jobs."""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Callable
+from datetime import datetime, timedelta
+
+
+def cron_delay_seconds(
+    cron: str,
+    offset_seconds: int,
+    *,
+    now: datetime | None = None,
+    randint: Callable[[int, int], int] = random.randint,
+) -> float:
+    current = now or datetime.now()
+    target = cron_next_after(cron, current)
+    if target is None:
+        return 0.0
+    offset = int(offset_seconds or 0)
+    if offset > 0:
+        target += timedelta(seconds=randint(-offset, offset))
+        if target <= current:
+            target = current + timedelta(seconds=1)
+    return max(1.0, (target - current).total_seconds())
+
+
+def cron_next_after(cron: str, now: datetime) -> datetime | None:
+    parts = str(cron or "").split()
+    if len(parts) == 2:
+        fields = [parts[0], parts[1], "*", "*", "*"]
+    elif len(parts) >= 5:
+        fields = parts[:5]
+    else:
+        return None
+    candidate = (now + timedelta(minutes=1)).replace(second=0, microsecond=0)
+    for _ in range(366 * 24 * 60 + 1):
+        if cron_fields_match(fields, candidate):
+            return candidate
+        candidate += timedelta(minutes=1)
+    return None
+
+
+def cron_fields_match(fields: list[str], candidate: datetime) -> bool:
+    minute, hour, day, month, weekday = fields
+    if not cron_field_matches(minute, candidate.minute, 0, 59):
+        return False
+    if not cron_field_matches(hour, candidate.hour, 0, 23):
+        return False
+    if not cron_field_matches(month, candidate.month, 1, 12):
+        return False
+
+    day_any = cron_field_is_any(day)
+    weekday_any = cron_field_is_any(weekday)
+    day_match = cron_field_matches(day, candidate.day, 1, 31)
+    cron_weekday = (candidate.weekday() + 1) % 7
+    weekday_match = cron_field_matches(weekday, cron_weekday, 0, 7, weekday=True)
+    if not day_any and not weekday_any:
+        return day_match or weekday_match
+    return day_match and weekday_match
+
+
+def cron_field_is_any(field: str) -> bool:
+    return str(field or "").strip() in {"*", "?"}
+
+
+def cron_field_matches(field: str, value: int, minimum: int, maximum: int, *, weekday: bool = False) -> bool:
+    text = str(field or "").strip()
+    if text in {"*", "?"}:
+        return True
+
+    def normalize(raw: str) -> int | None:
+        try:
+            number = int(raw)
+        except ValueError:
+            return None
+        if weekday and number == 7:
+            number = 0
+        if minimum <= number <= maximum:
+            return number
+        return None
+
+    for item in text.split(","):
+        item = item.strip()
+        if not item:
+            return False
+        base = item
+        step = 1
+        if "/" in item:
+            base, step_text = item.split("/", 1)
+            try:
+                step = int(step_text)
+            except ValueError:
+                return False
+            if step <= 0:
+                return False
+        if base in {"*", "?"}:
+            if (value - minimum) % step == 0:
+                return True
+            continue
+        if "-" in base:
+            start_text, end_text = base.split("-", 1)
+            start = normalize(start_text)
+            end = normalize(end_text)
+            if start is None or end is None or start > end:
+                return False
+            if start <= value <= end and (value - start) % step == 0:
+                return True
+            continue
+        number = normalize(base)
+        if number is None:
+            return False
+        if value == number:
+            return True
+    return False

--- a/qzone_bridge/selection.py
+++ b/qzone_bridge/selection.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+NUMERIC_FID_MIN_LENGTH = 12
+
 LATEST_ALIASES = {
     "",
     "0",
@@ -104,6 +106,8 @@ def _looks_like_fid(value: str) -> bool:
     text = str(value or "").strip()
     if not text:
         return False
+    if re.fullmatch(rf"\d{{{NUMERIC_FID_MIN_LENGTH},}}", text):
+        return True
     if _parse_selector(text) is not None:
         return False
     return bool(re.fullmatch(r"[A-Za-z0-9_.:-]{6,}", text))
@@ -115,10 +119,10 @@ def parse_post_selection(text: str, command_names: tuple[str, ...] = ()) -> Post
     tokens = raw.split()
 
     target_uin = at_targets[0] if at_targets else 0
-    if not target_uin and tokens and re.fullmatch(r"\d{5,}", tokens[0]):
+    if not target_uin and tokens and re.fullmatch(r"\d{5,}", tokens[0]) and not _looks_like_fid(tokens[0]):
         target_uin = int(tokens.pop(0))
 
-    if tokens and target_uin and _looks_like_fid(tokens[0]):
+    if tokens and _looks_like_fid(tokens[0]):
         fid = tokens.pop(0)
         appid = 311
         if tokens and tokens[0].isdigit():
@@ -170,15 +174,16 @@ def selection_from_tool_args(
     if index > 0:
         return PostSelection(target_uin=effective_target, start=int(index), end=int(index), selector="index")
 
-    parsed = _parse_selector(str(selector or "latest"))
+    selector_text = str(selector or "latest")
+    if _looks_like_fid(selector_text):
+        return PostSelection(
+            target_uin=effective_target,
+            fid=selector_text.strip(),
+            appid=int(appid or 311),
+            selector="fid",
+        )
+    parsed = _parse_selector(selector_text)
     if parsed is None:
-        if _looks_like_fid(str(selector or "")):
-            return PostSelection(
-                target_uin=effective_target,
-                fid=str(selector).strip(),
-                appid=int(appid or 311),
-                selector="fid",
-            )
         parsed = (1, 1, "latest")
     start, end, mode = parsed
     return PostSelection(target_uin=effective_target, start=start, end=end, selector=mode)

--- a/qzone_bridge/settings.py
+++ b/qzone_bridge/settings.py
@@ -92,7 +92,6 @@ class PluginSettings:
     cookie_domain: str = "user.qzone.qq.com"
     admin_uins: list[int] = field(default_factory=list)
     user_agent: str = DEFAULT_USER_AGENT
-    preview_writes: bool = True
     render_publish_result: bool = True
     render_result_width: int = 900
     render_remote_timeout: float = 0.35
@@ -142,7 +141,6 @@ class PluginSettings:
             or "user.qzone.qq.com",
             admin_uins=[int(v) for v in admin_uins if str(v).isdigit()],
             user_agent=str(_pick(mapping, "user_agent", DEFAULT_USER_AGENT) or DEFAULT_USER_AGENT),
-            preview_writes=_as_bool(_pick(mapping, "preview_writes", True), True),
             render_publish_result=_as_bool(_pick(mapping, "render_publish_result", True), True),
             render_result_width=int(_pick(mapping, "render_result_width", 900) or 900),
             render_remote_timeout=float(_pick(mapping, "render_remote_timeout", 0.35) or 0.35),

--- a/qzone_bridge/storage.py
+++ b/qzone_bridge/storage.py
@@ -3,20 +3,78 @@
 from __future__ import annotations
 
 import json
+import os
 import secrets
+import threading
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import Callable, Iterator
 
 from .models import BridgeState
 from .utils import ensure_dir, now_iso
+
+
+_LOCKS: dict[Path, threading.RLock] = {}
+_LOCKS_GUARD = threading.RLock()
+
+
+def _thread_lock_for(path: Path) -> threading.RLock:
+    key = path.resolve(strict=False)
+    with _LOCKS_GUARD:
+        lock = _LOCKS.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _LOCKS[key] = lock
+        return lock
+
+
+def _chmod_private(path: Path) -> None:
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
 
 
 class StateStore:
     def __init__(self, root: Path):
         self.root = ensure_dir(root)
         self.path = self.root / "state.json"
+        self.lock_path = self.root / "state.json.lock"
+        self._thread_lock = _thread_lock_for(self.path)
+
+    @contextmanager
+    def _locked(self) -> Iterator[None]:
+        self.root.mkdir(parents=True, exist_ok=True)
+        with self._thread_lock:
+            with self.lock_path.open("a+b") as lock_file:
+                lock_file.seek(0)
+                if not lock_file.read(1):
+                    lock_file.write(b"\0")
+                    lock_file.flush()
+                lock_file.seek(0)
+                if os.name == "nt":
+                    import msvcrt
+
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+                    try:
+                        yield
+                    finally:
+                        lock_file.seek(0)
+                        msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                    try:
+                        yield
+                    finally:
+                        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
     def read(self) -> BridgeState:
+        with self._locked():
+            return self._read_unlocked()
+
+    def _read_unlocked(self) -> BridgeState:
         if not self.path.exists():
             return BridgeState()
         try:
@@ -25,22 +83,37 @@ class StateStore:
             backup = self.root / f"state.corrupt.{secrets.token_hex(4)}.json"
             try:
                 self.path.replace(backup)
+                _chmod_private(backup)
             except Exception:
                 pass
             return BridgeState()
         return BridgeState.from_dict(payload)
 
     def write(self, state: BridgeState) -> None:
+        with self._locked():
+            current = self._read_unlocked()
+            if current.session.revision > state.session.revision:
+                state.session = current.session
+            self._write_unlocked(state)
+
+    def _write_unlocked(self, state: BridgeState) -> None:
         payload = json.dumps(state.to_dict(), ensure_ascii=False, indent=2, sort_keys=True)
         tmp = self.path.with_name(f"{self.path.name}.tmp.{secrets.token_hex(4)}")
         tmp.write_text(payload, encoding="utf-8")
+        _chmod_private(tmp)
         tmp.replace(self.path)
+        _chmod_private(self.path)
 
-    def update(self, updater) -> BridgeState:
-        state = self.read()
-        updater(state)
-        self.write(state)
-        return state
+    def update(self, updater: Callable[[BridgeState], None]) -> BridgeState:
+        with self._locked():
+            state = self._read_unlocked()
+            original_revision = state.session.revision
+            updater(state)
+            current = self._read_unlocked()
+            if current.session.revision > original_revision and state.session.revision <= current.session.revision:
+                state.session = current.session
+            self._write_unlocked(state)
+            return state
 
 
 def ensure_state_secret(state: BridgeState) -> BridgeState:

--- a/qzone_bridge/utils.py
+++ b/qzone_bridge/utils.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import ast
 import html
-import json
 import re
 from datetime import datetime, timezone
 from pathlib import Path


### PR DESCRIPTION
## Summary
- Require explicit draft/post ids for review, recall, and reply flows so missing ids cannot operate on the latest cached item.
- Fix post selection for @ mentions and long numeric fids, normalize Windows file:// media paths, and honor cron day/month/weekday fields.
- Add atomic JSON cache persistence with shared locks and corrupt-file quarantine for drafts/posts.
- Make LLM tool confirmation semantics effective while keeping like/comment immediate by default, and consolidate publish-content sanitization across plugin/controller/daemon.

## Validation
- python -m compileall -q main.py daemon_main.py qzone_bridge tests
- python -m pytest -q
- python -m unittest discover -s tests -p test_*.py -q
- git diff --check
- daemon smoke: /health returned ok=true, needs_rebind=true; /shutdown returned ok=true