### PR TITLE
[codex] Harden AstrBot compatibility and async stores

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import asyncio
 import os
 import inspect
-import importlib
 import json
 import random
 import re
 import shutil
-import sys
 import time
 from contextlib import contextmanager
 from datetime import datetime
@@ -209,23 +207,6 @@ def _public_error_reason(message: Any) -> str:
     return truncate(text, 80)
 
 
-def _prepare_local_qzone_bridge_imports() -> None:
-    """Force bundled qzone_bridge modules to reload from this plugin directory."""
-
-    def _same_path(value: str) -> bool:
-        try:
-            return Path(value).resolve() == PLUGIN_ROOT
-        except Exception:
-            return False
-
-    sys.path[:] = [path for path in sys.path if not _same_path(path)]
-    sys.path.insert(0, str(PLUGIN_ROOT))
-    importlib.invalidate_caches()
-    for name in list(sys.modules):
-        if name == "qzone_bridge" or name.startswith("qzone_bridge."):
-            sys.modules.pop(name, None)
-
-
 def _chmod_private(path: Path) -> None:
     try:
         os.chmod(path, 0o600)
@@ -420,7 +401,18 @@ def _standard_data_dir(plugin_root: Path) -> Path:
     return data_dir
 
 
-_prepare_local_qzone_bridge_imports()
+def _verify_local_qzone_bridge_package(package_file: str | None) -> None:
+    if not package_file:
+        raise RuntimeError("qzone_bridge package file is unavailable")
+    package_path = Path(package_file).resolve(strict=False)
+    expected_root = PLUGIN_ROOT / "qzone_bridge"
+    if not _path_contains(expected_root, package_path):
+        raise RuntimeError(f"qzone_bridge resolved outside plugin directory: {package_path}")
+
+
+import qzone_bridge as _qzone_bridge_package
+
+_verify_local_qzone_bridge_package(getattr(_qzone_bridge_package, "__file__", None))
 
 from qzone_bridge.controller import QzoneDaemonController
 from qzone_bridge.drafts import DraftPost, DraftStore
@@ -1526,8 +1518,8 @@ class QzoneStablePlugin(Star):
             command_prefixes=prefixes,
         )
 
-    def _create_draft(self, event: AstrMessageEvent, post: PostPayload, *, anonymous: bool = False) -> DraftPost:
-        return self.drafts.add(
+    async def _create_draft(self, event: AstrMessageEvent, post: PostPayload, *, anonymous: bool = False) -> DraftPost:
+        return await self.drafts.add_async(
             author_uin=self._sender_id(event),
             author_name=self._sender_name(event),
             group_id=self._group_id(event),
@@ -1815,7 +1807,7 @@ class QzoneStablePlugin(Star):
                 commented_keys.add(key)
                 self._save_auto_comment_keys(commented_keys)
                 continue
-            self._post_store().upsert(post)
+            await self._post_store().upsert_async(post)
             text = await self._generate_comment_text(None, post)  # type: ignore[arg-type]
             if not text.strip():
                 continue
@@ -1973,7 +1965,7 @@ class QzoneStablePlugin(Star):
         pass
 
     @filter.on_platform_loaded()
-    async def qzone_on_platform_loaded(self):
+    async def qzone_on_platform_loaded(self, event: Any):
         self._start_scheduled_tasks()
         await self._bootstrap_auto_bind("platform load")
 
@@ -2096,7 +2088,7 @@ class QzoneStablePlugin(Star):
                 content_sanitized=True,
             )
             if payload.get("fid"):
-                self._post_store().upsert(
+                await self._post_store().upsert_async(
                     QzonePost(
                         hostuin=self._self_id(event),
                         fid=str(payload.get("fid") or ""),
@@ -2126,7 +2118,7 @@ class QzoneStablePlugin(Star):
         if not post.content.strip() and not post.media:
             yield self._command_result(event, "说说生成失败。")
             return
-        draft = self._create_draft(event, post, anonymous=False)
+        draft = await self._create_draft(event, post, anonymous=False)
         await self._notify_review_target(event, draft, "有一条 AI 写稿等待审核")
         yield await self._markdown_result(event, f"已生成稿件 #{draft.id}，可用 过稿 {draft.id} 发布。", subdir="drafts")
 
@@ -2170,8 +2162,8 @@ class QzoneStablePlugin(Star):
             if comment_position <= 0:
                 yield self._command_result(event, "评论序号需要从 1 开始。")
                 return
-        saved = self._post_store().get(post_id)
-        draft = None if saved else self.drafts.get(post_id)
+        saved = await self._post_store().get_async(post_id)
+        draft = None if saved else await self.drafts.get_async(post_id)
         if saved is None and (draft is None or not draft.published_fid):
             yield self._command_result(event, f"稿件 #{post_id} 不存在或还没有发布。")
             return
@@ -2201,7 +2193,7 @@ class QzoneStablePlugin(Star):
                     for item in detail.get("comments") or []
                     if isinstance(item, dict)
                 ]
-            self._post_store().upsert(post)
+            await self._post_store().upsert_async(post)
             login_uin = int(status.get("login_uin") or 0)
             comments = [item for item in post.comments if not login_uin or item.uin != login_uin]
             if not comments:
@@ -2233,7 +2225,7 @@ class QzoneStablePlugin(Star):
         if not post.content.strip() and not post.media:
             yield self._command_result(event, "投稿内容或图片不能为空。")
             return
-        draft = self._create_draft(event, post, anonymous=False)
+        draft = await self._create_draft(event, post, anonymous=False)
         await self._notify_review_target(event, draft, "收到一条投稿")
         yield await self._markdown_result(event, f"投稿已收到，稿件编号 #{draft.id}。", subdir="drafts")
 
@@ -2243,7 +2235,7 @@ class QzoneStablePlugin(Star):
         if not post.content.strip() and not post.media:
             yield self._command_result(event, "投稿内容或图片不能为空。")
             return
-        draft = self._create_draft(event, post, anonymous=True)
+        draft = await self._create_draft(event, post, anonymous=True)
         await self._notify_review_target(event, draft, "收到一条匿名投稿")
         yield await self._markdown_result(event, f"匿名投稿已收到，稿件编号 #{draft.id}。", subdir="drafts")
 
@@ -2253,7 +2245,7 @@ class QzoneStablePlugin(Star):
         if draft_id <= 0:
             yield self._command_result(event, "请提供要撤回的稿件ID，例如：撤稿 3。")
             return
-        draft = self.drafts.get(draft_id)
+        draft = await self.drafts.get_async(draft_id)
         if draft is None:
             yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
             return
@@ -2275,7 +2267,7 @@ class QzoneStablePlugin(Star):
                 return
             current.status = "recalled"
 
-        updated = self.drafts.update(draft.id, recall)
+        updated = await self.drafts.update_async(draft.id, recall)
         if updated is None:
             yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
             return
@@ -2292,10 +2284,10 @@ class QzoneStablePlugin(Star):
     async def view_post(self, event: AstrMessageEvent):
         draft_id, _ = self._draft_id_from_event(event, ("看稿", "查看稿件"))
         if draft_id > 0:
-            draft = self.drafts.get(draft_id)
+            draft = await self.drafts.get_async(draft_id)
             text = draft.preview(include_private=True) if draft else f"稿件 #{draft_id} 不存在。"
         else:
-            drafts = self.drafts.list(status="pending")[-10:]
+            drafts = (await self.drafts.list_async(status="pending"))[-10:]
             text = "\n\n".join(draft.preview(include_private=True) for draft in drafts) or "暂无待审核稿件。"
         yield await self._markdown_result(event, text, subdir="drafts")
 
@@ -2306,7 +2298,7 @@ class QzoneStablePlugin(Star):
         if draft_id <= 0:
             yield self._command_result(event, "请提供要通过的稿件ID，例如：过稿 3。")
             return
-        draft = self.drafts.get(draft_id)
+        draft = await self.drafts.get_async(draft_id)
         if draft is None:
             yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
             return
@@ -2322,7 +2314,7 @@ class QzoneStablePlugin(Star):
                 return
             current.status = "approved"
 
-        claimed = self.drafts.update(draft.id, claim_approved)
+        claimed = await self.drafts.update_async(draft.id, claim_approved)
         if claimed is None:
             yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
             return
@@ -2346,7 +2338,7 @@ class QzoneStablePlugin(Star):
                 current.status = "published"
                 current.published_fid = published_fid
 
-            updated_draft = self.drafts.update(draft.id, mark_published) or draft
+            updated_draft = await self.drafts.update_async(draft.id, mark_published) or draft
             if published_fid:
                 login_uin = 0
                 try:
@@ -2361,7 +2353,7 @@ class QzoneStablePlugin(Star):
                     nickname="",
                     images=[str(item.source) for item in post.media],
                 )
-                self._post_store().upsert(saved_post)
+                await self._post_store().upsert_async(saved_post)
             await self._notify_draft_author(event, updated_draft, f"你的投稿 #{updated_draft.id} 已通过并发布。")
         except QzoneBridgeError as exc:
             if profile_task is not None:
@@ -2371,7 +2363,7 @@ class QzoneStablePlugin(Star):
                 if current.status == "approved":
                     current.status = "pending"
 
-            self.drafts.update(draft.id, rollback_approved)
+            await self.drafts.update_async(draft.id, rollback_approved)
             yield self._command_result(event, self._error_text(exc))
             return
         yield await self._publish_result(event, post, payload, profile_task=profile_task)
@@ -2383,7 +2375,7 @@ class QzoneStablePlugin(Star):
         if draft_id <= 0:
             yield self._command_result(event, "请提供要拒绝的稿件ID，例如：拒稿 3 原因。")
             return
-        draft = self.drafts.get(draft_id)
+        draft = await self.drafts.get_async(draft_id)
         if draft is None:
             yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
             return
@@ -2400,7 +2392,7 @@ class QzoneStablePlugin(Star):
             current.status = "rejected"
             current.reject_reason = reason or "未填写原因"
 
-        updated = self.drafts.update(draft.id, reject)
+        updated = await self.drafts.update_async(draft.id, reject)
         if updated is None:
             yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
             return

--- a/main.py
+++ b/main.py
@@ -1,14 +1,17 @@
 """AstrBot entry point for the QQ 空间 bridge."""
 
+# ruff: noqa: E402
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import os
 import inspect
 import json
 import random
 import re
 import shutil
+import sys
 import time
 from contextlib import contextmanager
 from datetime import datetime
@@ -401,18 +404,55 @@ def _standard_data_dir(plugin_root: Path) -> Path:
     return data_dir
 
 
-def _verify_local_qzone_bridge_package(package_file: str | None) -> None:
-    if not package_file:
-        raise RuntimeError("qzone_bridge package file is unavailable")
-    package_path = Path(package_file).resolve(strict=False)
-    expected_root = PLUGIN_ROOT / "qzone_bridge"
-    if not _path_contains(expected_root, package_path):
-        raise RuntimeError(f"qzone_bridge resolved outside plugin directory: {package_path}")
+def _local_qzone_bridge_root() -> Path:
+    package_root = (PLUGIN_ROOT / "qzone_bridge").resolve(strict=False)
+    package_init = package_root / "__init__.py"
+    if not package_init.is_file():
+        raise RuntimeError(f"qzone_bridge package is missing: {package_init}")
+    return package_root
 
 
-import qzone_bridge as _qzone_bridge_package
+def _verify_local_qzone_bridge_module(name: str, package_root: Path) -> None:
+    module = sys.modules.get(name)
+    if module is None:
+        return
+    module_file = getattr(module, "__file__", None)
+    if not module_file:
+        raise RuntimeError(f"{name} is already loaded without a file path")
+    package_path = Path(module_file).resolve(strict=False)
+    if not _path_contains(package_root, package_path):
+        raise RuntimeError(f"{name} resolved outside plugin directory: {package_path}")
 
-_verify_local_qzone_bridge_package(getattr(_qzone_bridge_package, "__file__", None))
+
+def _load_local_qzone_bridge_package() -> None:
+    package_root = _local_qzone_bridge_root()
+    for name in tuple(sys.modules):
+        if name == "qzone_bridge" or name.startswith("qzone_bridge."):
+            _verify_local_qzone_bridge_module(name, package_root)
+
+    if "qzone_bridge" in sys.modules:
+        return
+
+    package_init = package_root / "__init__.py"
+    spec = importlib.util.spec_from_file_location(
+        "qzone_bridge",
+        package_init,
+        submodule_search_locations=[str(package_root)],
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load qzone_bridge package from {package_init}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["qzone_bridge"] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        if sys.modules.get("qzone_bridge") is module:
+            sys.modules.pop("qzone_bridge", None)
+        raise
+    _verify_local_qzone_bridge_module("qzone_bridge", package_root)
+
+
+_load_local_qzone_bridge_package()
 
 from qzone_bridge.controller import QzoneDaemonController
 from qzone_bridge.drafts import DraftPost, DraftStore
@@ -1964,10 +2004,10 @@ class QzoneStablePlugin(Star):
     def qzone(self):
         pass
 
-    @filter.on_platform_loaded()
-    async def qzone_on_platform_loaded(self, event: Any):
+    @filter.on_astrbot_loaded()
+    async def qzone_on_astrbot_loaded(self):
         self._start_scheduled_tasks()
-        await self._bootstrap_auto_bind("platform load")
+        await self._bootstrap_auto_bind("astrbot load")
 
     @filter.platform_adapter_type(filter.PlatformAdapterType.AIOCQHTTP)
     async def qzone_capture_aiocqhttp_client(self, event: AstrMessageEvent):
@@ -2245,11 +2285,13 @@ class QzoneStablePlugin(Star):
         if draft_id <= 0:
             yield self._command_result(event, "请提供要撤回的稿件ID，例如：撤稿 3。")
             return
+        sender_id = self._sender_id(event)
+        is_admin = self._is_admin(event)
         draft = await self.drafts.get_async(draft_id)
         if draft is None:
             yield self._command_result(event, f"稿件 #{draft_id} 不存在。")
             return
-        if draft.author_uin != self._sender_id(event) and not self._is_admin(event):
+        if draft.author_uin != sender_id and not is_admin:
             yield self._command_result(event, "只能撤回自己的投稿。")
             return
         if draft.status != "pending":
@@ -2259,7 +2301,7 @@ class QzoneStablePlugin(Star):
 
         def recall(current: DraftPost) -> None:
             nonlocal failure
-            if current.author_uin != self._sender_id(event) and not self._is_admin(event):
+            if current.author_uin != sender_id and not is_admin:
                 failure = "permission"
                 return
             if current.status != "pending":

--- a/qzone_bridge/astrbot_logging.py
+++ b/qzone_bridge/astrbot_logging.py
@@ -3,32 +3,91 @@
 from __future__ import annotations
 
 import os
+import sys
+import traceback
+from datetime import datetime
+from typing import Any
 
 try:
     from astrbot.api import logger as _astrbot_logger
 
     USING_ASTRBOT_LOGGER = True
 except ImportError:
-    import logging
-
     _astrbot_logger = None
     USING_ASTRBOT_LOGGER = False
+
+
+_LEVEL_VALUES = {
+    "DEBUG": 10,
+    "INFO": 20,
+    "WARNING": 30,
+    "ERROR": 40,
+}
+
+
+class _StandaloneLogger:
+    def __init__(self, name: str):
+        self.name = name
+
+    @staticmethod
+    def _threshold() -> int:
+        level_name = os.getenv("QZONE_DAEMON_LOG_LEVEL", "INFO").upper()
+        return _LEVEL_VALUES.get(level_name, _LEVEL_VALUES["INFO"])
+
+    def _enabled(self, level: str) -> bool:
+        return _LEVEL_VALUES[level] >= self._threshold()
+
+    @staticmethod
+    def _format(message: object, args: tuple[Any, ...]) -> str:
+        text = str(message)
+        if not args:
+            return text
+        try:
+            return text % args
+        except Exception:
+            return " ".join([text, *(str(item) for item in args)])
+
+    def _write(self, level: str, message: object, *args: Any, exc_info: Any = None, **_: Any) -> None:
+        if not self._enabled(level):
+            return
+        timestamp = datetime.now().isoformat(timespec="seconds")
+        print(
+            f"{timestamp} {level} {self.name}: {self._format(message, args)}",
+            file=sys.stderr,
+        )
+        if exc_info:
+            if exc_info is True:
+                traceback.print_exc(file=sys.stderr)
+            elif isinstance(exc_info, tuple):
+                traceback.print_exception(*exc_info, file=sys.stderr)
+
+    def debug(self, message: object, *args: Any, **kwargs: Any) -> None:
+        self._write("DEBUG", message, *args, **kwargs)
+
+    def info(self, message: object, *args: Any, **kwargs: Any) -> None:
+        self._write("INFO", message, *args, **kwargs)
+
+    def warning(self, message: object, *args: Any, **kwargs: Any) -> None:
+        self._write("WARNING", message, *args, **kwargs)
+
+    warn = warning
+
+    def error(self, message: object, *args: Any, **kwargs: Any) -> None:
+        self._write("ERROR", message, *args, **kwargs)
+
+    def exception(self, message: object, *args: Any, **kwargs: Any) -> None:
+        kwargs.setdefault("exc_info", True)
+        self._write("ERROR", message, *args, **kwargs)
 
 
 def get_logger(name: str = "qzone_bridge"):
     if USING_ASTRBOT_LOGGER and _astrbot_logger is not None:
         return _astrbot_logger
-    import logging
-
-    return logging.getLogger(name)
+    return _StandaloneLogger(name)
 
 
 logger = get_logger("qzone_bridge")
 
 
 def configure_standalone_logging(default_level: str = "INFO") -> None:
-    if USING_ASTRBOT_LOGGER:
-        return
-    import logging
-
-    logging.basicConfig(level=os.getenv("QZONE_DAEMON_LOG_LEVEL", default_level))
+    os.environ.setdefault("QZONE_DAEMON_LOG_LEVEL", default_level)

--- a/qzone_bridge/astrbot_logging.py
+++ b/qzone_bridge/astrbot_logging.py
@@ -22,6 +22,7 @@ _LEVEL_VALUES = {
     "INFO": 20,
     "WARNING": 30,
     "ERROR": 40,
+    "CRITICAL": 50,
 }
 
 
@@ -75,9 +76,24 @@ class _StandaloneLogger:
     def error(self, message: object, *args: Any, **kwargs: Any) -> None:
         self._write("ERROR", message, *args, **kwargs)
 
+    def critical(self, message: object, *args: Any, **kwargs: Any) -> None:
+        self._write("CRITICAL", message, *args, **kwargs)
+
+    fatal = critical
+
     def exception(self, message: object, *args: Any, **kwargs: Any) -> None:
         kwargs.setdefault("exc_info", True)
         self._write("ERROR", message, *args, **kwargs)
+
+    def log(self, level: int, message: object, *args: Any, **kwargs: Any) -> None:
+        for level_name, level_value in sorted(_LEVEL_VALUES.items(), key=lambda item: item[1]):
+            if level <= level_value:
+                self._write(level_name, message, *args, **kwargs)
+                return
+        self._write("CRITICAL", message, *args, **kwargs)
+
+    def isEnabledFor(self, level: int) -> bool:
+        return int(level) >= self._threshold()
 
 
 def get_logger(name: str = "qzone_bridge"):

--- a/qzone_bridge/controller.py
+++ b/qzone_bridge/controller.py
@@ -43,25 +43,36 @@ async def _port_is_free_async(port: int) -> bool:
     return await asyncio.to_thread(_port_is_free, port)
 
 
-def _run_quiet(args: list[str], *, timeout: float = 5.0) -> subprocess.CompletedProcess:
+async def _run_quiet(args: list[str], *, timeout: float = 5.0) -> tuple[str, str, int]:
     kwargs: dict[str, Any] = {
-        "capture_output": True,
-        "text": True,
-        "timeout": timeout,
+        "stdout": asyncio.subprocess.PIPE,
+        "stderr": asyncio.subprocess.PIPE,
     }
     if os.name == "nt":
         kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
-    return subprocess.run(args, **kwargs)
+    process = await asyncio.create_subprocess_exec(*args, **kwargs)
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
+    except asyncio.TimeoutError as exc:
+        process.kill()
+        with contextlib.suppress(Exception):
+            await process.wait()
+        raise subprocess.TimeoutExpired(args, timeout) from exc
+    return (
+        stdout.decode("utf-8", errors="replace"),
+        stderr.decode("utf-8", errors="replace"),
+        int(process.returncode or 0),
+    )
 
 
-def _port_owner_pids(port: int) -> set[int]:
+async def _port_owner_pids(port: int) -> set[int]:
     pids: set[int] = set()
     if port <= 0:
         return pids
     if os.name == "nt":
         with contextlib.suppress(Exception):
-            result = _run_quiet(["netstat", "-ano", "-p", "tcp"], timeout=8.0)
-            for line in result.stdout.splitlines():
+            stdout, _, _ = await _run_quiet(["netstat", "-ano", "-p", "tcp"], timeout=8.0)
+            for line in stdout.splitlines():
                 parts = line.split()
                 if len(parts) < 5 or parts[0].upper() != "TCP":
                     continue
@@ -77,46 +88,48 @@ def _port_owner_pids(port: int) -> set[int]:
         return pids
 
     with contextlib.suppress(Exception):
-        result = _run_quiet(
+        stdout, _, _ = await _run_quiet(
             ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"],
             timeout=5.0,
         )
-        for line in result.stdout.splitlines():
+        for line in stdout.splitlines():
             with contextlib.suppress(ValueError):
                 pids.add(int(line.strip()))
     if pids:
         return pids
 
     with contextlib.suppress(Exception):
-        result = _run_quiet(["fuser", f"{port}/tcp"], timeout=5.0)
-        for token in (result.stdout + " " + result.stderr).split():
+        stdout, stderr, _ = await _run_quiet(["fuser", f"{port}/tcp"], timeout=5.0)
+        for token in (stdout + " " + stderr).split():
             token = token.strip()
             if token.isdigit():
                 pids.add(int(token))
     return pids
 
 
-def _pid_command_line(pid: int) -> str:
+async def _pid_command_line(pid: int) -> str:
     if pid <= 0:
         return ""
     if os.name == "nt":
         script = f"(Get-CimInstance Win32_Process -Filter \"ProcessId = {pid}\").CommandLine"
         with contextlib.suppress(Exception):
-            result = _run_quiet(["powershell", "-NoProfile", "-Command", script], timeout=5.0)
-            return result.stdout.strip()
+            stdout, _, _ = await _run_quiet(["powershell", "-NoProfile", "-Command", script], timeout=5.0)
+            return stdout.strip()
         return ""
 
     proc_cmdline = Path("/proc") / str(pid) / "cmdline"
     with contextlib.suppress(Exception):
-        return proc_cmdline.read_text(encoding="utf-8", errors="ignore").replace("\x00", " ").strip()
+        return (
+            await asyncio.to_thread(proc_cmdline.read_text, encoding="utf-8", errors="ignore")
+        ).replace("\x00", " ").strip()
     with contextlib.suppress(Exception):
-        result = _run_quiet(["ps", "-p", str(pid), "-o", "command="], timeout=5.0)
-        return result.stdout.strip()
+        stdout, _, _ = await _run_quiet(["ps", "-p", str(pid), "-o", "command="], timeout=5.0)
+        return stdout.strip()
     return ""
 
 
-def _is_plugin_daemon_pid(pid: int, plugin_root: Path) -> bool:
-    command_line = _pid_command_line(pid).lower()
+async def _is_plugin_daemon_pid(pid: int, plugin_root: Path) -> bool:
+    command_line = (await _pid_command_line(pid)).lower()
     if not command_line:
         return False
     root = str(plugin_root).lower()
@@ -181,7 +194,7 @@ def _redact_detail_for_log(value: Any) -> Any:
     return value
 
 
-def _terminate_pid_tree(pid: int, *, force: bool = False) -> None:
+async def _terminate_pid_tree(pid: int, *, force: bool = False) -> None:
     if pid <= 0 or pid == os.getpid():
         return
     if os.name == "nt":
@@ -189,7 +202,7 @@ def _terminate_pid_tree(pid: int, *, force: bool = False) -> None:
         if force:
             args.append("/F")
         with contextlib.suppress(Exception):
-            _run_quiet(args, timeout=8.0)
+            await _run_quiet(args, timeout=8.0)
         return
 
     with contextlib.suppress(ProcessLookupError):
@@ -568,8 +581,8 @@ class QzoneDaemonController:
         daemon_state = "offline"
         if probe_daemon and runtime.daemon_port and await self._probe_health(runtime.daemon_port):
             daemon_state = "needs_rebind" if needs_rebind else "ready"
-        elif state.session.cookies and state.session.uin:
-            daemon_state = "degraded"
+        elif state.session.cookies:
+            daemon_state = "needs_rebind" if needs_rebind else "degraded"
         return self._status_from_state(state, daemon_state=daemon_state)
 
     @staticmethod
@@ -825,20 +838,20 @@ class QzoneDaemonController:
         trusted_by_secret: bool,
     ) -> set[int]:
         killed: set[int] = set()
-        owners = await asyncio.to_thread(_port_owner_pids, port)
+        owners = await _port_owner_pids(port)
         for pid in owners:
             if pid <= 0 or pid == os.getpid():
                 continue
             is_expected = pid in expected_pids
-            is_plugin_daemon = await asyncio.to_thread(_is_plugin_daemon_pid, pid, self.plugin_root)
+            is_plugin_daemon = await _is_plugin_daemon_pid(pid, self.plugin_root)
             if not (trusted_by_secret or is_expected or is_plugin_daemon):
                 continue
-            await asyncio.to_thread(_terminate_pid_tree, pid, force=False)
+            await _terminate_pid_tree(pid, force=False)
             killed.add(pid)
 
         if killed and not await self._wait_for_port_release(port, 2.0):
             for pid in killed:
-                await asyncio.to_thread(_terminate_pid_tree, pid, force=True)
+                await _terminate_pid_tree(pid, force=True)
         return killed
 
     def _clear_runtime_process_state(self) -> None:

--- a/qzone_bridge/drafts.py
+++ b/qzone_bridge/drafts.py
@@ -152,24 +152,17 @@ class DraftStore:
         media: list[dict[str, Any]] | None = None,
         anonymous: bool = False,
     ) -> DraftPost:
-        def update(payload: dict[str, Any]) -> DraftPost:
-            draft_id = int(payload.get("next_id") or 1)
-            draft = DraftPost(
-                id=draft_id,
+        return self._store.transact(
+            lambda payload: self._add_to_payload(
+                payload,
                 author_uin=author_uin,
                 author_name=author_name,
                 group_id=group_id,
                 content=content,
-                media=list(media or []),
+                media=media,
                 anonymous=anonymous,
             )
-            items = [item for item in payload.get("items") or [] if isinstance(item, dict)]
-            items.append(draft.to_dict())
-            payload["items"] = items
-            payload["next_id"] = draft_id + 1
-            return draft
-
-        return self._store.transact(update)
+        )
 
     async def add_async(
         self,
@@ -222,25 +215,7 @@ class DraftStore:
 
     def save(self, draft: DraftPost) -> DraftPost:
         draft.updated_at = now_iso()
-
-        def update(payload: dict[str, Any]) -> DraftPost:
-            items: list[dict[str, Any]] = []
-            found = False
-            for item in payload.get("items") or []:
-                if not isinstance(item, dict):
-                    continue
-                if int(item.get("id") or 0) == draft.id:
-                    items.append(draft.to_dict())
-                    found = True
-                else:
-                    items.append(item)
-            if not found:
-                items.append(draft.to_dict())
-            payload["items"] = items
-            payload["next_id"] = max(int(payload.get("next_id") or 1), draft.id + 1)
-            return draft
-
-        return self._store.transact(update)
+        return self._store.transact(lambda payload: self._save_to_payload(payload, draft))
 
     async def save_async(self, draft: DraftPost) -> DraftPost:
         draft.updated_at = now_iso()
@@ -264,31 +239,10 @@ class DraftStore:
         return draft
 
     def update(self, draft_id: int, mutator: Callable[[DraftPost], None]) -> DraftPost | None:
-        try:
-            target_id = int(draft_id or 0)
-        except (TypeError, ValueError):
-            return None
+        target_id = self._normalize_id(draft_id)
         if target_id <= 0:
             return None
-
-        def update_payload(payload: dict[str, Any]) -> DraftPost | None:
-            items: list[dict[str, Any]] = []
-            updated: DraftPost | None = None
-            for item in payload.get("items") or []:
-                if not isinstance(item, dict):
-                    continue
-                if int(item.get("id") or 0) == target_id:
-                    draft = DraftPost.from_dict(item)
-                    mutator(draft)
-                    draft.updated_at = now_iso()
-                    updated = draft
-                    items.append(draft.to_dict())
-                else:
-                    items.append(item)
-            payload["items"] = items
-            return updated
-
-        return self._store.transact(update_payload)
+        return self._store.transact(lambda payload: self._update_payload(payload, target_id, mutator))
 
     async def update_async(self, draft_id: int, mutator: Callable[[DraftPost], None]) -> DraftPost | None:
         target_id = self._normalize_id(draft_id)

--- a/qzone_bridge/drafts.py
+++ b/qzone_bridge/drafts.py
@@ -86,18 +86,29 @@ class DraftStore:
     def _write_payload(self, payload: dict[str, Any]) -> None:
         self._store.write(payload)
 
+    async def _read_payload_async(self) -> dict[str, Any]:
+        return await self._store.read_async()
+
+    async def _write_payload_async(self, payload: dict[str, Any]) -> None:
+        await self._store.write_async(payload)
+
     def list(self, *, status: str | None = None) -> list[DraftPost]:
         payload = self._read_payload()
+        return self._items_from_payload(payload, status=status)
+
+    async def list_async(self, *, status: str | None = None) -> list[DraftPost]:
+        payload = await self._read_payload_async()
+        return self._items_from_payload(payload, status=status)
+
+    @staticmethod
+    def _items_from_payload(payload: dict[str, Any], *, status: str | None = None) -> list[DraftPost]:
         items = [DraftPost.from_dict(item) for item in payload.get("items") or [] if isinstance(item, dict)]
         if status:
             items = [item for item in items if item.status == status]
         return sorted(items, key=lambda item: item.id)
 
     def get(self, draft_id: int | None = None) -> DraftPost | None:
-        try:
-            target_id = int(draft_id or 0)
-        except (TypeError, ValueError):
-            return None
+        target_id = self._normalize_id(draft_id)
         if target_id <= 0:
             return None
         items = self.list()
@@ -106,8 +117,29 @@ class DraftStore:
                 return item
         return None
 
+    async def get_async(self, draft_id: int | None = None) -> DraftPost | None:
+        target_id = self._normalize_id(draft_id)
+        if target_id <= 0:
+            return None
+        items = await self.list_async()
+        for item in items:
+            if item.id == target_id:
+                return item
+        return None
+
+    @staticmethod
+    def _normalize_id(draft_id: int | None = None) -> int:
+        try:
+            return int(draft_id or 0)
+        except (TypeError, ValueError):
+            return 0
+
     def latest_pending(self) -> DraftPost | None:
         items = self.list(status="pending")
+        return items[-1] if items else None
+
+    async def latest_pending_async(self) -> DraftPost | None:
+        items = await self.list_async(status="pending")
         return items[-1] if items else None
 
     def add(
@@ -139,6 +171,55 @@ class DraftStore:
 
         return self._store.transact(update)
 
+    async def add_async(
+        self,
+        *,
+        author_uin: int,
+        author_name: str = "",
+        group_id: int = 0,
+        content: str = "",
+        media: list[dict[str, Any]] | None = None,
+        anonymous: bool = False,
+    ) -> DraftPost:
+        return await self._store.transact_async(
+            lambda payload: self._add_to_payload(
+                payload,
+                author_uin=author_uin,
+                author_name=author_name,
+                group_id=group_id,
+                content=content,
+                media=media,
+                anonymous=anonymous,
+            )
+        )
+
+    def _add_to_payload(
+        self,
+        payload: dict[str, Any],
+        *,
+        author_uin: int,
+        author_name: str,
+        group_id: int,
+        content: str,
+        media: list[dict[str, Any]] | None,
+        anonymous: bool,
+    ) -> DraftPost:
+        draft_id = int(payload.get("next_id") or 1)
+        draft = DraftPost(
+            id=draft_id,
+            author_uin=author_uin,
+            author_name=author_name,
+            group_id=group_id,
+            content=content,
+            media=list(media or []),
+            anonymous=anonymous,
+        )
+        items = [item for item in payload.get("items") or [] if isinstance(item, dict)]
+        items.append(draft.to_dict())
+        payload["items"] = items
+        payload["next_id"] = draft_id + 1
+        return draft
+
     def save(self, draft: DraftPost) -> DraftPost:
         draft.updated_at = now_iso()
 
@@ -160,6 +241,27 @@ class DraftStore:
             return draft
 
         return self._store.transact(update)
+
+    async def save_async(self, draft: DraftPost) -> DraftPost:
+        draft.updated_at = now_iso()
+        return await self._store.transact_async(lambda payload: self._save_to_payload(payload, draft))
+
+    def _save_to_payload(self, payload: dict[str, Any], draft: DraftPost) -> DraftPost:
+        items: list[dict[str, Any]] = []
+        found = False
+        for item in payload.get("items") or []:
+            if not isinstance(item, dict):
+                continue
+            if int(item.get("id") or 0) == draft.id:
+                items.append(draft.to_dict())
+                found = True
+            else:
+                items.append(item)
+        if not found:
+            items.append(draft.to_dict())
+        payload["items"] = items
+        payload["next_id"] = max(int(payload.get("next_id") or 1), draft.id + 1)
+        return draft
 
     def update(self, draft_id: int, mutator: Callable[[DraftPost], None]) -> DraftPost | None:
         try:
@@ -187,3 +289,31 @@ class DraftStore:
             return updated
 
         return self._store.transact(update_payload)
+
+    async def update_async(self, draft_id: int, mutator: Callable[[DraftPost], None]) -> DraftPost | None:
+        target_id = self._normalize_id(draft_id)
+        if target_id <= 0:
+            return None
+        return await self._store.transact_async(lambda payload: self._update_payload(payload, target_id, mutator))
+
+    @staticmethod
+    def _update_payload(
+        payload: dict[str, Any],
+        target_id: int,
+        mutator: Callable[[DraftPost], None],
+    ) -> DraftPost | None:
+        items: list[dict[str, Any]] = []
+        updated: DraftPost | None = None
+        for item in payload.get("items") or []:
+            if not isinstance(item, dict):
+                continue
+            if int(item.get("id") or 0) == target_id:
+                draft = DraftPost.from_dict(item)
+                mutator(draft)
+                draft.updated_at = now_iso()
+                updated = draft
+                items.append(draft.to_dict())
+            else:
+                items.append(item)
+        payload["items"] = items
+        return updated

--- a/qzone_bridge/json_store.py
+++ b/qzone_bridge/json_store.py
@@ -15,7 +15,6 @@ T = TypeVar("T")
 
 _LOCKS: dict[Path, threading.RLock] = {}
 _LOCKS_LOCK = threading.RLock()
-_ASYNC_LOCKS: dict[Path, asyncio.Lock] = {}
 
 
 def _default_payload() -> dict[str, Any]:
@@ -39,21 +38,10 @@ def _lock_for(path: Path) -> threading.RLock:
         return lock
 
 
-def _async_lock_for(path: Path) -> asyncio.Lock:
-    key = path.resolve(strict=False)
-    with _LOCKS_LOCK:
-        lock = _ASYNC_LOCKS.get(key)
-        if lock is None:
-            lock = asyncio.Lock()
-            _ASYNC_LOCKS[key] = lock
-        return lock
-
-
 class AtomicItemStoreFile:
     def __init__(self, path: Path):
         self.path = Path(path)
         self._lock = _lock_for(self.path)
-        self._async_lock = _async_lock_for(self.path)
 
     def read(self) -> dict[str, Any]:
         with self._lock:
@@ -71,16 +59,13 @@ class AtomicItemStoreFile:
             return result
 
     async def read_async(self) -> dict[str, Any]:
-        async with self._async_lock:
-            return await asyncio.to_thread(self.read)
+        return await asyncio.to_thread(self.read)
 
     async def write_async(self, payload: dict[str, Any]) -> None:
-        async with self._async_lock:
-            await asyncio.to_thread(self.write, payload)
+        await asyncio.to_thread(self.write, payload)
 
     async def transact_async(self, updater: Callable[[dict[str, Any]], T]) -> T:
-        async with self._async_lock:
-            return await asyncio.to_thread(self.transact, updater)
+        return await asyncio.to_thread(self.transact, updater)
 
     def _read_unlocked(self) -> dict[str, Any]:
         if not self.path.exists():

--- a/qzone_bridge/json_store.py
+++ b/qzone_bridge/json_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import threading
@@ -14,6 +15,7 @@ T = TypeVar("T")
 
 _LOCKS: dict[Path, threading.RLock] = {}
 _LOCKS_LOCK = threading.RLock()
+_ASYNC_LOCKS: dict[Path, asyncio.Lock] = {}
 
 
 def _default_payload() -> dict[str, Any]:
@@ -37,10 +39,21 @@ def _lock_for(path: Path) -> threading.RLock:
         return lock
 
 
+def _async_lock_for(path: Path) -> asyncio.Lock:
+    key = path.resolve(strict=False)
+    with _LOCKS_LOCK:
+        lock = _ASYNC_LOCKS.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _ASYNC_LOCKS[key] = lock
+        return lock
+
+
 class AtomicItemStoreFile:
     def __init__(self, path: Path):
         self.path = Path(path)
         self._lock = _lock_for(self.path)
+        self._async_lock = _async_lock_for(self.path)
 
     def read(self) -> dict[str, Any]:
         with self._lock:
@@ -56,6 +69,18 @@ class AtomicItemStoreFile:
             result = updater(payload)
             self._write_unlocked(payload)
             return result
+
+    async def read_async(self) -> dict[str, Any]:
+        async with self._async_lock:
+            return await asyncio.to_thread(self.read)
+
+    async def write_async(self, payload: dict[str, Any]) -> None:
+        async with self._async_lock:
+            await asyncio.to_thread(self.write, payload)
+
+    async def transact_async(self, updater: Callable[[dict[str, Any]], T]) -> T:
+        async with self._async_lock:
+            return await asyncio.to_thread(self.transact, updater)
 
     def _read_unlocked(self) -> dict[str, Any]:
         if not self.path.exists():

--- a/qzone_bridge/post_service.py
+++ b/qzone_bridge/post_service.py
@@ -95,7 +95,7 @@ class QzonePostService:
             post = post_from_entry(entry, detail=detail_payload.get("raw"), local_id=1)
             post.comments = self._comments_from_detail(detail_payload)
             post.comment_count = max(post.comment_count, len(post.comments))
-            self.post_store.upsert(post)
+            await self.post_store.upsert_async(post)
             return post
 
         post = QzonePost(
@@ -104,7 +104,7 @@ class QzonePostService:
             appid=selection.appid,
             local_id=1,
         )
-        self.post_store.upsert(post)
+        await self.post_store.upsert_async(post)
         return post
 
     async def resolve_posts(
@@ -149,7 +149,7 @@ class QzonePostService:
                 continue
             if no_commented and login_uin and any(comment.uin == login_uin for comment in post.comments):
                 continue
-            self.post_store.upsert(post)
+            await self.post_store.upsert_async(post)
             posts.append(post)
         return posts
 

--- a/qzone_bridge/posts.py
+++ b/qzone_bridge/posts.py
@@ -102,18 +102,26 @@ class PostStore:
     def _write_payload(self, payload: dict[str, Any]) -> None:
         self._store.write(payload)
 
+    async def _read_payload_async(self) -> dict:
+        return await self._store.read_async()
+
     def list(self) -> list[SavedPost]:
         payload = self._read_payload()
+        return self._items_from_payload(payload)
+
+    async def list_async(self) -> list[SavedPost]:
+        payload = await self._read_payload_async()
+        return self._items_from_payload(payload)
+
+    @staticmethod
+    def _items_from_payload(payload: dict) -> list[SavedPost]:
         return sorted(
             [SavedPost.from_dict(item) for item in payload.get("items") or [] if isinstance(item, dict)],
             key=lambda item: item.id,
         )
 
     def get(self, post_id: int | None = None) -> SavedPost | None:
-        try:
-            target_id = int(post_id or 0)
-        except (TypeError, ValueError):
-            return None
+        target_id = self._normalize_id(post_id)
         if target_id <= 0:
             return None
         items = self.list()
@@ -122,35 +130,60 @@ class PostStore:
                 return item
         return None
 
+    async def get_async(self, post_id: int | None = None) -> SavedPost | None:
+        target_id = self._normalize_id(post_id)
+        if target_id <= 0:
+            return None
+        items = await self.list_async()
+        for item in items:
+            if item.id == target_id:
+                return item
+        return None
+
+    @staticmethod
+    def _normalize_id(post_id: int | None = None) -> int:
+        try:
+            return int(post_id or 0)
+        except (TypeError, ValueError):
+            return 0
+
     def latest(self) -> SavedPost | None:
         items = self.list()
         return items[-1] if items else None
 
+    async def latest_async(self) -> SavedPost | None:
+        items = await self.list_async()
+        return items[-1] if items else None
+
     def upsert(self, post: QzonePost) -> SavedPost:
-        def update(payload: dict[str, Any]) -> SavedPost:
-            items = [item for item in payload.get("items") or [] if isinstance(item, dict)]
-            next_id = int(payload.get("next_id") or 1)
-            matched_id = 0
-            updated_items: list[dict[str, Any]] = []
-            for item in items:
-                if (
-                    str(item.get("fid") or "") == str(post.fid or "")
-                    and int(item.get("hostuin") or 0) == int(post.hostuin or 0)
-                    and str(post.fid or "")
-                ):
-                    matched_id = int(item.get("id") or 0) or next_id
-                    updated_items.append(SavedPost.from_post(post, matched_id).to_dict())
-                else:
-                    updated_items.append(item)
+        return self._store.transact(lambda payload: self._upsert_payload(payload, post))
 
-            if not matched_id:
-                matched_id = next_id
+    async def upsert_async(self, post: QzonePost) -> SavedPost:
+        return await self._store.transact_async(lambda payload: self._upsert_payload(payload, post))
+
+    @staticmethod
+    def _upsert_payload(payload: dict[str, Any], post: QzonePost) -> SavedPost:
+        items = [item for item in payload.get("items") or [] if isinstance(item, dict)]
+        next_id = int(payload.get("next_id") or 1)
+        matched_id = 0
+        updated_items: list[dict[str, Any]] = []
+        for item in items:
+            if (
+                str(item.get("fid") or "") == str(post.fid or "")
+                and int(item.get("hostuin") or 0) == int(post.hostuin or 0)
+                and str(post.fid or "")
+            ):
+                matched_id = int(item.get("id") or 0) or next_id
                 updated_items.append(SavedPost.from_post(post, matched_id).to_dict())
-                next_id += 1
+            else:
+                updated_items.append(item)
 
-            payload["items"] = updated_items
-            payload["next_id"] = max(next_id, matched_id + 1)
-            post.saved_id = matched_id
-            return SavedPost.from_post(post, matched_id)
+        if not matched_id:
+            matched_id = next_id
+            updated_items.append(SavedPost.from_post(post, matched_id).to_dict())
+            next_id += 1
 
-        return self._store.transact(update)
+        payload["items"] = updated_items
+        payload["next_id"] = max(next_id, matched_id + 1)
+        post.saved_id = matched_id
+        return SavedPost.from_post(post, matched_id)


### PR DESCRIPTION
﻿This PR hardens the Qzone plugin for AstrBot compatibility and removes several event-loop blockers.

What changed:
- Removed the broad `sys.path` / module-cache hot-reload helper from `main.py`.
- Added a deterministic local `qzone_bridge` package bootstrap that loads the bundled package by file path before importing bridge submodules, preventing ambient same-name packages from being executed.
- Added a bridge API contract version and targeted stale-module refresh for verified local `qzone_bridge.*` modules. This fixes AstrBot hot reload cases where `main.py` is updated but an old in-memory `qzone_bridge.posts.PostStore` still lacks `upsert_async`.
- Switched the startup hook to the documented `@filter.on_astrbot_loaded()` lifecycle signature.
- Removed Python `logging` usage from the bridge logging helper and kept AstrBot logger as the primary path, with a standalone stderr fallback.
- Converted controller port/process probing to async subprocess execution so the event loop is not blocked.
- Added async JSON store helpers without global `asyncio.Lock` reuse, relying on the shared thread lock for cross-loop file transaction serialization.
- Migrated draft/post persistence call sites to async APIs and consolidated draft sync/async mutation logic behind shared payload helpers.
- Kept transaction mutators data-only by capturing AstrBot event-derived values before entering threaded store transactions.

Validation:
- `python -m compileall -q main.py daemon_main.py qzone_bridge`
- `python -m json.tool _conf_schema.json > $null`
- `python -m ruff check main.py qzone_bridge`
- `git diff --check`
- Static checks for lifecycle hook, logger usage, global async locks, and event access inside threaded mutators
- Path-load smoke proving a fake ambient `qzone_bridge` ahead of the plugin root is not executed
- Stale hot-reload smoke proving an old in-memory `qzone_bridge.posts.PostStore` is refreshed before `main.py` imports it
- Async draft/post store smoke across repeated event loops
- Daemon lifecycle smoke covering repeated `ensure_running`, `stop_daemon`, occupied-port fallback, and port-owner helper behavior

Notes:
- No `tests/` or local `data/` paths were staged.
