### PR TITLE
Harden Qzone media source handling

### DIFF
--- a/daemon_main.py
+++ b/daemon_main.py
@@ -9,7 +9,7 @@ PLUGIN_ROOT = Path(__file__).resolve().parent
 if str(PLUGIN_ROOT) not in sys.path:
     sys.path.insert(0, str(PLUGIN_ROOT))
 
-from qzone_bridge.daemon import main
+from qzone_bridge.daemon import main  # noqa: E402
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -3364,6 +3364,10 @@ class QzoneStablePlugin(Star):
             self._publisher_profile_preload_task.cancel()
             await asyncio.gather(self._publisher_profile_preload_task, return_exceptions=True)
             self._publisher_profile_preload_task = None
+        if self._daemon_warmup_task is not None:
+            self._daemon_warmup_task.cancel()
+            await asyncio.gather(self._daemon_warmup_task, return_exceptions=True)
+            self._daemon_warmup_task = None
         try:
             await self.controller.close()
         except Exception as exc:

--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -30,6 +30,7 @@ from .parser import (
     unwrap_payload,
 )
 from .render import cookie_summary
+from .source_policy import is_remote_media_url_allowed, is_windows_drive_path, resolve_remote_media_redirect
 from .utils import extract_callback_json, json_loads, now_iso
 
 log = get_logger(__name__)
@@ -659,6 +660,8 @@ class QzoneClient:
         filename = item.name or source_name(source) or "image.jpg"
         mime_type = item.mime_type
         parsed = urlparse(source)
+        if parsed.scheme.lower() in {"http", "https"} and not is_remote_media_url_allowed(source):
+            raise QzoneParseError("图片 URL 不安全，仅允许 http/https 公网地址", detail={"url": source})
         cached = self._cached_image_source(source) if parsed.scheme.lower() in {"http", "https"} else None
         if cached is not None:
             cached_data, cached_mime = cached
@@ -684,42 +687,60 @@ class QzoneClient:
 
         if parsed.scheme.lower() in {"http", "https"}:
             try:
-                async with self._client.stream(
-                    "GET",
-                    source,
-                    headers=self._headers(referer=f"https://user.qzone.qq.com/{self.login_uin}"),
-                    follow_redirects=True,
-                ) as response:
-                    self._persist_cookie_response(response)
-                    if response.status_code >= 400:
-                        text = (await response.aread()).decode("utf-8", errors="ignore")
-                        raise QzoneRequestError(
-                            f"图片下载失败 HTTP {response.status_code}",
-                            status_code=response.status_code,
-                            detail={"url": source, "text": text[:500]},
-                        )
-                    length = response.headers.get("content-length")
-                    try:
-                        if length and int(length) > MAX_UPLOAD_IMAGE_BYTES:
-                            raise QzoneParseError("图片大小超过限制", detail={"url": source})
-                    except ValueError:
-                        pass
-                    chunks: list[bytes] = []
-                    total = 0
-                    async for chunk in response.aiter_bytes():
-                        if not chunk:
+                current_url = source
+                for redirect_count in range(4):
+                    async with self._client.stream(
+                        "GET",
+                        current_url,
+                        headers=self._headers(referer=f"https://user.qzone.qq.com/{self.login_uin}"),
+                        follow_redirects=False,
+                    ) as response:
+                        self._persist_cookie_response(response)
+                        if response.status_code in QZONE_REDIRECT_STATUS_CODES:
+                            if redirect_count >= 3:
+                                raise QzoneRequestError("图片跳转次数过多", detail={"url": source})
+                            redirected = resolve_remote_media_redirect(
+                                current_url,
+                                response.headers.get("location", ""),
+                            )
+                            if not redirected:
+                                raise QzoneParseError("图片跳转地址不安全", detail={"url": current_url})
+                            current_url = redirected
                             continue
-                        total += len(chunk)
-                        if total > MAX_UPLOAD_IMAGE_BYTES:
-                            raise QzoneParseError("图片大小超过限制", detail={"url": source})
-                        chunks.append(chunk)
+                        if response.status_code >= 400:
+                            text = (await response.aread()).decode("utf-8", errors="ignore")
+                            raise QzoneRequestError(
+                                f"图片下载失败 HTTP {response.status_code}",
+                                status_code=response.status_code,
+                                detail={"url": current_url, "text": text[:500]},
+                            )
+                        length = response.headers.get("content-length")
+                        try:
+                            if length and int(length) > MAX_UPLOAD_IMAGE_BYTES:
+                                raise QzoneParseError("图片大小超过限制", detail={"url": current_url})
+                        except ValueError:
+                            pass
+                        chunks: list[bytes] = []
+                        total = 0
+                        async for chunk in response.aiter_bytes():
+                            if not chunk:
+                                continue
+                            total += len(chunk)
+                            if total > MAX_UPLOAD_IMAGE_BYTES:
+                                raise QzoneParseError("图片大小超过限制", detail={"url": current_url})
+                            chunks.append(chunk)
+                        content_type = response.headers.get("content-type", "").split(";", 1)[0]
+                        data = b"".join(chunks)
+                        self._store_image_source_cache(source, data, content_type)
+                        return data, filename, mime_type or content_type
             except httpx.HTTPError as exc:
                 raise QzoneRequestError("图片下载失败", detail={"url": source}) from exc
-            content_type = response.headers.get("content-type", "").split(";", 1)[0]
-            data = b"".join(chunks)
-            self._store_image_source_cache(source, data, content_type)
-            return data, filename, mime_type or content_type
+            raise QzoneRequestError("图片下载失败", detail={"url": source})
 
+        if parsed.scheme and not is_windows_drive_path(source):
+            raise QzoneParseError("图片来源协议不支持，仅允许 http/https/base64/data 或消息附件缓存")
+        if not item.trusted_local:
+            raise QzoneParseError("本地图片路径只允许来自 AstrBot 消息附件缓存", detail={"name": filename})
         path = Path(source)
         def read_local_image() -> bytes:
             if not path.exists() or not path.is_file():

--- a/qzone_bridge/media.py
+++ b/qzone_bridge/media.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Any, Iterable
 from urllib.parse import unquote, urlparse
 
+from .source_policy import is_windows_drive_path
+
 
 QZONE_MAX_IMAGES = 9
 QZONE_IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"}
@@ -57,6 +59,7 @@ class PostMedia:
     mime_type: str = ""
     size: int = 0
     raw_type: str = ""
+    trusted_local: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -82,6 +85,25 @@ def _is_url(value: str) -> bool:
 
 def _is_base64_source(value: str) -> bool:
     return value.startswith("base64://") or value.startswith("data:")
+
+
+def _is_local_source(value: str) -> bool:
+    if not value:
+        return False
+    parsed = urlparse(value)
+    if parsed.scheme.lower() in {"http", "https"} or _is_base64_source(value):
+        return False
+    if parsed.scheme and not is_windows_drive_path(value):
+        return False
+    return True
+
+
+def _bool_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
 
 
 def _looks_like_path(value: str) -> bool:
@@ -148,10 +170,20 @@ def is_supported_image(media: PostMedia | dict[str, Any]) -> bool:
     return suffix in QZONE_IMAGE_SUFFIXES
 
 
-def normalize_media_item(item: Any, *, default_kind: str = "file") -> PostMedia | None:
+def normalize_media_item(item: Any, *, default_kind: str = "file", trusted_local: bool = False) -> PostMedia | None:
     if item is None:
         return None
     if isinstance(item, PostMedia):
+        if trusted_local and _is_local_source(item.source) and not item.trusted_local:
+            return PostMedia(
+                kind=item.kind,
+                source=item.source,
+                name=item.name,
+                mime_type=item.mime_type,
+                size=item.size,
+                raw_type=item.raw_type,
+                trusted_local=True,
+            )
         return item
     if isinstance(item, str):
         source = normalize_source(item)
@@ -163,6 +195,7 @@ def normalize_media_item(item: Any, *, default_kind: str = "file") -> PostMedia 
             source=source,
             name=name,
             mime_type=guess_mime_type(name or source),
+            trusted_local=trusted_local and _is_local_source(source),
         )
         if is_supported_image(media):
             media.kind = "image"
@@ -181,19 +214,35 @@ def normalize_media_item(item: Any, *, default_kind: str = "file") -> PostMedia 
             size = int(size_value or 0)
         except (TypeError, ValueError):
             size = 0
-        media = PostMedia(kind=kind, source=source, name=name, mime_type=mime_type, size=size, raw_type=kind)
+        item_trusted_local = trusted_local or _bool_value(
+            item.get("trusted_local") or item.get("trusted_local_source") or item.get("from_message")
+        )
+        media = PostMedia(
+            kind=kind,
+            source=source,
+            name=name,
+            mime_type=mime_type,
+            size=size,
+            raw_type=kind,
+            trusted_local=item_trusted_local and _is_local_source(source),
+        )
         if is_supported_image(media):
             media.kind = "image"
         return media
     return None
 
 
-def normalize_media_list(items: Iterable[Any] | None, *, default_kind: str = "file") -> list[PostMedia]:
+def normalize_media_list(
+    items: Iterable[Any] | None,
+    *,
+    default_kind: str = "file",
+    trusted_local: bool = False,
+) -> list[PostMedia]:
     if isinstance(items, (str, dict, PostMedia)):
         items = [items]
     media: list[PostMedia] = []
     for item in items or []:
-        normalized = normalize_media_item(item, default_kind=default_kind)
+        normalized = normalize_media_item(item, default_kind=default_kind, trusted_local=trusted_local)
         if normalized:
             media.append(normalized)
     return media
@@ -211,6 +260,7 @@ def split_publishable_images(media: Iterable[PostMedia]) -> tuple[list[PostMedia
                 mime_type=item.mime_type or guess_mime_type(item.name or item.source),
                 size=item.size,
                 raw_type=item.raw_type or item.kind,
+                trusted_local=item.trusted_local,
             )
             images.append(normalized)
         else:
@@ -362,7 +412,15 @@ def _component_media(component: Any, kind: str) -> PostMedia | None:
         size = int(data.get("size") or 0)
     except (TypeError, ValueError):
         size = 0
-    media = PostMedia(kind=kind, source=source, name=name, mime_type=mime_type, size=size, raw_type=kind)
+    media = PostMedia(
+        kind=kind,
+        source=source,
+        name=name,
+        mime_type=mime_type,
+        size=size,
+        raw_type=kind,
+        trusted_local=_is_local_source(source),
+    )
     if is_supported_image(media):
         media.kind = "image"
     return media
@@ -424,7 +482,7 @@ def _media_from_reference_field(value: Any, *, key: str) -> list[PostMedia]:
         values = value
     else:
         values = [value]
-    return normalize_media_list(values, default_kind=default_kind)
+    return normalize_media_list(values, default_kind=default_kind, trusted_local=True)
 
 
 def _collect_referenced_media(value: Any, *, seen: set[int], depth: int = 0) -> list[PostMedia]:
@@ -649,7 +707,7 @@ def collect_post_payload(
             add_attachment_reference=True,
         )
 
-    for item in normalize_media_list(extra_media):
+    for item in normalize_media_list(extra_media, trusted_local=False):
         _append_collected_media(
             item,
             media=media,

--- a/qzone_bridge/publish_renderer.py
+++ b/qzone_bridge/publish_renderer.py
@@ -22,6 +22,7 @@ import httpx
 from PIL import Image, ImageDraw, ImageFont, ImageOps, UnidentifiedImageError
 
 from .media import PostMedia, PostPayload, source_name
+from .source_policy import is_remote_media_url_allowed, is_windows_drive_path, resolve_remote_media_redirect
 
 
 WHITE = (255, 255, 255)
@@ -125,7 +126,7 @@ def preload_publish_render_assets(
             continue
         seen.add(source)
         preview = _load_image_preview(
-            PostMedia(kind="image", source=source, name="avatar"),
+            PostMedia(kind="image", source=source, name="avatar", trusted_local=True),
             remote_timeout=remote_timeout,
         )
         if preview.image is None:
@@ -282,7 +283,7 @@ def render_publish_result_image(
     preview_targets: list[PostMedia] = []
     avatar_offset = 0
     if profile.avatar_source:
-        preview_targets.append(PostMedia(kind="image", source=profile.avatar_source, name="avatar"))
+        preview_targets.append(PostMedia(kind="image", source=profile.avatar_source, name="avatar", trusted_local=True))
         avatar_offset = 1
     preview_targets.extend(post.media[:9])
     loaded_previews = _load_image_previews(preview_targets, remote_timeout=remote_timeout)
@@ -544,7 +545,12 @@ def _truncate_to_width(draw: ImageDraw.ImageDraw, text: str, font: ImageFont.Ima
 
 
 def _load_image_preview(media: PostMedia, *, remote_timeout: float) -> _ImagePreview:
-    data = _read_source_bytes(media.source, max_bytes=SOURCE_IMAGE_MAX_BYTES, remote_timeout=remote_timeout)
+    data = _read_source_bytes(
+        media.source,
+        max_bytes=SOURCE_IMAGE_MAX_BYTES,
+        remote_timeout=remote_timeout,
+        allow_local=media.trusted_local,
+    )
     if not data:
         return _ImagePreview(media=media, image=None, failed=True)
     try:
@@ -583,9 +589,12 @@ def _load_image_previews(items: list[PostMedia], *, remote_timeout: float) -> li
     return previews
 
 
-def _read_source_bytes(source: str, *, max_bytes: int, remote_timeout: float) -> bytes:
+def _read_source_bytes(source: str, *, max_bytes: int, remote_timeout: float, allow_local: bool = False) -> bytes:
     source = str(source or "").strip()
     if not source:
+        return b""
+    parsed = urlparse(source)
+    if parsed.scheme.lower() in {"http", "https"} and not is_remote_media_url_allowed(source):
         return b""
     cache_key = _bytes_cache_key(source)
     cached = _get_cached_bytes(cache_key)
@@ -608,39 +617,57 @@ def _read_source_bytes(source: str, *, max_bytes: int, remote_timeout: float) ->
                 return b""
         return unquote_to_bytes(encoded)[:max_bytes]
 
-    parsed = urlparse(source)
     if parsed.scheme.lower() in {"http", "https"}:
         try:
             client = _thread_http_client()
-            with client.stream(
-                "GET",
-                source,
-                timeout=httpx.Timeout(remote_timeout),
-                follow_redirects=True,
-            ) as response:
-                if response.status_code >= 400:
-                    return b""
-                length = response.headers.get("content-length")
-                if length and int(length) > max_bytes:
-                    return b""
-                chunks: list[bytes] = []
-                total = 0
-                for chunk in response.iter_bytes():
-                    if not chunk:
+            current_url = source
+            for redirect_count in range(4):
+                with client.stream(
+                    "GET",
+                    current_url,
+                    timeout=httpx.Timeout(remote_timeout),
+                    follow_redirects=False,
+                ) as response:
+                    if response.status_code in {301, 302, 303, 307, 308}:
+                        if redirect_count >= 3:
+                            return b""
+                        redirected = resolve_remote_media_redirect(current_url, response.headers.get("location", ""))
+                        if not redirected:
+                            return b""
+                        current_url = redirected
                         continue
-                    total += len(chunk)
-                    if total > max_bytes:
+                    if response.status_code >= 400:
                         return b""
-                    chunks.append(chunk)
-            data = b"".join(chunks)
+                    length = response.headers.get("content-length")
+                    if length and int(length) > max_bytes:
+                        return b""
+                    chunks: list[bytes] = []
+                    total = 0
+                    for chunk in response.iter_bytes():
+                        if not chunk:
+                            continue
+                        total += len(chunk)
+                        if total > max_bytes:
+                            return b""
+                        chunks.append(chunk)
+                    data = b"".join(chunks)
+                    break
+            else:
+                return b""
             _store_cached_bytes(cache_key, data)
             return data
         except Exception:
             return b""
 
+    if not allow_local:
+        return b""
+    if parsed.scheme and not source.startswith("file://") and not is_windows_drive_path(source):
+        return b""
     if source.startswith("file://"):
         parsed = urlparse(source)
         source = parsed.path or ""
+        if re.match(r"^/[A-Za-z]:[\\/]", source):
+            source = source[1:]
     path = Path(source)
     try:
         stat = path.stat()

--- a/qzone_bridge/source_policy.py
+++ b/qzone_bridge/source_policy.py
@@ -1,0 +1,50 @@
+"""Shared policy for media source loading."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from urllib.parse import urljoin, urlparse
+
+REMOTE_MEDIA_SCHEMES = {"http", "https"}
+WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+UNSAFE_HOST_NAMES = {"localhost", "localhost.localdomain"}
+
+
+def is_windows_drive_path(source: str) -> bool:
+    return bool(WINDOWS_DRIVE_RE.match(str(source or "")))
+
+
+def is_remote_media_url_allowed(source: str) -> bool:
+    parsed = urlparse(str(source or "").strip())
+    if parsed.scheme.lower() not in REMOTE_MEDIA_SCHEMES or not parsed.netloc:
+        return False
+    host = parsed.hostname
+    if not host:
+        return False
+    return not is_unsafe_media_host(host)
+
+
+def is_unsafe_media_host(host: str) -> bool:
+    normalized = str(host or "").strip().lower().rstrip(".")
+    if not normalized or normalized in UNSAFE_HOST_NAMES or normalized.endswith(".localhost"):
+        return True
+    try:
+        address = ipaddress.ip_address(normalized.strip("[]"))
+    except ValueError:
+        return False
+    return bool(
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+    )
+
+
+def resolve_remote_media_redirect(base_url: str, location: str) -> str:
+    if not location:
+        return ""
+    resolved = urljoin(base_url, location)
+    return resolved if is_remote_media_url_allowed(resolved) else ""


### PR DESCRIPTION
## Summary
- install and apply a shared media source policy for Qzone image loading
- allow remote media only through http/https public URLs and validate every redirect hop
- keep local image support only for trusted AstrBot message/cache sources, while blocking LLM/external local paths
- cancel daemon warmup tasks during plugin terminate to avoid pending task leaks
- add a ruff-safe daemon entrypoint import annotation

## Validation
- python -m compileall -q main.py daemon_main.py qzone_bridge
- python -m ruff check main.py daemon_main.py qzone_bridge
- python -m json.tool _conf_schema.json
- git diff --check
- decorated handler signature AST check
- media source policy smoke test for loopback, file://, trusted local cache, and untrusted local path rejection

## Notes
- The reported db_config.py, web/server.py, chat_archive_ext, and record_message code paths are not present in this repository, so the equivalent fixes were applied to the existing Qzone media upload/rendering paths.
- No tests/ or data/ files are included.