### PR TITLE
[codex] Harden Qzone feed card rendering compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ from astrbot.api.star import Context, Star
 
 PLUGIN_ROOT = Path(__file__).resolve().parent
 PLUGIN_DATA_NAME_FALLBACK = "astrbot_plugin_qzone_ultra"
-REQUIRED_QZONE_BRIDGE_API_VERSION = 2026051901
+REQUIRED_QZONE_BRIDGE_API_VERSION = 2026052001
 LEGACY_MIGRATION_FILES = ("state.json", "drafts.json", "posts.json")
 LEGACY_MIGRATION_SENTINEL = ".legacy-qzone-migration.json"
 LEGACY_MIGRATION_LOCK = ".legacy-qzone-migration.lock"
@@ -485,6 +485,35 @@ def _qzone_bridge_contract_is_current(package_root: Path) -> bool:
             for method_name in methods:
                 if not callable(getattr(cls, method_name, None)):
                     return False
+
+    contract_attributes = {
+        "qzone_bridge.publish_renderer": ("combine_rendered_post_cards",),
+        "qzone_bridge.social": ("extract_nickname",),
+    }
+    for module_name, attributes in contract_attributes.items():
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        _verify_local_qzone_bridge_module(module_name, package_root)
+        for attribute in attributes:
+            if getattr(module, attribute, None) is None:
+                return False
+
+    contract_class_attributes = {
+        "qzone_bridge.selection": {"PostSelection": ("has_explicit_input",)},
+    }
+    for module_name, classes in contract_class_attributes.items():
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        _verify_local_qzone_bridge_module(module_name, package_root)
+        for class_name, attributes in classes.items():
+            cls = getattr(module, class_name, None)
+            if cls is None:
+                return False
+            for attribute in attributes:
+                if getattr(cls, attribute, None) is None:
+                    return False
     return True
 
 
@@ -541,15 +570,11 @@ from qzone_bridge.onebot_cookie import fetch_cookie_text
 from qzone_bridge.parser import normalize_uin, parse_cookie_text
 from qzone_bridge.post_service import QzonePostService
 from qzone_bridge.posts import PostStore
-from qzone_bridge.publish_renderer import (
-    RenderProfile,
-    cached_avatar_source,
-    combine_rendered_post_cards,
-    preload_publish_render_assets,
-    preload_static_render_assets,
-    profile_from_event,
-    render_publish_result_image,
-)
+import qzone_bridge.publish_renderer as _publish_renderer
+try:
+    import qzone_bridge.compat as _bridge_compat
+except Exception:
+    _bridge_compat = None
 from qzone_bridge.render import (
     format_action_result,
     format_feed_detail,
@@ -559,10 +584,187 @@ from qzone_bridge.render import (
     format_status,
 )
 from qzone_bridge.scheduler import cron_delay_seconds
-from qzone_bridge.selection import PostSelection, parse_post_selection, selection_from_tool_args
+import qzone_bridge.selection as _selection
 from qzone_bridge.settings import PluginSettings
-from qzone_bridge.social import QzoneComment, QzonePost, extract_nickname, post_from_entry
+import qzone_bridge.social as _social
 from qzone_bridge.utils import truncate
+
+
+class _CompatRenderProfile:
+    def __init__(self, nickname: str = "", user_id: str = "", avatar_source: str = "", time_text: str = ""):
+        self.nickname = nickname
+        self.user_id = user_id
+        self.avatar_source = avatar_source
+        self.time_text = time_text
+
+
+def _profile_from_event_fallback(event: Any) -> Any:
+    nickname = ""
+    for getter_name in ("get_sender_name", "get_sender_nickname"):
+        getter = getattr(event, getter_name, None)
+        if callable(getter):
+            try:
+                nickname = str(getter() or "").strip()
+            except Exception:
+                nickname = ""
+            if nickname:
+                break
+    return RenderProfile(nickname=nickname or "QQ Space", time_text=datetime.now().strftime("%H:%M"))
+
+
+def _missing_publish_renderer(*args: Any, **kwargs: Any) -> Path:
+    raise RuntimeError("qzone publish renderer is unavailable; falling back to text")
+
+
+RenderProfile = getattr(_publish_renderer, "RenderProfile", _CompatRenderProfile)
+cached_avatar_source = getattr(_publish_renderer, "cached_avatar_source", lambda cache_dir, profile: "")
+preload_static_render_assets = getattr(_publish_renderer, "preload_static_render_assets", lambda: None)
+profile_from_event = getattr(_publish_renderer, "profile_from_event", _profile_from_event_fallback)
+render_publish_result_image = getattr(_publish_renderer, "render_publish_result_image", _missing_publish_renderer)
+preload_publish_render_assets = getattr(
+    _publish_renderer,
+    "preload_publish_render_assets",
+    lambda profile, cache_dir, **kwargs: profile,
+)
+
+PostSelection = _selection.PostSelection
+parse_post_selection = _selection.parse_post_selection
+selection_from_tool_args = _selection.selection_from_tool_args
+
+QzoneComment = _social.QzoneComment
+QzonePost = _social.QzonePost
+post_from_entry = _social.post_from_entry
+
+
+def _clean_nickname_fallback(value: Any, *, hostuin: int = 0) -> str:
+    text = re.sub(r"<[^>]+>", "", re.sub(r"\[em\].*?\[/em\]", "", str(value or ""))).strip()
+    if not text or (hostuin and text == str(hostuin)) or re.fullmatch(r"\d{5,}", text):
+        return ""
+    return text
+
+
+def _extract_nickname_compat(raw: dict[str, Any] | None, *, hostuin: int = 0) -> str:
+    helper = getattr(_bridge_compat, "extract_nickname_compat", None)
+    if callable(helper):
+        return helper(raw, hostuin=hostuin, social_module=_social)
+    extractor = getattr(_social, "extract_nickname", None)
+    if callable(extractor):
+        try:
+            nickname = str(extractor(raw, hostuin=hostuin) or "").strip()
+        except Exception:
+            nickname = ""
+        if _clean_nickname_fallback(nickname, hostuin=hostuin):
+            return nickname
+    if isinstance(raw, dict):
+        stack: list[Any] = [raw]
+        for _ in range(48):
+            if not stack:
+                break
+            item = stack.pop(0)
+            if isinstance(item, dict):
+                owner = int(item.get("uin") or item.get("hostuin") or item.get("user_id") or 0)
+                if not hostuin or not owner or owner == hostuin:
+                    for key in ("nickname", "nickName", "name", "ownerName"):
+                        nickname = _clean_nickname_fallback(item.get(key), hostuin=hostuin)
+                        if nickname:
+                            return nickname
+                stack.extend(value for value in item.values() if isinstance(value, (dict, list)))
+            elif isinstance(item, list):
+                stack.extend(value for value in item if isinstance(value, (dict, list)))
+    return ""
+
+
+def _selection_has_explicit_input(selection: Any) -> bool:
+    helper = getattr(_bridge_compat, "selection_has_explicit_input", None)
+    if callable(helper):
+        return bool(helper(selection))
+    for attribute in (
+        "has_explicit_input",
+        "explicit_target",
+        "explicit_selector",
+        "explicit_comment_text",
+        "fid",
+        "comment_text",
+        "target_uin",
+    ):
+        try:
+            if bool(getattr(selection, attribute, False)):
+                return True
+        except Exception:
+            pass
+    try:
+        selector = str(getattr(selection, "selector", "") or "").strip().lower()
+        explicit_range = (
+            int(getattr(selection, "start", 1) or 1) != 1
+            or int(getattr(selection, "end", 1) or 1) != 1
+        )
+        return bool(selector and selector != "latest") or explicit_range
+    except Exception:
+        return False
+
+
+def _minimal_combine_rendered_post_cards(paths: list[Path], output_dir: Path) -> Path | None:
+    if len(paths) <= 1:
+        return paths[0] if paths else None
+    try:
+        import uuid
+        from PIL import Image, UnidentifiedImageError
+    except Exception:
+        return None
+    images: list[Any] = []
+    try:
+        for path in paths:
+            try:
+                with Image.open(path) as opened:
+                    images.append(opened.convert("RGB").copy())
+            except (OSError, UnidentifiedImageError):
+                return None
+        width = max((image.width for image in images), default=0)
+        if not width:
+            return None
+        gap = max(12, min(32, width // 40))
+        height = sum(image.height for image in images) + gap * (len(images) - 1)
+        canvas = Image.new("RGB", (width, height), (255, 255, 255))
+        y = 0
+        for image in images:
+            canvas.paste(image, (0, y))
+            y += image.height + gap
+        output_dir.mkdir(parents=True, exist_ok=True)
+        prune = getattr(_publish_renderer, "_prune_output_dir", None)
+        if callable(prune):
+            prune(output_dir)
+        output_path = output_dir / f"publish_result_{int(time.time())}_{uuid.uuid4().hex[:10]}_cards.png"
+        canvas.save(output_path, "PNG", optimize=False, compress_level=1)
+        canvas.close()
+        return output_path
+    finally:
+        for image in images:
+            try:
+                image.close()
+            except Exception:
+                pass
+
+
+def _combine_rendered_post_cards(paths: list[Path], output_dir: Path) -> Path | None:
+    helper = getattr(_bridge_compat, "combine_rendered_post_cards_compat", None)
+    if callable(helper):
+        return helper(paths, output_dir, renderer_module=_publish_renderer)
+    combiner = getattr(_publish_renderer, "combine_rendered_post_cards", None)
+    if callable(combiner):
+        return combiner(paths, output_dir)
+    logger.warning("qzone post card combiner missing; using minimal import-compatible fallback")
+    return _minimal_combine_rendered_post_cards(paths, output_dir)
+
+
+def _render_publish_result_image(*args: Any, fixed_width: bool = False, **kwargs: Any) -> Path:
+    if not fixed_width:
+        return render_publish_result_image(*args, **kwargs)
+    try:
+        return render_publish_result_image(*args, fixed_width=fixed_width, **kwargs)
+    except TypeError as exc:
+        if "fixed_width" not in str(exc):
+            raise
+        return render_publish_result_image(*args, **kwargs)
 
 
 def _identity_filter_decorator(*args: Any, **kwargs: Any):
@@ -887,7 +1089,7 @@ class QzoneStablePlugin(Star):
             profile = profile_from_event(event)
         try:
             image_path = await asyncio.to_thread(
-                render_publish_result_image,
+                _render_publish_result_image,
                 post,
                 self.data_dir / "rendered_posts",
                 profile=profile,
@@ -914,9 +1116,9 @@ class QzoneStablePlugin(Star):
     @staticmethod
     def _post_display_nickname(post: QzonePost) -> str:
         hostuin = int(post.hostuin or 0)
-        nickname = extract_nickname({"nickname": post.nickname}, hostuin=hostuin)
+        nickname = _extract_nickname_compat({"nickname": post.nickname}, hostuin=hostuin)
         if not nickname:
-            nickname = extract_nickname(post.raw, hostuin=hostuin)
+            nickname = _extract_nickname_compat(post.raw, hostuin=hostuin)
         return nickname or "QQ 空间用户"
 
     @staticmethod
@@ -950,18 +1152,19 @@ class QzoneStablePlugin(Star):
         ]
         return PostPayload(content=(post.summary or "(空)").strip(), media=media)
 
-    async def _render_qzone_post_card(self, post: QzonePost) -> Path | None:
+    async def _render_qzone_post_card(self, post: QzonePost, *, fixed_width: bool = False) -> Path | None:
         if not self.settings.render_publish_result:
             return None
         try:
             return await asyncio.to_thread(
-                render_publish_result_image,
+                _render_publish_result_image,
                 self._post_render_payload(post),
                 self.data_dir / "rendered_posts",
                 profile=self._post_render_profile(post),
                 result={"ok": True, "tool": "qzone_post_card", "fid": post.fid},
                 width=self.settings.render_result_width,
                 remote_timeout=self.settings.render_remote_timeout,
+                fixed_width=fixed_width,
             )
         except Exception as exc:
             logger.exception("qzone post card render failed: %s", exc)
@@ -978,7 +1181,7 @@ class QzoneStablePlugin(Star):
 
         async def render_one(post: QzonePost) -> Path | None:
             async with semaphore:
-                return await self._render_qzone_post_card(post)
+                return await self._render_qzone_post_card(post, fixed_width=True)
 
         rendered = await asyncio.gather(*(render_one(post) for post in posts))
         return [path for path in rendered if path is not None]
@@ -1006,7 +1209,7 @@ class QzoneStablePlugin(Star):
         if len(image_paths) > 1:
             try:
                 combined_path = await asyncio.to_thread(
-                    combine_rendered_post_cards,
+                    _combine_rendered_post_cards,
                     image_paths,
                     self.data_dir / "rendered_posts",
                 )
@@ -2349,7 +2552,7 @@ class QzoneStablePlugin(Star):
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
             selection = self._selection_for_event(event, ("评说说", "评论说说", "读说说"))
-            use_safety_filters = not selection.has_explicit_input
+            use_safety_filters = not _selection_has_explicit_input(selection)
             posts = await self._posts_for_selection(
                 selection,
                 with_detail=True,

--- a/qzone_bridge/__init__.py
+++ b/qzone_bridge/__init__.py
@@ -1,4 +1,4 @@
 """QQ空间 AstrBot bridge."""
 
 __version__ = "0.1.0"
-BRIDGE_API_VERSION = 2026051901
+BRIDGE_API_VERSION = 2026052001

--- a/qzone_bridge/compat.py
+++ b/qzone_bridge/compat.py
@@ -1,0 +1,287 @@
+"""Compatibility helpers for AstrBot hot-reload and half-updated plugin trees."""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+import time
+import uuid
+from html import unescape
+from pathlib import Path
+from typing import Any
+
+
+NICKNAME_KEYS = (
+    "nickname",
+    "nickName",
+    "nick_name",
+    "nick",
+    "name",
+    "uinname",
+    "userName",
+    "username",
+    "ownerName",
+    "displayName",
+)
+NICKNAME_CONTAINER_KEYS = (
+    "userinfo",
+    "userInfo",
+    "user",
+    "owner",
+    "author",
+    "poster",
+    "host",
+    "profile",
+    "blogInfo",
+    "cell_userinfo",
+)
+USER_ID_KEYS = ("uin", "hostuin", "hostUin", "user_id", "userId", "qq", "uinnum")
+NESTED_NICKNAME_PATHS = (
+    ("data", "userinfo"),
+    ("data", "userInfo"),
+    ("data", "user"),
+    ("data", "owner"),
+    ("data", "feed", "userinfo"),
+    ("feed", "userinfo"),
+    ("feed", "user"),
+    ("entry", "userinfo"),
+    ("entry", "user"),
+)
+
+
+def _to_int(value: Any, default: int = 0) -> int:
+    try:
+        if value in (None, ""):
+            return default
+        return int(value)
+    except Exception:
+        return default
+
+
+def clean_nickname(value: Any, *, hostuin: int = 0) -> str:
+    text = unescape(re.sub(r"<[^>]+>", "", re.sub(r"\[em\].*?\[/em\]", "", str(value or "")))).strip()
+    if not text:
+        return ""
+    if hostuin and text == str(hostuin):
+        return ""
+    if re.fullmatch(r"\d{5,}", text):
+        return ""
+    return text
+
+
+def _mapping_uin(raw: dict[str, Any]) -> int:
+    for key in USER_ID_KEYS:
+        value = raw.get(key)
+        if value not in (None, ""):
+            return _to_int(value)
+    return 0
+
+
+def _owner_matches(raw: dict[str, Any], *, hostuin: int = 0) -> bool:
+    owner_uin = _mapping_uin(raw)
+    return not hostuin or not owner_uin or owner_uin == hostuin
+
+
+def _iter_mappings(value: Any):
+    if isinstance(value, dict):
+        yield value
+    elif isinstance(value, list):
+        for item in value:
+            if isinstance(item, dict):
+                yield item
+
+
+def _nested_mapping(raw: dict[str, Any], *keys: str) -> dict[str, Any]:
+    current: Any = raw
+    for key in keys:
+        if not isinstance(current, dict):
+            return {}
+        current = current.get(key)
+    return current if isinstance(current, dict) else {}
+
+
+def _first_nickname(raw: dict[str, Any], *, hostuin: int = 0) -> str:
+    if not _owner_matches(raw, hostuin=hostuin):
+        return ""
+    for key in NICKNAME_KEYS:
+        nickname = clean_nickname(raw.get(key), hostuin=hostuin)
+        if nickname:
+            return nickname
+    return ""
+
+
+def fallback_extract_nickname(raw: dict[str, Any] | None, *, hostuin: int = 0) -> str:
+    if not isinstance(raw, dict):
+        return ""
+    for key in NICKNAME_CONTAINER_KEYS:
+        for item in _iter_mappings(raw.get(key)):
+            nickname = _first_nickname(item, hostuin=hostuin)
+            if nickname:
+                return nickname
+    for path in NESTED_NICKNAME_PATHS:
+        nickname = _first_nickname(_nested_mapping(raw, *path), hostuin=hostuin)
+        if nickname:
+            return nickname
+    return _first_nickname(raw, hostuin=hostuin)
+
+
+def extract_nickname_compat(raw: dict[str, Any] | None, *, hostuin: int = 0, social_module: Any = None) -> str:
+    extractor = getattr(social_module, "extract_nickname", None)
+    if callable(extractor):
+        try:
+            nickname = str(extractor(raw, hostuin=hostuin) or "").strip()
+        except Exception:
+            nickname = ""
+        if clean_nickname(nickname, hostuin=hostuin):
+            return nickname
+    return fallback_extract_nickname(raw, hostuin=hostuin)
+
+
+def selection_has_explicit_input(selection: Any) -> bool:
+    try:
+        return bool(getattr(selection, "has_explicit_input"))
+    except Exception:
+        pass
+    for attribute in ("explicit_target", "explicit_selector", "explicit_comment_text"):
+        try:
+            if bool(getattr(selection, attribute, False)):
+                return True
+        except Exception:
+            pass
+    for attribute in ("fid", "comment_text", "target_uin"):
+        try:
+            if bool(getattr(selection, attribute, "")):
+                return True
+        except Exception:
+            pass
+    try:
+        selector = str(getattr(selection, "selector", "") or "").strip().lower()
+        if selector and selector != "latest":
+            return True
+    except Exception:
+        pass
+    try:
+        return int(getattr(selection, "start", 1) or 1) != 1 or int(getattr(selection, "end", 1) or 1) != 1
+    except Exception:
+        return False
+
+
+def _resample_filter(renderer_module: Any, image_module: Any) -> Any:
+    resample = getattr(renderer_module, "QUALITY_RESAMPLE", None)
+    if resample is not None:
+        return resample
+    resampling = getattr(image_module, "Resampling", image_module)
+    return getattr(resampling, "LANCZOS", getattr(image_module, "LANCZOS", 1))
+
+
+def _prune_output_dir(
+    renderer_module: Any,
+    output_dir: Path,
+    *,
+    keep: int = 128,
+    max_age_seconds: int = 3 * 24 * 3600,
+) -> None:
+    prune = getattr(renderer_module, "_prune_output_dir", None)
+    if callable(prune):
+        try:
+            prune(output_dir)
+            return
+        except Exception:
+            pass
+    try:
+        files = sorted(
+            [path for path in output_dir.glob("publish_result_*.png") if path.is_file()],
+            key=lambda path: path.stat().st_mtime,
+            reverse=True,
+        )
+    except OSError:
+        return
+    cutoff = time.time() - max_age_seconds
+    for index, path in enumerate(files):
+        try:
+            if index >= keep or path.stat().st_mtime < cutoff:
+                os.remove(path)
+        except OSError:
+            continue
+
+
+def fallback_combine_rendered_post_cards(
+    paths: list[Path],
+    output_dir: Path,
+    *,
+    renderer_module: Any = None,
+) -> Path | None:
+    if not paths:
+        return None
+    if len(paths) == 1:
+        return paths[0]
+    try:
+        from PIL import Image, UnidentifiedImageError
+    except Exception:
+        return None
+
+    images: list[Any] = []
+    try:
+        for path in paths:
+            try:
+                with Image.open(path) as opened:
+                    images.append(opened.convert("RGB").copy())
+            except (OSError, UnidentifiedImageError):
+                return None
+        if not images:
+            return None
+
+        width = max(image.width for image in images)
+        gap = max(12, min(32, width // 40))
+        height = sum(image.height for image in images) + gap * (len(images) - 1)
+        pixel_count = width * height
+        scale = 1.0
+        max_height = int(getattr(renderer_module, "COMBINED_CARD_MAX_HEIGHT", 12000) or 12000)
+        max_pixels = int(getattr(renderer_module, "COMBINED_CARD_MAX_PIXELS", 30_000_000) or 30_000_000)
+        if max_height > 0 and height > max_height:
+            scale = min(scale, max_height / height)
+        if max_pixels > 0 and pixel_count > max_pixels:
+            scale = min(scale, math.sqrt(max_pixels / pixel_count))
+        if scale < 1.0:
+            resized: list[Any] = []
+            resample = _resample_filter(renderer_module, Image)
+            for image in images:
+                target_size = (max(1, int(image.width * scale)), max(1, int(image.height * scale)))
+                resized.append(image.resize(target_size, resample))
+                image.close()
+            images = resized
+            width = max(image.width for image in images)
+            gap = max(8, int(gap * scale))
+            height = sum(image.height for image in images) + gap * (len(images) - 1)
+
+        canvas = Image.new("RGB", (width, height), (255, 255, 255))
+        y = 0
+        for image in images:
+            canvas.paste(image, (0, y))
+            y += image.height + gap
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        _prune_output_dir(renderer_module, output_dir)
+        output_path = output_dir / f"publish_result_{int(time.time())}_{uuid.uuid4().hex[:10]}_cards.png"
+        canvas.save(output_path, "PNG", optimize=False, compress_level=1)
+        canvas.close()
+        return output_path
+    finally:
+        for image in images:
+            try:
+                image.close()
+            except Exception:
+                pass
+
+
+def combine_rendered_post_cards_compat(
+    paths: list[Path],
+    output_dir: Path,
+    *,
+    renderer_module: Any = None,
+) -> Path | None:
+    combiner = getattr(renderer_module, "combine_rendered_post_cards", None)
+    if callable(combiner):
+        return combiner(paths, output_dir)
+    return fallback_combine_rendered_post_cards(paths, output_dir, renderer_module=renderer_module)

--- a/qzone_bridge/publish_renderer.py
+++ b/qzone_bridge/publish_renderer.py
@@ -234,6 +234,7 @@ def render_publish_result_image(
     result: dict[str, Any] | None = None,
     width: int = 900,
     remote_timeout: float = 1.5,
+    fixed_width: bool = False,
 ) -> Path:
     """Render a published post into a PNG and return the file path."""
 
@@ -248,13 +249,17 @@ def render_publish_result_image(
     render_scale = RENDER_SCALE
     scratch = ImageDraw.Draw(Image.new("RGB", (1, 1), WHITE))
     content_text = _render_content_text(post)
-    logical_width = _adaptive_logical_width(
-        post,
-        int(width or 900),
-        scratch,
-        content_text,
-        scale=render_scale,
-    )
+    requested_width = int(width or 900)
+    if fixed_width:
+        logical_width = _fixed_logical_width(requested_width)
+    else:
+        logical_width = _adaptive_logical_width(
+            post,
+            requested_width,
+            scratch,
+            content_text,
+            scale=render_scale,
+        )
     width = _scale_px(logical_width, render_scale)
     margin = _scale_px(24, render_scale)
     content_width = width - margin * 2
@@ -459,6 +464,10 @@ def _adaptive_logical_width(
     else:
         min_width, max_width = 700, requested
     return max(min_width, min(requested, max_width, natural))
+
+
+def _fixed_logical_width(requested_width: int) -> int:
+    return max(640, min(int(requested_width or 900), 1280))
 
 
 def _preferred_content_font_size(compact_len: int) -> int:

--- a/qzone_bridge/social.py
+++ b/qzone_bridge/social.py
@@ -77,6 +77,8 @@ def _clean_nickname(value: Any, *, hostuin: int = 0) -> str:
         return ""
     if hostuin and text == str(hostuin):
         return ""
+    if re.fullmatch(r"\d{5,}", text):
+        return ""
     return text
 
 

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -72,6 +72,60 @@ def _import_main_with_stubs(monkeypatch: pytest.MonkeyPatch):
     return importlib.import_module("main")
 
 
+def test_main_import_recovers_from_stale_renderer_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    saved_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "qzone_bridge" or name.startswith("qzone_bridge.")
+    }
+    import qzone_bridge.publish_renderer as renderer
+
+    try:
+        monkeypatch.delattr(renderer, "combine_rendered_post_cards", raising=False)
+
+        main = _import_main_with_stubs(monkeypatch)
+
+        assert main.QzoneStablePlugin.__name__ == "QzoneStablePlugin"
+    finally:
+        for name in list(sys.modules):
+            if name == "qzone_bridge" or name.startswith("qzone_bridge."):
+                sys.modules.pop(name, None)
+        sys.modules.update(saved_modules)
+        sys.modules.pop("main", None)
+
+
+def test_main_import_tolerates_missing_optional_renderer_exports(monkeypatch: pytest.MonkeyPatch) -> None:
+    saved_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "qzone_bridge" or name.startswith("qzone_bridge.")
+    }
+    import qzone_bridge.publish_renderer as renderer
+
+    try:
+        for name in (
+            "RenderProfile",
+            "cached_avatar_source",
+            "preload_publish_render_assets",
+            "preload_static_render_assets",
+            "profile_from_event",
+            "render_publish_result_image",
+        ):
+            monkeypatch.delattr(renderer, name, raising=False)
+
+        main = _import_main_with_stubs(monkeypatch)
+        profile = main.RenderProfile(nickname="昵称", user_id="12345", avatar_source="", time_text="12:00")
+
+        assert main.QzoneStablePlugin.__name__ == "QzoneStablePlugin"
+        assert profile.nickname == "昵称"
+    finally:
+        for name in list(sys.modules):
+            if name == "qzone_bridge" or name.startswith("qzone_bridge."):
+                sys.modules.pop(name, None)
+        sys.modules.update(saved_modules)
+        sys.modules.pop("main", None)
+
+
 def test_remote_media_download_headers_do_not_send_qzone_cookie() -> None:
     client = QzoneClient(SessionState(uin=12345, cookies={"uin": "o12345", "p_skey": "secret"}))
     try:
@@ -291,17 +345,19 @@ def test_qzone_post_card_profile_uses_nickname_not_numeric_fallback(monkeypatch:
 def test_qzone_post_card_range_renders_single_combined_image(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     main = _import_main_with_stubs(monkeypatch)
     rendered_names: set[str] = set()
+    fixed_width_flags: list[bool] = []
     sizes = {
         "第一条": (80, 20, (255, 0, 0)),
         "第二条": (60, 20, (0, 255, 0)),
         "第三条": (70, 20, (0, 0, 255)),
     }
 
-    def fake_render(post, output_dir, *, profile=None, result=None, width=900, remote_timeout=1.5):
+    def fake_render(post, output_dir, *, profile=None, result=None, width=900, remote_timeout=1.5, fixed_width=False):
         from PIL import Image
 
         output_dir.mkdir(parents=True, exist_ok=True)
         rendered_names.add(profile.nickname)
+        fixed_width_flags.append(fixed_width)
         path = output_dir / f"{post.content}.png"
         image_width, image_height, color = sizes[post.content]
         Image.new("RGB", (image_width, image_height), color).save(path)
@@ -345,12 +401,128 @@ def test_qzone_post_card_range_renders_single_combined_image(monkeypatch: pytest
     assert results[0]["type"] == "image"
     assert Path(results[0]["path"]).name.startswith("publish_result_")
     assert rendered_names == {"阿一", "阿二", "阿三"}
+    assert fixed_width_flags == [True, True, True]
     with Image.open(results[0]["path"]) as combined:
         assert combined.width == 80
         assert combined.height > 60
         assert combined.getpixel((0, 0)) == (255, 0, 0)
         assert combined.getpixel((0, 32)) == (0, 255, 0)
         assert combined.getpixel((0, 64)) == (0, 0, 255)
+
+
+def test_publish_renderer_fixed_width_keeps_range_cards_aligned(tmp_path: Path) -> None:
+    from PIL import Image
+
+    from qzone_bridge.media import PostPayload
+    from qzone_bridge.publish_renderer import RenderProfile, render_publish_result_image
+
+    short = render_publish_result_image(
+        PostPayload(content="短内容", media=[]),
+        tmp_path,
+        profile=RenderProfile(nickname="阿一", time_text="12:34"),
+        width=720,
+        remote_timeout=0.01,
+        fixed_width=True,
+    )
+    long = render_publish_result_image(
+        PostPayload(content="这是一条更长的说说内容，用来确认范围合成长图里头像、昵称和操作按钮处在同一套宽度坐标里。", media=[]),
+        tmp_path,
+        profile=RenderProfile(nickname="阿二", time_text="12:34"),
+        width=720,
+        remote_timeout=0.01,
+        fixed_width=True,
+    )
+
+    with Image.open(short) as short_image, Image.open(long) as long_image:
+        assert short_image.width == long_image.width
+        assert short_image.width == 720 * 3
+
+
+def test_qzone_post_card_range_combines_when_renderer_combiner_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    monkeypatch.delattr(main._publish_renderer, "combine_rendered_post_cards", raising=False)
+    sizes = {
+        "第一条": (80, 20, (255, 0, 0)),
+        "第二条": (60, 20, (0, 255, 0)),
+    }
+
+    def fake_render(post, output_dir, *, profile=None, result=None, width=900, remote_timeout=1.5, fixed_width=False):
+        from PIL import Image
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        path = output_dir / f"{post.content}.png"
+        image_width, image_height, color = sizes[post.content]
+        Image.new("RGB", (image_width, image_height), color).save(path)
+        return path
+
+    class _Event:
+        stopped = False
+
+        def stop_event(self):
+            self.stopped = True
+
+        def image_result(self, path: str):
+            return {"type": "image", "path": path}
+
+        def plain_result(self, text: str):
+            return {"type": "plain", "text": text}
+
+    plugin = object.__new__(main.QzoneStablePlugin)
+    plugin.settings = types.SimpleNamespace(
+        render_publish_result=True,
+        render_result_width=720,
+        render_remote_timeout=0.01,
+        render_feed_card_limit=5,
+        max_feed_limit=20,
+    )
+    plugin.data_dir = tmp_path
+    monkeypatch.setattr(main, "render_publish_result_image", fake_render)
+
+    posts = [
+        main.QzonePost(hostuin=10001, fid="fid-1", summary="第一条", nickname="阿一", local_id=1),
+        main.QzonePost(hostuin=10002, fid="fid-2", summary="第二条", nickname="阿二", local_id=2),
+    ]
+
+    results = asyncio.run(plugin._post_card_results(_Event(), posts, "fallback"))
+
+    from PIL import Image
+
+    assert len(results) == 1
+    assert results[0]["type"] == "image"
+    with Image.open(results[0]["path"]) as combined:
+        assert combined.width == 80
+        assert combined.height > 40
+        assert combined.getpixel((0, 0)) == (255, 0, 0)
+        assert combined.getpixel((0, 32)) == (0, 255, 0)
+
+
+def test_compat_fallback_combiner_prunes_stale_rendered_images(tmp_path: Path) -> None:
+    import os
+
+    from PIL import Image
+
+    from qzone_bridge.compat import fallback_combine_rendered_post_cards
+
+    output_dir = tmp_path / "rendered"
+    output_dir.mkdir()
+    for index in range(132):
+        stale = output_dir / f"publish_result_stale_{index}.png"
+        stale.write_bytes(b"old")
+        old_time = 1_700_000_000 + index
+        os.utime(stale, (old_time, old_time))
+
+    first = output_dir / "first.png"
+    second = output_dir / "second.png"
+    Image.new("RGB", (24, 12), (255, 0, 0)).save(first)
+    Image.new("RGB", (24, 12), (0, 255, 0)).save(second)
+
+    result = fallback_combine_rendered_post_cards([first, second], output_dir, renderer_module=types.SimpleNamespace())
+
+    assert result is not None and result.exists()
+    assert len(list(output_dir.glob("publish_result_*.png"))) <= 129
 
 
 def test_qzone_commands_render_post_cards(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -424,6 +596,28 @@ def test_qzone_post_nickname_prefers_matching_owner_and_never_briefs_qq_number()
     text = post.brief(1)
     assert "12345" not in text
     assert "QQ 空间用户" in text
+
+
+def test_post_render_profile_keeps_nickname_without_social_extractor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    monkeypatch.delattr(main._social, "extract_nickname", raising=False)
+
+    plugin = object.__new__(main.QzoneStablePlugin)
+    plugin.data_dir = tmp_path
+    post = main.QzonePost(
+        hostuin=12345,
+        fid="fid-1",
+        nickname="12345",
+        raw={"owner": {"uin": 12345, "nickname": "正确昵称"}},
+        local_id=1,
+    )
+
+    profile = plugin._post_render_profile(post)
+
+    assert profile.nickname == "正确昵称"
 
 
 def test_manual_comment_feed_does_not_hide_selected_posts(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -549,3 +743,76 @@ def test_empty_manual_comment_feed_keeps_auto_comment_safety_filters(
     assert captured["post_kwargs"]["no_self"] is True
     assert captured["post_kwargs"]["with_detail"] is True
     assert results == [{"type": "plain", "text": "没有找到可评论的说说。可以先用 看说说 1~3 确认编号或范围。"}]
+
+
+def test_manual_comment_feed_handles_old_selection_without_explicit_property(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    monkeypatch.delattr(main.PostSelection, "has_explicit_input", raising=False)
+    captured: dict[str, object] = {}
+
+    class _Event:
+        message_str = "评说说 1 已经看到啦"
+
+        def is_admin(self):
+            return True
+
+        def get_self_id(self):
+            return 12345
+
+        def stop_event(self):
+            captured["stopped"] = True
+
+        def plain_result(self, text: str):
+            return {"type": "plain", "text": text}
+
+    class _PostService:
+        async def comment_post(self, post, content, *, private=False):
+            captured["comment"] = (post.fid, content, private)
+            return {"ok": True}
+
+        async def like_post(self, post):
+            return {"ok": True}
+
+    plugin = object.__new__(main.QzoneStablePlugin)
+    plugin.settings = types.SimpleNamespace(
+        admin_uins=[],
+        like_when_comment=False,
+        max_feed_limit=20,
+        render_publish_result=True,
+    )
+    plugin.data_dir = tmp_path
+    plugin.controller = types.SimpleNamespace()
+    post = main.QzonePost(hostuin=12345, fid="fid-1", summary="自己的说说", nickname="自己", local_id=1)
+
+    async def fake_ready(*args, **kwargs):
+        return None
+
+    async def fake_posts(selection, **kwargs):
+        captured["post_kwargs"] = kwargs
+        return [post]
+
+    async def fake_yield_cards(*args, **kwargs):
+        if False:
+            yield None
+
+    plugin._ensure_cookie_ready = fake_ready
+    plugin._ensure_daemon = fake_ready
+    plugin._posts_for_selection = fake_posts
+    plugin._post_service = lambda: _PostService()
+    plugin._yield_post_card_results = fake_yield_cards
+
+    async def collect_results():
+        results = []
+        async for item in plugin.comment_feed(_Event()):
+            results.append(item)
+        return results
+
+    results = asyncio.run(collect_results())
+
+    assert captured["post_kwargs"]["no_commented"] is False
+    assert captured["post_kwargs"]["no_self"] is False
+    assert captured["comment"] == ("fid-1", "已经看到啦", False)
+    assert results == [{"type": "plain", "text": "已评论第 1 条：已经看到啦"}]


### PR DESCRIPTION
﻿## Summary
- harden AstrBot hot-reload compatibility for Qzone feed-card rendering by avoiding import-time hard failures when renderer/social/selection modules are stale or half-updated
- add `qzone_bridge.compat` helpers for nickname extraction, explicit-selection detection, and long-card fallback composition with pruning
- render multi-post/range feed cards at a fixed width so avatars, nicknames, and like/comment/share controls align cleanly in combined long images
- keep single publish/single-card rendering adaptive for low-latency, compact output

## Root Cause
PR #61 added new renderer/social/selection symbols and then referenced some of them from `main.py` during plugin import. In an AstrBot long-running process or a half-updated plugin directory, a new `main.py` can load while a stale `qzone_bridge.publish_renderer` is still present, producing `ImportError: cannot import name 'combine_rendered_post_cards'` before any graceful fallback can run.

## Validation
- `python -m pytest -q` -> 23 passed
- `python -m pytest -q -p no:cacheprovider` -> 23 passed
- `python -m compileall -q main.py qzone_bridge`
- `git diff --check`
- rendered local Chinese smoke images and a fixed-width combined long image to verify Chinese text is not corrupted and multi-card UI columns align

## Notes
- The pytest cache warning in normal mode is caused by this Windows workspace denying writes to `.pytest_cache`; no-cache mode passes cleanly.
