### PR TITLE
[codex] Align Qzone plugin with AstrBot runtime APIs

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import importlib
 import json
 import random
 import re
+import shutil
 import sys
 import time
 from datetime import datetime
@@ -17,9 +18,10 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, filter
-from astrbot.api.star import Context, Star
+from astrbot.api.star import Context, Star, StarTools
 
 PLUGIN_ROOT = Path(__file__).resolve().parent
+PLUGIN_DATA_NAME = "astrbot_plugin_qzone_ultra"
 
 SENSITIVE_LOG_KEYS = {
     "cookie",
@@ -219,6 +221,41 @@ def _prepare_local_qzone_bridge_imports() -> None:
             sys.modules.pop(name, None)
 
 
+def _migrate_legacy_data_dir(legacy_dir: Path, data_dir: Path) -> None:
+    try:
+        legacy = legacy_dir.resolve()
+        target = data_dir.resolve()
+    except Exception:
+        legacy = legacy_dir
+        target = data_dir
+    if legacy == target or not legacy_dir.exists() or not legacy_dir.is_dir():
+        return
+    try:
+        data_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as exc:
+        logger.warning("qzone standard data dir is not writable: %s", exc)
+        return
+    for item in legacy_dir.iterdir():
+        if item.name in {"__pycache__", ".pytest_cache"}:
+            continue
+        target_item = data_dir / item.name
+        if target_item.exists():
+            continue
+        try:
+            if item.is_dir():
+                shutil.copytree(item, target_item)
+            elif item.is_file():
+                shutil.copy2(item, target_item)
+        except Exception as exc:
+            logger.warning("qzone legacy data migration skipped %s: %s", item.name, exc)
+
+
+def _standard_data_dir(plugin_root: Path) -> Path:
+    data_dir = Path(StarTools.get_data_dir(PLUGIN_DATA_NAME))
+    _migrate_legacy_data_dir(plugin_root / "data" / "qzone", data_dir)
+    return data_dir
+
+
 _prepare_local_qzone_bridge_imports()
 
 from qzone_bridge.controller import QzoneDaemonController
@@ -276,7 +313,7 @@ class QzoneStablePlugin(Star):
         raw_config = config if config is not None else getattr(context, "get_config", lambda: {})()
         self.settings = PluginSettings.from_mapping(raw_config)
         self.root = Path(__file__).resolve().parent
-        self.data_dir = self.root / "data" / "qzone"
+        self.data_dir = _standard_data_dir(self.root)
         self._onebot_client: Any | None = None
         self._cookie_lock: asyncio.Lock | None = None
         self.controller = QzoneDaemonController(

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import inspect
 import importlib
 import json
@@ -11,17 +12,21 @@ import re
 import shutil
 import sys
 import time
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, filter
-from astrbot.api.star import Context, Star, StarTools
+from astrbot.api.star import Context, Star
 
 PLUGIN_ROOT = Path(__file__).resolve().parent
-PLUGIN_DATA_NAME = "astrbot_plugin_qzone_ultra"
+PLUGIN_DATA_NAME_FALLBACK = "astrbot_plugin_qzone_ultra"
+LEGACY_MIGRATION_FILES = ("state.json", "drafts.json", "posts.json")
+LEGACY_MIGRATION_SENTINEL = ".legacy-qzone-migration.json"
+LEGACY_MIGRATION_LOCK = ".legacy-qzone-migration.lock"
 
 SENSITIVE_LOG_KEYS = {
     "cookie",
@@ -221,6 +226,127 @@ def _prepare_local_qzone_bridge_imports() -> None:
             sys.modules.pop(name, None)
 
 
+def _chmod_private(path: Path) -> None:
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def _chmod_private_dir(path: Path) -> None:
+    try:
+        os.chmod(path, 0o700)
+    except OSError:
+        pass
+
+
+def _path_contains(parent: Path, child: Path) -> bool:
+    try:
+        child.resolve(strict=False).relative_to(parent.resolve(strict=False))
+        return True
+    except Exception:
+        return False
+
+
+@contextmanager
+def _migration_lock(data_dir: Path) -> Iterator[None]:
+    data_dir.mkdir(parents=True, exist_ok=True)
+    _chmod_private_dir(data_dir)
+    lock_path = data_dir / LEGACY_MIGRATION_LOCK
+    with lock_path.open("a+b") as lock_file:
+        lock_file.seek(0)
+        if not lock_file.read(1):
+            lock_file.write(b"\0")
+            lock_file.flush()
+        lock_file.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+            try:
+                yield
+            finally:
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _read_plugin_name(plugin_root: Path) -> str:
+    metadata = plugin_root / "metadata.yaml"
+    try:
+        for line in metadata.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped.startswith("name:"):
+                continue
+            value = stripped.split(":", 1)[1].strip().strip("'\"")
+            if value:
+                return value
+    except Exception:
+        pass
+    return PLUGIN_DATA_NAME_FALLBACK
+
+
+def _star_tools_data_dir(plugin_name: str) -> Path | None:
+    try:
+        from astrbot.api.star import StarTools
+    except ImportError as exc:
+        logger.warning("qzone StarTools unavailable; using legacy data dir: %s", exc)
+        return None
+    try:
+        return Path(StarTools.get_data_dir(plugin_name))
+    except Exception as exc:
+        logger.warning("qzone StarTools data dir unavailable; using legacy data dir: %s", exc)
+        return None
+
+
+def _safe_copy_legacy_file(source: Path, target: Path, *, legacy_root: Path, data_dir: Path) -> str:
+    if source.is_symlink():
+        return "skipped_symlink"
+    if not source.is_file():
+        return "skipped_not_file"
+    if not _path_contains(legacy_root, source):
+        return "skipped_source_outside_legacy"
+    if not _path_contains(data_dir, target):
+        return "skipped_target_outside_data_dir"
+    if target.exists():
+        return "skipped_target_exists"
+    tmp = target.with_name(f"{target.name}.tmp.{int(time.time() * 1000)}.{random.randrange(1000000):06d}")
+    try:
+        shutil.copyfile(source, tmp)
+        _chmod_private(tmp)
+        tmp.replace(target)
+        _chmod_private(target)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except Exception:
+                pass
+    return "copied"
+
+
+def _write_json_private(path: Path, payload: dict[str, Any]) -> None:
+    tmp = path.with_name(f"{path.name}.tmp.{int(time.time() * 1000)}.{random.randrange(1000000):06d}")
+    try:
+        tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+        _chmod_private(tmp)
+        tmp.replace(path)
+        _chmod_private(path)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except Exception:
+                pass
+
+
 def _migrate_legacy_data_dir(legacy_dir: Path, data_dir: Path) -> None:
     try:
         legacy = legacy_dir.resolve()
@@ -232,26 +358,64 @@ def _migrate_legacy_data_dir(legacy_dir: Path, data_dir: Path) -> None:
         return
     try:
         data_dir.mkdir(parents=True, exist_ok=True)
+        _chmod_private_dir(data_dir)
     except Exception as exc:
         logger.warning("qzone standard data dir is not writable: %s", exc)
         return
-    for item in legacy_dir.iterdir():
-        if item.name in {"__pycache__", ".pytest_cache"}:
-            continue
-        target_item = data_dir / item.name
-        if target_item.exists():
-            continue
-        try:
-            if item.is_dir():
-                shutil.copytree(item, target_item)
-            elif item.is_file():
-                shutil.copy2(item, target_item)
-        except Exception as exc:
-            logger.warning("qzone legacy data migration skipped %s: %s", item.name, exc)
+    try:
+        with _migration_lock(data_dir):
+            sentinel = data_dir / LEGACY_MIGRATION_SENTINEL
+            if sentinel.exists():
+                try:
+                    marker = json.loads(sentinel.read_text(encoding="utf-8"))
+                    if isinstance(marker, dict) and marker.get("complete") is True:
+                        return
+                except Exception:
+                    pass
+            results: dict[str, str] = {}
+            for name in LEGACY_MIGRATION_FILES:
+                source = legacy_dir / name
+                if not source.exists():
+                    results[name] = "skipped_missing"
+                    continue
+                try:
+                    results[name] = _safe_copy_legacy_file(
+                        source,
+                        data_dir / name,
+                        legacy_root=legacy_dir,
+                        data_dir=data_dir,
+                    )
+                except Exception as exc:
+                    results[name] = f"failed_{type(exc).__name__}"
+                    logger.warning("qzone legacy data migration skipped %s: %s", name, exc)
+            payload = {
+                "complete": not any(status.startswith("failed_") for status in results.values()),
+                "completed_at": datetime.now().isoformat(timespec="seconds"),
+                "legacy_dir": str(legacy_dir),
+                "data_dir": str(data_dir),
+                "files": results,
+                "legacy_cleanup_recommended": True,
+            }
+            _write_json_private(sentinel, payload)
+            try:
+                (legacy_dir / ".migrated-to-astrbot-data").write_text(
+                    f"Copied supported Qzone data files to {data_dir} at {payload['completed_at']}.\n"
+                    "Review the standard data directory, then remove old sensitive files here if no rollback is needed.\n",
+                    encoding="utf-8",
+                )
+            except Exception:
+                pass
+            if any(status == "copied" for status in results.values()):
+                logger.warning("qzone legacy data copied to AstrBot data dir; review and remove old data/qzone when safe")
+    except Exception as exc:
+        logger.warning("qzone legacy data migration failed: %s", exc)
 
 
 def _standard_data_dir(plugin_root: Path) -> Path:
-    data_dir = Path(StarTools.get_data_dir(PLUGIN_DATA_NAME))
+    plugin_name = _read_plugin_name(plugin_root)
+    data_dir = _star_tools_data_dir(plugin_name)
+    if data_dir is None:
+        return plugin_root / "data" / "qzone"
     _migrate_legacy_data_dir(plugin_root / "data" / "qzone", data_dir)
     return data_dir
 

--- a/qzone_bridge/astrbot_logging.py
+++ b/qzone_bridge/astrbot_logging.py
@@ -5,14 +5,25 @@ from __future__ import annotations
 import os
 
 try:
-    from astrbot.api import logger
+    from astrbot.api import logger as _astrbot_logger
 
     USING_ASTRBOT_LOGGER = True
-except Exception:
+except ImportError:
     import logging
 
-    logger = logging.getLogger("qzone_bridge")
+    _astrbot_logger = None
     USING_ASTRBOT_LOGGER = False
+
+
+def get_logger(name: str = "qzone_bridge"):
+    if USING_ASTRBOT_LOGGER and _astrbot_logger is not None:
+        return _astrbot_logger
+    import logging
+
+    return logging.getLogger(name)
+
+
+logger = get_logger("qzone_bridge")
 
 
 def configure_standalone_logging(default_level: str = "INFO") -> None:

--- a/qzone_bridge/astrbot_logging.py
+++ b/qzone_bridge/astrbot_logging.py
@@ -1,0 +1,23 @@
+"""Logging adapter for AstrBot-hosted and standalone daemon execution."""
+
+from __future__ import annotations
+
+import os
+
+try:
+    from astrbot.api import logger
+
+    USING_ASTRBOT_LOGGER = True
+except Exception:
+    import logging
+
+    logger = logging.getLogger("qzone_bridge")
+    USING_ASTRBOT_LOGGER = False
+
+
+def configure_standalone_logging(default_level: str = "INFO") -> None:
+    if USING_ASTRBOT_LOGGER:
+        return
+    import logging
+
+    logging.basicConfig(level=os.getenv("QZONE_DAEMON_LOG_LEVEL", default_level))

--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -15,7 +15,7 @@ from urllib.parse import parse_qsl, unquote, urlencode, urljoin, urlparse, urlun
 import httpx
 
 from .errors import QzoneNeedsRebind, QzoneParseError, QzoneRequestError
-from .astrbot_logging import logger as log
+from .astrbot_logging import get_logger
 from .media import QZONE_MAX_IMAGES, is_supported_image, normalize_media_item, source_name
 from .models import FeedEntry, SessionState
 from .parser import (
@@ -31,6 +31,8 @@ from .parser import (
 )
 from .render import cookie_summary
 from .utils import extract_callback_json, json_loads, now_iso
+
+log = get_logger(__name__)
 
 AUTH_ERROR_CODES = {-3000}
 AUTH_ERROR_KEYWORDS = (

--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-import logging
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -16,6 +15,7 @@ from urllib.parse import parse_qsl, unquote, urlencode, urljoin, urlparse, urlun
 import httpx
 
 from .errors import QzoneNeedsRebind, QzoneParseError, QzoneRequestError
+from .astrbot_logging import logger as log
 from .media import QZONE_MAX_IMAGES, is_supported_image, normalize_media_item, source_name
 from .models import FeedEntry, SessionState
 from .parser import (
@@ -31,8 +31,6 @@ from .parser import (
 )
 from .render import cookie_summary
 from .utils import extract_callback_json, json_loads, now_iso
-
-log = logging.getLogger(__name__)
 
 AUTH_ERROR_CODES = {-3000}
 AUTH_ERROR_KEYWORDS = (

--- a/qzone_bridge/controller.py
+++ b/qzone_bridge/controller.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import logging
 import os
 import signal
 import socket
@@ -16,6 +15,7 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import httpx
 
+from .astrbot_logging import logger as log
 from .errors import DaemonUnavailableError, QzoneNeedsRebind, QzoneParseError, QzoneRequestError
 from .media import sanitize_publish_content
 from .models import SessionState
@@ -24,8 +24,6 @@ from .protocol import SECRET_HEADER
 from .storage import StateStore, ensure_state_secret
 from .utils import now_iso
 
-
-log = logging.getLogger(__name__)
 SENSITIVE_DETAIL_KEYS = {"cookie", "cookies", "p_skey", "skey", "pt4_token", "pt_key", "qzonetoken", "secret", "token"}
 SENSITIVE_URL_QUERY_KEYS = {"g_tk", "gtk", "p_skey", "skey", "pt4_token", "pt_key", "qzonetoken", "token", "secret"}
 
@@ -38,6 +36,10 @@ def _port_is_free(port: int) -> bool:
         except OSError:
             return False
     return True
+
+
+async def _port_is_free_async(port: int) -> bool:
+    return await asyncio.to_thread(_port_is_free, port)
 
 
 def _run_quiet(args: list[str], *, timeout: float = 5.0) -> subprocess.CompletedProcess:
@@ -401,12 +403,12 @@ class QzoneDaemonController:
             if await self._probe_health(port):
                 return self._status_from_state(self.store.read(), daemon_state="ready")
 
-            if not _port_is_free(port):
+            if not await _port_is_free_async(port):
                 candidate = port
                 found_port = 0
                 for _ in range(32):
                     candidate += 1
-                    if _port_is_free(candidate):
+                    if await _port_is_free_async(candidate):
                         found_port = candidate
                         break
                 if not found_port:
@@ -770,10 +772,10 @@ class QzoneDaemonController:
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
         while loop.time() < deadline:
-            if _port_is_free(port):
+            if await _port_is_free_async(port):
                 return True
             await asyncio.sleep(0.2)
-        return _port_is_free(port)
+        return await _port_is_free_async(port)
 
     async def _terminate_tracked_process(self) -> None:
         process = self._process

--- a/qzone_bridge/controller.py
+++ b/qzone_bridge/controller.py
@@ -15,7 +15,7 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import httpx
 
-from .astrbot_logging import logger as log
+from .astrbot_logging import get_logger
 from .errors import DaemonUnavailableError, QzoneNeedsRebind, QzoneParseError, QzoneRequestError
 from .media import sanitize_publish_content
 from .models import SessionState
@@ -24,6 +24,7 @@ from .protocol import SECRET_HEADER
 from .storage import StateStore, ensure_state_secret
 from .utils import now_iso
 
+log = get_logger(__name__)
 SENSITIVE_DETAIL_KEYS = {"cookie", "cookies", "p_skey", "skey", "pt4_token", "pt_key", "qzonetoken", "secret", "token"}
 SENSITIVE_URL_QUERY_KEYS = {"g_tk", "gtk", "p_skey", "skey", "pt4_token", "pt_key", "qzonetoken", "token", "secret"}
 
@@ -396,30 +397,25 @@ class QzoneDaemonController:
             "session_revision": state.session.revision,
         }
 
+    async def _available_daemon_port(self, port: int) -> int:
+        if await _port_is_free_async(port):
+            return port
+        candidate = port
+        for _ in range(32):
+            candidate += 1
+            if await _port_is_free_async(candidate):
+                return candidate
+        raise DaemonUnavailableError(
+            "QQ 空间 daemon 端口被占用，未找到可用备用端口",
+            detail={"daemon_port": port, "checked_ports": f"{port + 1}-{port + 32}"},
+        )
+
     async def ensure_running(self) -> dict[str, Any]:
         async with self._lock:
             runtime = self._runtime()
             port = runtime.daemon_port or self.default_port
             if await self._probe_health(port):
                 return self._status_from_state(self.store.read(), daemon_state="ready")
-
-            if not await _port_is_free_async(port):
-                candidate = port
-                found_port = 0
-                for _ in range(32):
-                    candidate += 1
-                    if await _port_is_free_async(candidate):
-                        found_port = candidate
-                        break
-                if not found_port:
-                    exc = DaemonUnavailableError(
-                        "QQ 空间 daemon 端口被占用，未找到可用备用端口",
-                        detail={"daemon_port": port, "checked_ports": f"{port + 1}-{port + 32}"},
-                    )
-                    self._record_daemon_start_error(exc, port=port)
-                    raise exc
-                port = found_port
-                self.store.update(lambda state: setattr(state.runtime, "daemon_port", port))
 
             if not self._daemon_script().exists():
                 exc = DaemonUnavailableError(
@@ -429,44 +425,69 @@ class QzoneDaemonController:
                 self._record_daemon_start_error(exc, port=port)
                 raise exc
 
-            try:
-                self._process = self._spawn_daemon(port)
-            except OSError as exc:
-                error = DaemonUnavailableError(
-                    "QQ 空间 daemon 启动失败",
-                    detail=self._daemon_start_detail(port, error=str(exc)),
-                )
-                self._record_daemon_start_error(error, port=port)
-                raise error from exc
+            attempts: list[dict[str, Any]] = []
+            last_exc: Exception | None = None
+            for attempt in range(3):
+                try:
+                    port = await self._available_daemon_port(port)
+                except DaemonUnavailableError as exc:
+                    self._record_daemon_start_error(exc, port=port)
+                    raise
 
-            deadline = asyncio.get_running_loop().time() + self.start_timeout
-            while asyncio.get_running_loop().time() < deadline:
-                if await self._probe_health(port):
-                    runtime.daemon_port = port
-                    runtime.daemon_pid = self._process.pid if self._process else 0
-                    runtime.started_at = now_iso()
-                    runtime.last_seen_at = now_iso()
-                    def update(state):
-                        state.runtime = runtime
-                        if isinstance(state.session.last_error, dict) and state.session.last_error.get("type") == "DaemonUnavailableError":
-                            state.session.last_error = None
+                if port != runtime.daemon_port:
+                    self.store.update(lambda state: setattr(state.runtime, "daemon_port", port))
 
-                    state = self.store.update(update)
-                    self._health_cache = (
-                        port,
-                        runtime.secret,
-                        True,
-                        asyncio.get_running_loop().time() + self._health_cache_ttl,
+                try:
+                    self._process = self._spawn_daemon(port)
+                except OSError as exc:
+                    last_exc = exc
+                    attempts.append(self._daemon_start_detail(port, error=str(exc)))
+                    if attempt < 2:
+                        port += 1
+                        continue
+                    error = DaemonUnavailableError(
+                        "QQ 空间 daemon 启动失败",
+                        detail={"attempts": attempts},
                     )
-                    return self._status_from_state(state, daemon_state="ready")
-                if self._process and self._process.poll() is not None:
-                    break
-                await asyncio.sleep(0.5)
+                    self._record_daemon_start_error(error, port=port)
+                    raise error from exc
 
-            returncode = self._process.poll() if self._process else None
+                deadline = asyncio.get_running_loop().time() + self.start_timeout
+                while asyncio.get_running_loop().time() < deadline:
+                    if await self._probe_health(port):
+                        runtime.daemon_port = port
+                        runtime.daemon_pid = self._process.pid if self._process else 0
+                        runtime.started_at = now_iso()
+                        runtime.last_seen_at = now_iso()
+
+                        def update(state):
+                            state.runtime = runtime
+                            if isinstance(state.session.last_error, dict) and state.session.last_error.get("type") == "DaemonUnavailableError":
+                                state.session.last_error = None
+
+                        state = self.store.update(update)
+                        self._health_cache = (
+                            port,
+                            runtime.secret,
+                            True,
+                            asyncio.get_running_loop().time() + self._health_cache_ttl,
+                        )
+                        return self._status_from_state(state, daemon_state="ready")
+                    if self._process and self._process.poll() is not None:
+                        break
+                    await asyncio.sleep(0.5)
+
+                returncode = self._process.poll() if self._process else None
+                attempts.append(self._daemon_start_detail(port, returncode=returncode))
+                if returncode is not None and attempt < 2:
+                    self._invalidate_health_cache()
+                    port += 1
+                    continue
+                break
+
             error = DaemonUnavailableError(
                 "QQ 空间 daemon 启动超时",
-                detail=self._daemon_start_detail(port, returncode=returncode),
+                detail={"attempts": attempts, "error": str(last_exc) if last_exc else ""},
             )
             self._record_daemon_start_error(error, port=port)
             raise error
@@ -825,6 +846,10 @@ class QzoneDaemonController:
         self.store.update(update)
 
     async def stop_daemon(self) -> None:
+        async with self._lock:
+            await self._stop_daemon_locked()
+
+    async def _stop_daemon_locked(self) -> None:
         state = self.store.read()
         runtime = state.runtime
         port = int(runtime.daemon_port or self.default_port or 0)

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import logging
 import os
 from dataclasses import asdict
 from pathlib import Path
@@ -13,6 +12,7 @@ from datetime import datetime, timezone
 
 from aiohttp import web
 
+from .astrbot_logging import configure_standalone_logging, logger as log
 from .client import QzoneClient
 from .errors import QzoneAuthError, QzoneBridgeError, QzoneNeedsRebind, QzoneParseError, QzoneRequestError
 from .media import (
@@ -37,8 +37,6 @@ from .selection import NUMERIC_FID_MIN_LENGTH
 from .social import extract_comments
 from .storage import StateStore, ensure_state_secret
 from .utils import now_iso, from_iso
-
-log = logging.getLogger(__name__)
 LIKE_VERIFY_RETRY_DELAYS_SECONDS = (0.35, 0.85, 1.6)
 TRUE_TEXT_VALUES = {"1", "true", "yes", "y", "on"}
 FALSE_TEXT_VALUES = {"0", "false", "no", "n", "off", ""}
@@ -1119,7 +1117,7 @@ def main() -> None:
     parser.add_argument("--version", default="0.1.0")
     args = parser.parse_args()
 
-    logging.basicConfig(level=os.getenv("QZONE_DAEMON_LOG_LEVEL", "INFO"))
+    configure_standalone_logging()
     asyncio.run(
         run_daemon(
             data_dir=Path(args.data_dir),

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 
 from aiohttp import web
 
-from .astrbot_logging import configure_standalone_logging, logger as log
+from .astrbot_logging import configure_standalone_logging, get_logger
 from .client import QzoneClient
 from .errors import QzoneAuthError, QzoneBridgeError, QzoneNeedsRebind, QzoneParseError, QzoneRequestError
 from .media import (
@@ -37,6 +37,8 @@ from .selection import NUMERIC_FID_MIN_LENGTH
 from .social import extract_comments
 from .storage import StateStore, ensure_state_secret
 from .utils import now_iso, from_iso
+
+log = get_logger(__name__)
 LIKE_VERIFY_RETRY_DELAYS_SECONDS = (0.35, 0.85, 1.6)
 TRUE_TEXT_VALUES = {"1", "true", "yes", "y", "on"}
 FALSE_TEXT_VALUES = {"0", "false", "no", "n", "off", ""}

--- a/qzone_bridge/post_service.py
+++ b/qzone_bridge/post_service.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from dataclasses import asdict
 from typing import Any
 
-from .astrbot_logging import logger as log
+from .astrbot_logging import get_logger
 from .errors import QzoneParseError
 from .models import FeedEntry
 from .posts import PostStore
 from .selection import PostSelection
 from .social import QzoneComment, QzonePost, post_from_entry
+
+log = get_logger(__name__)
 
 
 class QzonePostService:

--- a/qzone_bridge/post_service.py
+++ b/qzone_bridge/post_service.py
@@ -2,17 +2,15 @@
 
 from __future__ import annotations
 
-import logging
 from dataclasses import asdict
 from typing import Any
 
+from .astrbot_logging import logger as log
 from .errors import QzoneParseError
 from .models import FeedEntry
 from .posts import PostStore
 from .selection import PostSelection
 from .social import QzoneComment, QzonePost, post_from_entry
-
-log = logging.getLogger(__name__)
 
 
 class QzonePostService:


### PR DESCRIPTION
## Summary
- Use `StarTools.get_data_dir()` as the primary plugin data directory, with a safe legacy fallback for older/broken AstrBot runtimes.
- Migrate only whitelisted legacy Qzone data files (`state.json`, `drafts.json`, `posts.json`) under a cross-process lock, write a completion sentinel, avoid symlink/directory copying, and set private file permissions best-effort.
- Replace direct `logging` usage in Qzone bridge files with an AstrBot logger adapter that preserves standalone daemon fallback and module-level logger names.
- Move controller port availability probes out of the event loop, retry daemon startup on port bind races, and serialize daemon start/stop through the same lifecycle lock.

## Validation
- `python -m compileall -q main.py daemon_main.py qzone_bridge`
- `python -m json.tool _conf_schema.json > $null`
- `python daemon_main.py --help`
- Standalone daemon smoke: `/health` then `/shutdown`
- Data migration smoke with temporary legacy/target dirs, StarTools data dir, whitelist copy, sentinel, and legacy fallback
- Port fallback smoke with the preferred port occupied, `ensure_running()` selecting a backup port, then clean shutdown
- Scanned target files for `import logging`, `logging.`, and `getLogger(`
- Confirmed PR diff contains no `tests/` or `data/`