### PR TITLE
[codex] Expose safe public Qzone daemon health

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ pip install -r requirements.txt
 
 插件会在首次使用时按需启动本地 daemon。daemon 默认使用 `18999` 端口并只监听 `127.0.0.1`，用于隔离 QQ 空间请求、Cookie 管理和渲染逻辑。除非端口被占用，不建议修改默认端口；如果系统防火墙或安全软件拦截本地连接，请放行本插件的 `18999` 端口。
 
+浏览器打开 `http://127.0.0.1:18999/` 或 `/health` 时只返回最小公开健康信息，用于确认端口可达；完整 daemon 状态和登录信息仍必须通过插件命令或携带 `X-Qzone-Secret` 的本地请求获取。
+
 ## Cookie 绑定
 
 推荐在 OneBot v11 / aiocqhttp 环境使用自动绑定：
@@ -142,6 +144,7 @@ pip install -r requirements.txt
 
 - `/qzone status` 显示未绑定：先执行 `/qzone autobind`，失败后使用 `/qzone bind <cookie>`。
 - daemon 无法启动：确认默认 `18999` 端口没有被占用，防火墙或安全软件已放行本地连接，并检查 AstrBot 日志。
+- 浏览器访问 `127.0.0.1:18999`：看到 `ok: true` 代表本地 daemon 端口可达；如果需要 Cookie、QQ 号或完整状态，请使用 `/qzone status`。
 - 自动绑定失败：确认 AstrBot 使用的是 OneBot v11 / aiocqhttp，且适配器允许获取 Cookie。
 - 图片发布失败：确认图片可被 AstrBot 正常读取，远程图片地址可访问。
 - LLM 生成内容为空：检查 AstrBot 当前会话 provider，或分别配置 `llm.post_provider_id`、`llm.comment_provider_id`、`llm.reply_provider_id`。

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install -r requirements.txt
 
 插件会在首次使用时按需启动本地 daemon。daemon 默认使用 `18999` 端口并只监听 `127.0.0.1`，用于隔离 QQ 空间请求、Cookie 管理和渲染逻辑。除非端口被占用，不建议修改默认端口；如果系统防火墙或安全软件拦截本地连接，请放行本插件的 `18999` 端口。
 
-浏览器打开 `http://127.0.0.1:18999/` 或 `/health` 时只返回最小公开健康信息，用于确认端口可达；完整 daemon 状态和登录信息仍必须通过插件命令或携带 `X-Qzone-Secret` 的本地请求获取。
+浏览器打开 `http://127.0.0.1:18999/` 或 `/health` 时只返回最小公开健康信息，用于确认端口可达。未认证公开响应只包含 `daemon_state`、`daemon_port`、`daemon_version`，其中 `daemon_state` 只表示进程生命周期，不包含登录、绑定、Cookie、QQ 号、时间戳、token、缓存或 revision 等状态；完整 daemon 状态和登录信息仍必须通过插件命令或携带 `X-Qzone-Secret` 的本地请求获取。
 
 ## Cookie 绑定
 
@@ -144,7 +144,7 @@ pip install -r requirements.txt
 
 - `/qzone status` 显示未绑定：先执行 `/qzone autobind`，失败后使用 `/qzone bind <cookie>`。
 - daemon 无法启动：确认默认 `18999` 端口没有被占用，防火墙或安全软件已放行本地连接，并检查 AstrBot 日志。
-- 浏览器访问 `127.0.0.1:18999`：看到 `ok: true` 代表本地 daemon 端口可达；如果需要 Cookie、QQ 号或完整状态，请使用 `/qzone status`。
+- 浏览器访问 `127.0.0.1:18999`：看到 `ok: true` 代表本地 daemon 端口可达；空或错误的 `X-Qzone-Secret` 仍会返回 401。如果需要 Cookie、QQ 号或完整状态，请使用 `/qzone status`。
 - 自动绑定失败：确认 AstrBot 使用的是 OneBot v11 / aiocqhttp，且适配器允许获取 Cookie。
 - 图片发布失败：确认图片可被 AstrBot 正常读取，远程图片地址可访问。
 - LLM 生成内容为空：检查 AstrBot 当前会话 provider，或分别配置 `llm.post_provider_id`、`llm.comment_provider_id`、`llm.reply_provider_id`。

--- a/qzone_bridge/controller.py
+++ b/qzone_bridge/controller.py
@@ -378,6 +378,7 @@ class QzoneDaemonController:
 
     def _status_from_state(self, state, *, daemon_state: str) -> dict[str, Any]:
         runtime = state.runtime
+        needs_rebind = self._session_needs_rebind(state.session)
         return {
             "daemon_state": daemon_state,
             "daemon_pid": runtime.daemon_pid,
@@ -389,13 +390,17 @@ class QzoneDaemonController:
             "session_source": state.session.source,
             "cookie_summary": self.cookie_summary(state.session.cookies),
             "cookie_count": len(state.session.cookies),
-            "needs_rebind": state.session.needs_rebind or not bool(state.session.cookies),
+            "needs_rebind": needs_rebind,
             "last_ok_at": state.session.last_ok_at,
             "last_error": state.session.last_error,
             "qzonetoken_hosts": sorted(int(k) for k in state.session.qzonetokens.keys() if str(k).isdigit()),
             "feed_cache_size": 0,
             "session_revision": state.session.revision,
         }
+
+    @staticmethod
+    def _session_needs_rebind(session) -> bool:
+        return bool(session.needs_rebind or not (session.cookies and session.uin))
 
     async def _available_daemon_port(self, port: int) -> int:
         if await _port_is_free_async(port):
@@ -559,10 +564,11 @@ class QzoneDaemonController:
     async def get_status(self, *, probe_daemon: bool = True) -> dict[str, Any]:
         state = self.store.read()
         runtime = state.runtime
+        needs_rebind = self._session_needs_rebind(state.session)
         daemon_state = "offline"
         if probe_daemon and runtime.daemon_port and await self._probe_health(runtime.daemon_port):
-            daemon_state = "ready"
-        elif state.session.cookies:
+            daemon_state = "needs_rebind" if needs_rebind else "ready"
+        elif state.session.cookies and state.session.uin:
             daemon_state = "degraded"
         return self._status_from_state(state, daemon_state=daemon_state)
 

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -916,6 +916,7 @@ def _error_detail(exc: QzoneBridgeError):
 SERVICE_APP_KEY = web.AppKey("qzone_service", QzoneDaemonService)
 SHUTDOWN_EVENT_APP_KEY = web.AppKey("qzone_shutdown_event", asyncio.Event)
 AUTHENTICATED_REQUEST_APP_KEY = web.AppKey("qzone_authenticated_request", bool)
+PUBLIC_HEALTH_PATHS = {"/", "/health"}
 
 
 def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None = None) -> web.Application:
@@ -929,7 +930,7 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
         secret = request.headers.get(SECRET_HEADER) or ""
         authenticated = bool(secret and secret == service.state.runtime.secret)
         request[AUTHENTICATED_REQUEST_APP_KEY] = authenticated
-        if request.method == "GET" and request.path == "/health" and not secret:
+        if request.method == "GET" and request.path in PUBLIC_HEALTH_PATHS and not secret:
             return await handler(request)
         if not authenticated:
             return fail("UNAUTHORIZED", "secret 不正确", status=401)
@@ -1080,6 +1081,7 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
             asyncio.get_running_loop().call_later(0.1, event.set)
         return ok({"stopping": True})
 
+    app.router.add_get("/", health)
     app.router.add_get("/health", health)
     app.router.add_get("/status", status)
     app.router.add_post("/bind", bind)

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -150,6 +150,11 @@ class QzoneDaemonService:
     def _session_needs_rebind(self) -> bool:
         return bool(self.state.session.needs_rebind or self._session_missing_credentials())
 
+    def _public_daemon_state(self) -> str:
+        if self._closing or self.health_state == "stopping":
+            return "stopping"
+        return "online"
+
     def _ensure_session_ready(self) -> None:
         if self._session_needs_rebind():
             raise QzoneNeedsRebind()
@@ -190,7 +195,7 @@ class QzoneDaemonService:
             self.client.feed_cache.clear()
             self.recent_feed_entries.clear()
         elif isinstance(exc, QzoneRequestError) and exc.status_code is not None and 400 <= exc.status_code < 500:
-            if self.state.session.cookies and not self.state.session.needs_rebind:
+            if not self._session_needs_rebind():
                 self.health_state = "ready"
             else:
                 self.health_state = "needs_rebind"
@@ -213,7 +218,7 @@ class QzoneDaemonService:
     def public_snapshot(self) -> dict[str, Any]:
         runtime = self.state.runtime
         return {
-            "daemon_state": self.health_state,
+            "daemon_state": self._public_daemon_state(),
             "daemon_port": runtime.daemon_port,
             "daemon_version": runtime.version,
         }
@@ -253,6 +258,7 @@ class QzoneDaemonService:
 
     async def close(self) -> None:
         self._closing = True
+        self.health_state = "stopping"
         if self._warmup_task:
             self._warmup_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -1079,6 +1085,7 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
         )
 
     async def shutdown(request: web.Request) -> web.Response:
+        service.health_state = "stopping"
         service.touch()
         service.save()
         event = request.app.get(SHUTDOWN_EVENT_APP_KEY)

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -42,6 +42,9 @@ log = get_logger(__name__)
 LIKE_VERIFY_RETRY_DELAYS_SECONDS = (0.35, 0.85, 1.6)
 TRUE_TEXT_VALUES = {"1", "true", "yes", "y", "on"}
 FALSE_TEXT_VALUES = {"0", "false", "no", "n", "off", ""}
+PUBLIC_HEALTH_METHODS = {"GET", "HEAD"}
+PUBLIC_HEALTH_PATHS = {"/", "/health"}
+AUTHENTICATED_REQUEST_KEY = "qzone_authenticated_request"
 LATEST_FEED_REFERENCES = {
     "latest",
     "newest",
@@ -140,8 +143,15 @@ class QzoneDaemonService:
     def touch(self) -> None:
         self.state.runtime.last_seen_at = now_iso()
 
+    def _session_missing_credentials(self) -> bool:
+        session = self.state.session
+        return not bool(session.cookies and session.uin)
+
+    def _session_needs_rebind(self) -> bool:
+        return bool(self.state.session.needs_rebind or self._session_missing_credentials())
+
     def _ensure_session_ready(self) -> None:
-        if self.state.session.needs_rebind or not self.state.session.cookies or not self.state.session.uin:
+        if self._session_needs_rebind():
             raise QzoneNeedsRebind()
 
     def _schedule_save(self) -> None:
@@ -161,10 +171,11 @@ class QzoneDaemonService:
         self._save_task = asyncio.create_task(runner())
 
     def _set_success(self, *, defer_save: bool = False) -> None:
-        self.health_state = "ready" if self.state.session.cookies else "needs_rebind"
+        missing_credentials = self._session_missing_credentials()
+        self.health_state = "needs_rebind" if missing_credentials else "ready"
         self.state.session.last_ok_at = now_iso()
         self.state.session.last_error = None
-        self.state.session.needs_rebind = not bool(self.state.session.cookies)
+        self.state.session.needs_rebind = missing_credentials
         self.touch()
         if defer_save:
             self._schedule_save()
@@ -201,17 +212,10 @@ class QzoneDaemonService:
 
     def public_snapshot(self) -> dict[str, Any]:
         runtime = self.state.runtime
-        session = self.state.session
-        needs_rebind = session.needs_rebind or not bool(session.cookies)
         return {
             "daemon_state": self.health_state,
             "daemon_port": runtime.daemon_port,
             "daemon_version": runtime.version,
-            "started_at": runtime.started_at,
-            "last_seen_at": runtime.last_seen_at,
-            "uptime_seconds": self._uptime_seconds(),
-            "login_bound": bool(session.uin and session.cookies and not needs_rebind),
-            "needs_rebind": needs_rebind,
         }
 
     def snapshot(self) -> dict[str, Any]:
@@ -229,7 +233,7 @@ class QzoneDaemonService:
             "session_source": session.source,
             "cookie_summary": self.client.cookie_summary(),
             "cookie_count": self.client.cookie_count,
-            "needs_rebind": session.needs_rebind or not bool(session.cookies),
+            "needs_rebind": self._session_needs_rebind(),
             "last_ok_at": session.last_ok_at,
             "last_error": session.last_error,
             "qzonetoken_hosts": sorted(int(k) for k in session.qzonetokens.keys() if str(k).isdigit()),
@@ -855,7 +859,7 @@ class QzoneDaemonService:
         return result
 
     async def health(self) -> dict[str, Any]:
-        if self.state.session.needs_rebind or not self.state.session.cookies or not self.state.session.uin:
+        if self._session_needs_rebind():
             if self.health_state != "needs_rebind":
                 self.health_state = "needs_rebind"
                 self.save()
@@ -873,12 +877,7 @@ class QzoneDaemonService:
             await asyncio.sleep(self.keepalive_interval)
             if self._closing:
                 break
-            if self.state.session.needs_rebind:
-                if self.health_state != "needs_rebind":
-                    self.health_state = "needs_rebind"
-                    self.save()
-                continue
-            if not self.state.session.cookies or not self.state.session.uin:
+            if self._session_needs_rebind():
                 if self.health_state != "needs_rebind":
                     self.health_state = "needs_rebind"
                     self.save()
@@ -915,8 +914,6 @@ def _error_detail(exc: QzoneBridgeError):
 
 SERVICE_APP_KEY = web.AppKey("qzone_service", QzoneDaemonService)
 SHUTDOWN_EVENT_APP_KEY = web.AppKey("qzone_shutdown_event", asyncio.Event)
-AUTHENTICATED_REQUEST_APP_KEY = web.AppKey("qzone_authenticated_request", bool)
-PUBLIC_HEALTH_PATHS = {"/", "/health"}
 
 
 def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None = None) -> web.Application:
@@ -927,10 +924,14 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
 
     @web.middleware
     async def auth_middleware(request: web.Request, handler):
-        secret = request.headers.get(SECRET_HEADER) or ""
-        authenticated = bool(secret and secret == service.state.runtime.secret)
-        request[AUTHENTICATED_REQUEST_APP_KEY] = authenticated
-        if request.method == "GET" and request.path in PUBLIC_HEALTH_PATHS and not secret:
+        supplied_secret = request.headers.get(SECRET_HEADER)
+        authenticated = bool(supplied_secret and supplied_secret == service.state.runtime.secret)
+        request[AUTHENTICATED_REQUEST_KEY] = authenticated
+        if (
+            supplied_secret is None
+            and request.method in PUBLIC_HEALTH_METHODS
+            and request.path in PUBLIC_HEALTH_PATHS
+        ):
             return await handler(request)
         if not authenticated:
             return fail("UNAUTHORIZED", "secret 不正确", status=401)
@@ -939,12 +940,16 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
     app.middlewares.append(auth_middleware)
 
     async def health(request: web.Request) -> web.Response:
-        service.touch()
-        if request.get(AUTHENTICATED_REQUEST_APP_KEY, False):
+        if request.get(AUTHENTICATED_REQUEST_KEY, False):
+            service.touch()
             return ok(service.snapshot())
         return ok(
             service.public_snapshot(),
-            meta={"authenticated": False, "full_status_requires": SECRET_HEADER},
+            meta={
+                "authenticated": False,
+                "public": True,
+                "full_status_requires": SECRET_HEADER,
+            },
         )
 
     async def status(request: web.Request) -> web.Response:

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -192,13 +192,31 @@ class QzoneDaemonService:
         self.touch()
         self.save()
 
+    def _uptime_seconds(self) -> int:
+        runtime = self.state.runtime
+        started_at = from_iso(runtime.started_at)
+        if started_at:
+            return int((datetime.now(timezone.utc) - started_at).total_seconds())
+        return 0
+
+    def public_snapshot(self) -> dict[str, Any]:
+        runtime = self.state.runtime
+        session = self.state.session
+        needs_rebind = session.needs_rebind or not bool(session.cookies)
+        return {
+            "daemon_state": self.health_state,
+            "daemon_port": runtime.daemon_port,
+            "daemon_version": runtime.version,
+            "started_at": runtime.started_at,
+            "last_seen_at": runtime.last_seen_at,
+            "uptime_seconds": self._uptime_seconds(),
+            "login_bound": bool(session.uin and session.cookies and not needs_rebind),
+            "needs_rebind": needs_rebind,
+        }
+
     def snapshot(self) -> dict[str, Any]:
         runtime = self.state.runtime
         session = self.state.session
-        started_at = from_iso(runtime.started_at)
-        uptime = 0
-        if started_at:
-            uptime = int((datetime.now(timezone.utc) - started_at).total_seconds())
         return {
             "daemon_state": self.health_state,
             "daemon_pid": runtime.daemon_pid,
@@ -206,7 +224,7 @@ class QzoneDaemonService:
             "daemon_version": runtime.version,
             "started_at": runtime.started_at,
             "last_seen_at": runtime.last_seen_at,
-            "uptime_seconds": uptime,
+            "uptime_seconds": self._uptime_seconds(),
             "login_uin": session.uin,
             "session_source": session.source,
             "cookie_summary": self.client.cookie_summary(),
@@ -897,6 +915,7 @@ def _error_detail(exc: QzoneBridgeError):
 
 SERVICE_APP_KEY = web.AppKey("qzone_service", QzoneDaemonService)
 SHUTDOWN_EVENT_APP_KEY = web.AppKey("qzone_shutdown_event", asyncio.Event)
+AUTHENTICATED_REQUEST_APP_KEY = web.AppKey("qzone_authenticated_request", bool)
 
 
 def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None = None) -> web.Application:
@@ -908,7 +927,11 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
     @web.middleware
     async def auth_middleware(request: web.Request, handler):
         secret = request.headers.get(SECRET_HEADER) or ""
-        if secret != service.state.runtime.secret:
+        authenticated = bool(secret and secret == service.state.runtime.secret)
+        request[AUTHENTICATED_REQUEST_APP_KEY] = authenticated
+        if request.method == "GET" and request.path == "/health" and not secret:
+            return await handler(request)
+        if not authenticated:
             return fail("UNAUTHORIZED", "secret 不正确", status=401)
         return await handler(request)
 
@@ -916,7 +939,12 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
 
     async def health(request: web.Request) -> web.Response:
         service.touch()
-        return ok(service.snapshot())
+        if request.get(AUTHENTICATED_REQUEST_APP_KEY, False):
+            return ok(service.snapshot())
+        return ok(
+            service.public_snapshot(),
+            meta={"authenticated": False, "full_status_requires": SECRET_HEADER},
+        )
 
     async def status(request: web.Request) -> web.Response:
         service.touch()


### PR DESCRIPTION
## Summary
- Allow unauthenticated `GET`/`HEAD /` and `/health` to return a minimal public daemon health payload, so opening `127.0.0.1:18999` in a browser no longer shows `UNAUTHORIZED` when the daemon is healthy.
- Keep full daemon state behind `X-Qzone-Secret`; authenticated `/health` and `/status` still return the existing complete snapshot.
- Harden the auth boundary: wrong or empty `X-Qzone-Secret` stays 401, public payload does not expose login/bind readiness, timestamps, cookie summaries, qzonetokens, QQ account fields, cache state, or revision state.
- Map public `daemon_state` to process lifecycle only (`online` / `stopping`) instead of internal `ready` / `needs_rebind` / `degraded` states.
- Unify daemon/controller session rebind checks so missing `uin` is treated consistently, and document the public health contract in README.

## Review follow-up
- Security: narrowed public health to daemon liveness only and preserved 401 for invalid secrets.
- Code quality/maintainability: replaced request `AppKey` state with a string request key, centralized session rebind logic, and made public/full status boundaries explicit.
- Bug/test stability: added HEAD support and covered GET/HEAD, empty secret, wrong secret, public `/status`, authenticated status, and controller missing-uin semantics in smoke validation.
- Race conditions: public health no longer mutates `last_seen_at` or writes state; shutdown now marks the service as `stopping` before cleanup.
- AstrBot norms checked locally: metadata, config schema types, StarTools data path use, async HTTP dependencies, and no committed `tests/` or `data/` paths.

## Validation
- `python -m compileall -q main.py daemon_main.py qzone_bridge`
- `python -m json.tool _conf_schema.json > $null`
- `git diff --check`
- Temporary daemon smoke: public `GET`/`HEAD /` and `/health` return `ok: true`; public payload exact keys are `daemon_state`, `daemon_port`, `daemon_version`; public `daemon_state` is `online`; empty/wrong secret returns 401; `/status` without secret returns 401; authenticated `/health` returns full internal `needs_rebind` state; authenticated `/shutdown` succeeds.
- Controller smoke: a state with cookies but missing `uin` returns `needs_rebind: true` instead of being treated as ready/degraded.
- Confirmed committed tree contains no `tests/` or `data/` paths.