### PR TITLE
[codex] Fix Qzone comment card renderer hot reload

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ from astrbot.api.star import Context, Star
 
 PLUGIN_ROOT = Path(__file__).resolve().parent
 PLUGIN_DATA_NAME_FALLBACK = "astrbot_plugin_qzone_ultra"
-REQUIRED_QZONE_BRIDGE_API_VERSION = 2026052001
+REQUIRED_QZONE_BRIDGE_API_VERSION = 2026052002
 LEGACY_MIGRATION_FILES = ("state.json", "drafts.json", "posts.json")
 LEGACY_MIGRATION_SENTINEL = ".legacy-qzone-migration.json"
 LEGACY_MIGRATION_LOCK = ".legacy-qzone-migration.lock"
@@ -487,7 +487,7 @@ def _qzone_bridge_contract_is_current(package_root: Path) -> bool:
                     return False
 
     contract_attributes = {
-        "qzone_bridge.publish_renderer": ("combine_rendered_post_cards",),
+        "qzone_bridge.publish_renderer": ("combine_rendered_post_cards", "SUPPORTS_COMMENT_RESULT_SECTIONS"),
         "qzone_bridge.social": ("extract_nickname",),
     }
     for module_name, attributes in contract_attributes.items():

--- a/main.py
+++ b/main.py
@@ -496,7 +496,10 @@ def _qzone_bridge_contract_is_current(package_root: Path) -> bool:
             continue
         _verify_local_qzone_bridge_module(module_name, package_root)
         for attribute in attributes:
-            if getattr(module, attribute, None) is None:
+            value = getattr(module, attribute, None)
+            if value is None:
+                return False
+            if attribute == "SUPPORTS_COMMENT_RESULT_SECTIONS" and value is not True:
                 return False
 
     contract_class_attributes = {
@@ -3218,6 +3221,7 @@ class QzoneStablePlugin(Star):
                 [post],
                 post.detail_text(1),
                 fallback_when_unrendered=False,
+                comment_texts={id(post): content},
             ):
                 yield result
 

--- a/qzone_bridge/__init__.py
+++ b/qzone_bridge/__init__.py
@@ -1,4 +1,4 @@
 """QQ空间 AstrBot bridge."""
 
 __version__ = "0.1.0"
-BRIDGE_API_VERSION = 2026052001
+BRIDGE_API_VERSION = 2026052002

--- a/qzone_bridge/publish_renderer.py
+++ b/qzone_bridge/publish_renderer.py
@@ -76,6 +76,7 @@ REGULAR_FONT_ASSET = FONT_ASSET_DIR / "AlibabaPuHuiTi-3-55-Regular.ttf"
 BOLD_FONT_ASSET = FONT_ASSET_DIR / "AlibabaPuHuiTi-3-75-SemiBold.ttf"
 _ACTION_STRIP_CACHE: dict[tuple[str, int], Image.Image] = {}
 _AVATAR_MASK_CACHE: dict[tuple[int, int], Image.Image] = {}
+SUPPORTS_COMMENT_RESULT_SECTIONS = True
 
 
 @dataclass(slots=True)

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -119,6 +119,31 @@ def test_main_import_recovers_from_renderer_without_comment_section_contract(
         sys.modules.pop("main", None)
 
 
+def test_main_import_recovers_from_renderer_with_false_comment_section_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    saved_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "qzone_bridge" or name.startswith("qzone_bridge.")
+    }
+    import qzone_bridge.publish_renderer as renderer
+
+    try:
+        monkeypatch.setattr(renderer, "SUPPORTS_COMMENT_RESULT_SECTIONS", False, raising=False)
+
+        main = _import_main_with_stubs(monkeypatch)
+
+        assert main.QzoneStablePlugin.__name__ == "QzoneStablePlugin"
+        assert getattr(main._publish_renderer, "SUPPORTS_COMMENT_RESULT_SECTIONS", False) is True
+    finally:
+        for name in list(sys.modules):
+            if name == "qzone_bridge" or name.startswith("qzone_bridge."):
+                sys.modules.pop(name, None)
+        sys.modules.update(saved_modules)
+        sys.modules.pop("main", None)
+
+
 def test_main_import_tolerates_missing_optional_renderer_exports(monkeypatch: pytest.MonkeyPatch) -> None:
     saved_modules = {
         name: module
@@ -614,6 +639,64 @@ def test_qzone_commands_render_post_cards(monkeypatch: pytest.MonkeyPatch) -> No
 
     like_source = inspect.getsource(main.QzoneStablePlugin.like_feed)
     assert 'with_detail=True' in like_source
+
+
+def test_qzone_comment_renders_card_with_comment_text(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    captured: dict[str, object] = {}
+
+    class _Event:
+        def is_admin(self):
+            return True
+
+        def stop_event(self):
+            pass
+
+        def plain_result(self, text: str):
+            return {"type": "plain", "text": text}
+
+    class _Controller:
+        async def comment_post(self, *, hostuin: int, fid: str, content: str):
+            captured["comment"] = (hostuin, fid, content)
+            return {"ok": True}
+
+    plugin = object.__new__(main.QzoneStablePlugin)
+    plugin.settings = types.SimpleNamespace(admin_uins=[])
+    plugin.data_dir = tmp_path
+    plugin.controller = _Controller()
+    post = main.QzonePost(hostuin=12345, fid="fid-1", summary="原文", nickname="自己", local_id=1)
+
+    async def fake_ready(*args, **kwargs):
+        return None
+
+    async def fake_detail(*args, **kwargs):
+        return post
+
+    async def fake_yield_cards(event, selected_posts, fallback_text, **kwargs):
+        captured["cards"] = (selected_posts, fallback_text, kwargs)
+        yield {"type": "image", "path": str(tmp_path / "qzone-comment-card.png")}
+
+    plugin._ensure_cookie_ready = fake_ready
+    plugin._ensure_daemon = fake_ready
+    plugin._post_from_detail_target = fake_detail
+    plugin._yield_post_card_results = fake_yield_cards
+
+    async def collect_results():
+        results = []
+        async for item in plugin.qzone_comment(_Event(), 12345, "fid-1", "评论内容"):
+            results.append(item)
+        return results
+
+    results = asyncio.run(collect_results())
+
+    assert captured["comment"] == (12345, "fid-1", "评论内容")
+    assert captured["cards"][0] == [post]
+    assert captured["cards"][2]["comment_texts"] == {id(post): "评论内容"}
+    assert results[0]["type"] == "plain"
+    assert results[1] == {"type": "image", "path": str(tmp_path / "qzone-comment-card.png")}
 
 
 def test_auto_comment_admin_feedback_sends_rendered_card(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -94,6 +94,31 @@ def test_main_import_recovers_from_stale_renderer_module(monkeypatch: pytest.Mon
         sys.modules.pop("main", None)
 
 
+def test_main_import_recovers_from_renderer_without_comment_section_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    saved_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "qzone_bridge" or name.startswith("qzone_bridge.")
+    }
+    import qzone_bridge.publish_renderer as renderer
+
+    try:
+        monkeypatch.delattr(renderer, "SUPPORTS_COMMENT_RESULT_SECTIONS", raising=False)
+
+        main = _import_main_with_stubs(monkeypatch)
+
+        assert main.QzoneStablePlugin.__name__ == "QzoneStablePlugin"
+        assert getattr(main._publish_renderer, "SUPPORTS_COMMENT_RESULT_SECTIONS", False) is True
+    finally:
+        for name in list(sys.modules):
+            if name == "qzone_bridge" or name.startswith("qzone_bridge."):
+                sys.modules.pop(name, None)
+        sys.modules.update(saved_modules)
+        sys.modules.pop("main", None)
+
+
 def test_main_import_tolerates_missing_optional_renderer_exports(monkeypatch: pytest.MonkeyPatch) -> None:
     saved_modules = {
         name: module


### PR DESCRIPTION
﻿## Summary
- Force AstrBot hot reloads to evict stale `qzone_bridge` modules that do not support comment result sections.
- Add a renderer capability contract for comment sections and bump the bridge API version.
- Add regression tests for missing and false comment-section renderer contracts.
- Carry comment text into the `qzone comment` fallback command card path as well as `评说说`.

## Root Cause
`评说说` already passed the comment text through `result["comment"]`, but AstrBot can keep an older `qzone_bridge.publish_renderer` module in `sys.modules` across plugin reloads. That stale renderer still accepts the render call but only draws the original post content, so the comment succeeds while the returned card shows only the original text.

## Validation
- Reproduced with `test_main_import_recovers_from_renderer_without_comment_section_contract` before the fix.
- `python -m pytest -q -p no:cacheprovider` -> 39 passed
- `python -m compileall -q main.py qzone_bridge tests`
- `git diff --check` -> only Windows LF to CRLF warnings before commit
- Manual render preview generated under `data/codex_preview_hot_reload_fix/rendered_posts/`
- Independent AstrBot-skill subagent reviewed PR #65; follow-up contract hardening and `qzone comment` card comment propagation were added and pushed.
