### PR TITLE
[codex] Preserve original Qzone post render time

### DIFF
--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -7,7 +7,7 @@ import base64
 import json
 import time
 from collections import OrderedDict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, unquote, urlencode, urljoin, urlparse, urlunparse
@@ -1167,8 +1167,28 @@ class QzoneClient:
         payload = await self.shuoshuo(fid=fid, uin=hostuin, appid=appid, busi_param=busi_param)
         return payload
 
+    def merge_cached_feed_entry(self, entry: FeedEntry) -> FeedEntry:
+        cached = self.feed_cache.get((entry.hostuin, entry.fid))
+        if cached is None:
+            return entry
+        default_unikey = compute_unikey(entry.appid, entry.hostuin, entry.fid)
+        curkey = cached.curkey if cached.curkey and entry.curkey == default_unikey else entry.curkey
+        unikey = cached.unikey if cached.unikey and entry.unikey == default_unikey else entry.unikey
+        return replace(
+            entry,
+            summary=entry.summary or cached.summary,
+            nickname=entry.nickname or cached.nickname,
+            created_at=entry.created_at if entry.created_at > 0 else cached.created_at,
+            curkey=curkey or cached.curkey,
+            unikey=unikey or cached.unikey,
+            busi_param=entry.busi_param or cached.busi_param,
+            topic_id=entry.topic_id or cached.topic_id,
+            raw=entry.raw or cached.raw,
+        )
+
     def feed_entry_from_payload(self, payload: dict[str, Any], *, default_hostuin: int = 0) -> FeedEntry:
         entry = extract_feed_entry(payload, default_hostuin=default_hostuin)
+        entry = self.merge_cached_feed_entry(entry)
         self.feed_cache[(entry.hostuin, entry.fid)] = entry
         return entry
 

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -428,9 +428,15 @@ class QzoneDaemonService:
         comments = [item.to_dict() for item in extract_comments(raw)]
         return {"entry": asdict(entry), "comments": comments, "raw": raw}
 
-    async def _detail_from_cached_or_legacy_feed(self, *, hostuin: int, fid: str) -> dict[str, Any] | None:
+    async def _detail_from_cached_or_legacy_feed(
+        self,
+        *,
+        hostuin: int,
+        fid: str,
+        require_created_at: bool = False,
+    ) -> dict[str, Any] | None:
         cached = self.client.feed_cache.get((hostuin, fid))
-        if cached is not None:
+        if cached is not None and (not require_created_at or cached.created_at > 0):
             return self._detail_payload_from_entry(cached)
 
         fetchers: list[Any] = []
@@ -449,7 +455,7 @@ class QzoneDaemonService:
                 continue
             self.client.cache_feed_page(hostuin, entries)
             for entry in entries:
-                if entry.fid == fid:
+                if entry.fid == fid and (not require_created_at or entry.created_at > 0):
                     return self._detail_payload_from_entry(entry)
         return None
 
@@ -471,6 +477,14 @@ class QzoneDaemonService:
             if not isinstance(payload, dict):
                 raise QzoneParseError("说说详情返回格式异常")
             entry = self.client.feed_entry_from_payload(payload, default_hostuin=hostuin)
+            if entry.created_at <= 0:
+                fallback = await self._detail_from_cached_or_legacy_feed(
+                    hostuin=hostuin,
+                    fid=fid,
+                    require_created_at=True,
+                )
+                if fallback is not None:
+                    entry = self.client.merge_cached_feed_entry(entry)
             return self._detail_payload_from_entry(entry)
         except (QzoneRequestError, QzoneParseError) as exc:
             if token_error is None and not self._should_fallback_feed_fetch(exc):

--- a/qzone_bridge/parser.py
+++ b/qzone_bridge/parser.py
@@ -25,6 +25,29 @@ FEED_CONTAINER_KEYS = ("feedpage", "main")
 FEED_LIST_KEYS = ("vFeeds", "vfeeds", "msglist", "data", "feeds", "feedlist", "feedList")
 FEED_CURSOR_KEYS = ("attachinfo", "attach_info", "attachInfo", "attach", "externparam", "res_attach")
 FEED_HAS_MORE_KEYS = ("hasmore", "hasMore", "hasMoreFeeds", "has_more")
+FEED_EXPLICIT_TIME_KEYS = (
+    "time",
+    "abstime",
+    "created_time",
+    "createdTime",
+    "created_at",
+    "createdAt",
+    "create_time",
+    "createTime",
+    "pubtime",
+    "pub_time",
+    "publish_time",
+    "publishTime",
+    "feedtime",
+    "feedTime",
+)
+FEED_GENERIC_TIME_KEYS = (
+    "timestamp",
+    "date",
+)
+HTML_TIME_ATTR_KEYS = ("data-time", "data-abstime", "data-pubtime", "time", "abstime", "pubtime")
+MIN_QZONE_TIMESTAMP_SECONDS = 1_100_000_000
+MAX_QZONE_TIMESTAMP_SECONDS = 4_102_444_800
 HTML_ATTR_RE_TEMPLATE = r"""\b{name}\s*=\s*(["'])(.*?)\1"""
 HTML_BREAK_RE = re.compile(r"<\s*br\s*/?\s*>", re.I)
 HTML_BLOCK_RE = re.compile(r"</\s*(?:p|div|li|tr)\s*>", re.I)
@@ -89,6 +112,36 @@ def _int(value: Any, default: int = 0) -> int:
         return int(value or 0)
     except Exception:
         return default
+
+
+def _timestamp_seconds(value: Any) -> int:
+    timestamp = _int(value)
+    if timestamp <= 0:
+        return 0
+    while timestamp > MAX_QZONE_TIMESTAMP_SECONDS and timestamp > 10_000_000_000:
+        timestamp //= 1000
+    if not (MIN_QZONE_TIMESTAMP_SECONDS <= timestamp <= MAX_QZONE_TIMESTAMP_SECONDS):
+        return 0
+    return timestamp
+
+
+def _created_at_from_feed_item(feed_item: dict[str, Any], common: dict[str, Any], html_markup: Any) -> int:
+    data = feed_item.get("data")
+    data_source = data if isinstance(data, dict) else {}
+    for source in (common, feed_item, data_source):
+        for key in FEED_EXPLICIT_TIME_KEYS:
+            timestamp = _timestamp_seconds(source.get(key))
+            if timestamp:
+                return timestamp
+    for key in FEED_GENERIC_TIME_KEYS:
+        timestamp = _timestamp_seconds(common.get(key))
+        if timestamp:
+            return timestamp
+    for key in HTML_TIME_ATTR_KEYS:
+        timestamp = _timestamp_seconds(_html_attr(html_markup, key))
+        if timestamp:
+            return timestamp
+    return 0
 
 
 def _bool(value: Any, default: bool = False) -> bool:
@@ -402,7 +455,7 @@ def extract_feed_entry(
         311,
     )
     fid = extract_fid(feed_item)
-    created_at = _int(common.get("time") or feed_item.get("abstime") or feed_item.get("created_time") or 0)
+    created_at = _created_at_from_feed_item(feed_item, common, html_markup)
     summary = extract_summary_text(feed_item)
     if not summary:
         summary = extract_summary_text(original)
@@ -418,7 +471,11 @@ def extract_feed_entry(
         or ""
     )
     unikey = (
-        _html_attr(html_markup, "data-unikey")
+        feed_item.get("unikey")
+        or feed_item.get("unlikekey")
+        or common.get("unikey")
+        or common.get("unlikekey")
+        or _html_attr(html_markup, "data-unikey")
         or _html_attr(html_markup, "unikey")
         or compute_unikey(appid, hostuin, fid)
     )

--- a/qzone_bridge/post_service.py
+++ b/qzone_bridge/post_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict
+from dataclasses import asdict, replace
 from typing import Any
 
 from .astrbot_logging import get_logger
@@ -48,6 +48,22 @@ class QzonePostService:
             )
         return comments
 
+    @staticmethod
+    def _merge_detail_entry(feed_entry: FeedEntry, detail_entry: FeedEntry) -> FeedEntry:
+        """Keep list metadata when Qzone detail payload omits feed-level fields."""
+
+        return replace(
+            detail_entry,
+            summary=detail_entry.summary or feed_entry.summary,
+            nickname=detail_entry.nickname or feed_entry.nickname,
+            created_at=detail_entry.created_at if detail_entry.created_at > 0 else feed_entry.created_at,
+            curkey=detail_entry.curkey or feed_entry.curkey,
+            unikey=detail_entry.unikey or feed_entry.unikey,
+            busi_param=detail_entry.busi_param or feed_entry.busi_param,
+            topic_id=detail_entry.topic_id or feed_entry.topic_id,
+            raw=detail_entry.raw or feed_entry.raw,
+        )
+
     async def _detail_post(self, entry: FeedEntry, *, local_id: int, required: bool) -> QzonePost:
         detail_payload: dict[str, Any] | None = None
         feed_entry = entry
@@ -61,9 +77,7 @@ class QzonePostService:
             if isinstance(entry_data, dict):
                 detail_entry = FeedEntry(**entry_data)
                 if detail_entry.fid == entry.fid and detail_entry.hostuin == entry.hostuin:
-                    if not detail_entry.nickname:
-                        detail_entry.nickname = entry.nickname
-                    entry = detail_entry
+                    entry = self._merge_detail_entry(entry, detail_entry)
         except Exception:
             if required:
                 raise

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import inspect
+from datetime import datetime
 from pathlib import Path
 import sys
 import types
@@ -12,8 +13,9 @@ import pytest
 from qzone_bridge.client import QzoneClient
 from qzone_bridge.controller import QzoneDaemonController
 from qzone_bridge.errors import QzoneBridgeError, QzoneParseError, QzoneRequestError
-from qzone_bridge.models import SessionState
+from qzone_bridge.models import BridgeState, SessionState
 from qzone_bridge.settings import PluginSettings
+from qzone_bridge.storage import StateStore
 from qzone_bridge import source_policy
 
 
@@ -359,6 +361,7 @@ def test_qzone_post_card_result_uses_publish_renderer(monkeypatch: pytest.Monkey
     assert rendered_post.media[0].source == "https://example.test/a.png"
     assert profile.nickname == "小明"
     assert profile.user_id == "12345"
+    assert profile.time_text == datetime.fromtimestamp(1_700_000_000).strftime("%m-%d %H:%M")
     assert captured["width"] == 720
     assert captured["remote_timeout"] == 0.01
 
@@ -699,6 +702,98 @@ def test_qzone_comment_renders_card_with_comment_text(
     assert results[1] == {"type": "image", "path": str(tmp_path / "qzone-comment-card.png")}
 
 
+@pytest.mark.parametrize("command_name", ["qzone_detail", "qzone_comment", "qzone_like"])
+def test_direct_qzone_commands_render_original_post_time(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    command_name: str,
+) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    captured: dict[str, object] = {}
+
+    class _Event:
+        stopped = False
+
+        def is_admin(self):
+            return True
+
+        def stop_event(self):
+            self.stopped = True
+
+        def image_result(self, path: str):
+            return {"type": "image", "path": path}
+
+        def plain_result(self, text: str):
+            return {"type": "plain", "text": text}
+
+    class _Controller:
+        async def detail_feed(self, *, hostuin: int, fid: str, appid: int = 311):
+            return {
+                "entry": {
+                    "hostuin": hostuin,
+                    "fid": fid,
+                    "appid": appid,
+                    "summary": "原说说内容",
+                    "nickname": "真实昵称",
+                    "created_at": 1_690_000_000,
+                    "raw": {"summary": "原说说内容"},
+                },
+                "raw": {"summary": "原说说内容"},
+                "comments": [],
+            }
+
+        async def comment_post(self, *, hostuin: int, fid: str, content: str):
+            return {"ok": True}
+
+        async def like_post(self, *, hostuin: int, fid: str, appid: int = 311, unlike: bool = False):
+            return {"ok": True, "liked": not unlike, "summary": "原说说内容"}
+
+    def fake_render(post, output_dir, *, profile=None, result=None, width=900, remote_timeout=1.5, fixed_width=False):
+        output_dir.mkdir(parents=True, exist_ok=True)
+        path = output_dir / f"{command_name}.png"
+        path.write_bytes(b"png")
+        captured.setdefault("profiles", []).append(profile)
+        return path
+
+    plugin = object.__new__(main.QzoneStablePlugin)
+    plugin.settings = types.SimpleNamespace(
+        admin_uins=[],
+        render_publish_result=True,
+        render_result_width=720,
+        render_remote_timeout=0.01,
+        render_feed_card_limit=5,
+        max_feed_limit=20,
+    )
+    plugin.data_dir = tmp_path
+    plugin.controller = _Controller()
+
+    async def fake_ready(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(main, "render_publish_result_image", fake_render)
+    plugin._ensure_cookie_ready = fake_ready
+    plugin._ensure_daemon = fake_ready
+
+    async def collect_results():
+        event = _Event()
+        results = []
+        if command_name == "qzone_detail":
+            iterator = plugin.qzone_detail(event, 12345, "fid-direct", 311)
+        elif command_name == "qzone_comment":
+            iterator = plugin.qzone_comment(event, 12345, "fid-direct", "评论内容")
+        else:
+            iterator = plugin.qzone_like(event, 12345, "fid-direct", 311, False)
+        async for item in iterator:
+            results.append(item)
+        return results
+
+    results = asyncio.run(collect_results())
+
+    profiles = captured["profiles"]
+    assert profiles[-1].time_text == datetime.fromtimestamp(1_690_000_000).strftime("%m-%d %H:%M")
+    assert any(item.get("type") == "image" for item in results)
+
+
 def test_auto_comment_admin_feedback_sends_rendered_card(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     main = _import_main_with_stubs(monkeypatch)
 
@@ -823,6 +918,51 @@ def test_default_feed_page_skips_numeric_info_nickname_for_owner_context() -> No
     assert entries[0].nickname == "真实昵称"
 
 
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"time": 1_690_000_000}, 1_690_000_000),
+        ({"created_at": 1_690_000_000}, 1_690_000_000),
+        ({"createdTime": 1_690_000_000}, 1_690_000_000),
+        ({"createTime": 1_690_000_000}, 1_690_000_000),
+        ({"pubtime": 1_690_000_000}, 1_690_000_000),
+        ({"common": {"timestamp": 1_690_000_000_000}}, 1_690_000_000),
+        ({"common": {"date": 1_690_000_000}}, 1_690_000_000),
+    ],
+)
+def test_feed_entry_extracts_common_qzone_time_aliases(payload: dict[str, object], expected: int) -> None:
+    from qzone_bridge.parser import extract_feed_entry
+
+    payload = {
+        "hostuin": 12345,
+        "fid": "fid-time-alias",
+        "summary": "发布时间别名",
+        **payload,
+    }
+    entry = extract_feed_entry(
+        payload,
+        default_hostuin=12345,
+    )
+
+    assert entry.created_at == expected
+
+
+def test_feed_entry_ignores_unreasonable_generic_timestamps() -> None:
+    from qzone_bridge.parser import extract_feed_entry
+
+    entry = extract_feed_entry(
+        {
+            "hostuin": 12345,
+            "fid": "fid-invalid-timestamp",
+            "summary": "异常时间戳",
+            "timestamp": 99_999_999_999_999_999,
+        },
+        default_hostuin=12345,
+    )
+
+    assert entry.created_at == 0
+
+
 def test_detail_post_keeps_feed_raw_nickname_when_detail_omits_owner(tmp_path: Path) -> None:
     from qzone_bridge.models import FeedEntry
     from qzone_bridge.post_service import QzonePostService
@@ -855,6 +995,139 @@ def test_detail_post_keeps_feed_raw_nickname_when_detail_omits_owner(tmp_path: P
 
     assert post.nickname == "列表昵称"
     assert "QQ 空间用户" not in post.brief(1)
+
+
+def test_detail_post_preserves_feed_created_at_when_detail_omits_time(tmp_path: Path) -> None:
+    from qzone_bridge.models import FeedEntry
+    from qzone_bridge.post_service import QzonePostService
+
+    class _Controller:
+        async def detail_feed(self, *, hostuin: int, fid: str, appid: int = 311):
+            return {
+                "entry": {
+                    "hostuin": hostuin,
+                    "fid": fid,
+                    "appid": appid,
+                    "summary": "详情内容",
+                    "nickname": "列表昵称",
+                    "raw": {"summary": "详情内容"},
+                },
+                "raw": {"summary": "详情内容"},
+                "comments": [],
+            }
+
+    entry = FeedEntry(
+        hostuin=12345,
+        fid="fid-time",
+        appid=311,
+        summary="列表内容",
+        nickname="列表昵称",
+        created_at=1_690_000_000,
+    )
+    service = QzonePostService(_Controller(), types.SimpleNamespace(), max_feed_limit=20)
+
+    post = asyncio.run(service._detail_post(entry, local_id=1, required=True))
+
+    assert post.created_at == 1_690_000_000
+
+
+def test_client_detail_payload_preserves_cached_created_at_when_detail_omits_time() -> None:
+    from qzone_bridge.models import FeedEntry
+
+    client = QzoneClient(SessionState(uin=12345, cookies={}))
+    try:
+        client.feed_cache[(12345, "fid-cached")] = FeedEntry(
+            hostuin=12345,
+            fid="fid-cached",
+            appid=311,
+            summary="列表内容",
+            nickname="列表昵称",
+            created_at=1_690_000_000,
+            curkey="cached-curkey",
+            unikey="cached-unikey",
+        )
+
+        entry = client.feed_entry_from_payload(
+            {
+                "hostuin": 12345,
+                "fid": "fid-cached",
+                "summary": "详情内容",
+                "nickname": "详情昵称",
+            },
+            default_hostuin=12345,
+        )
+    finally:
+        asyncio.run(client.close())
+
+    assert entry.created_at == 1_690_000_000
+    assert entry.curkey == "cached-curkey"
+    assert entry.unikey == "cached-unikey"
+
+
+def test_daemon_detail_feed_uses_legacy_feed_time_when_primary_detail_omits_time(tmp_path: Path) -> None:
+    from qzone_bridge.daemon import QzoneDaemonService
+
+    store = StateStore(tmp_path)
+    store.write(
+        BridgeState(
+            session=SessionState(
+                uin=12345,
+                cookies={"uin": "12345", "p_skey": "token"},
+                qzonetokens={"12345": "token"},
+                needs_rebind=False,
+            )
+        )
+    )
+    service = QzoneDaemonService(store, secret="secret", port=8765, keepalive_interval=30, request_timeout=0.01)
+    calls: list[str] = []
+
+    async def fake_detail(hostuin: int, fid: str, *, appid: int = 311, busi_param: str = ""):
+        calls.append("detail")
+        return {
+            "hostuin": hostuin,
+            "fid": fid,
+            "appid": appid,
+            "summary": "详情内容",
+            "nickname": "详情昵称",
+        }
+
+    async def fake_legacy_recent_feeds():
+        calls.append("legacy_recent")
+        return {
+            "vFeeds": [
+                {
+                    "hostuin": 12345,
+                    "fid": "fid-daemon-time",
+                    "appid": 311,
+                    "summary": "列表内容",
+                    "nickname": "列表昵称",
+                    "created_at": 1_690_000_000,
+                    "curkey": "legacy-curkey",
+                    "unikey": "legacy-unikey",
+                }
+            ]
+        }
+
+    async def fake_legacy_feeds(hostuin: int, *, page: int = 1, num: int = 20):
+        calls.append("legacy_profile")
+        return {"vFeeds": []}
+
+    service.client.detail = fake_detail
+    service.client.legacy_recent_feeds = fake_legacy_recent_feeds
+    service.client.legacy_feeds = fake_legacy_feeds
+
+    try:
+        payload = asyncio.run(service.detail_feed(hostuin=12345, fid="fid-daemon-time", appid=311))
+    finally:
+        asyncio.run(service.client.close())
+
+    entry = payload["entry"]
+    assert calls == ["detail", "legacy_recent"]
+    assert entry["summary"] == "详情内容"
+    assert entry["nickname"] == "详情昵称"
+    assert entry["created_at"] == 1_690_000_000
+    assert entry["curkey"] == "legacy-curkey"
+    assert entry["unikey"] == "legacy-unikey"
 
 
 def test_post_render_profile_keeps_nickname_without_social_extractor(


### PR DESCRIPTION
## Summary
- preserve original feed publish timestamps when detail payloads omit time fields
- parse additional Qzone time aliases with sane timestamp bounds and preserve real feed unikey values
- keep cached/legacy feed metadata for list-detail and direct detail/comment/like card rendering paths
- avoid copying stale list like/comment counts into detail cards
- refine rendered comment sections to match the provided reference: bright block, blue L accent, larger text, stronger original/comment separation, and a straight top edge that connects directly to the blue accent

## Root cause
Detail fetches for 说说详情/评论/点赞 could replace the list FeedEntry with a detail FeedEntry that had created_at=0, causing card rendering to fall back to the current time. Direct fid detail/comment/like paths had the same risk when the detail endpoint succeeded but omitted publish time.

For comment result cards, the old renderer used a compact dark-bordered rounded rectangle and an inset pill accent. That made the comment area visually diverge from the requested Qzone-style reference, especially around the top-left corner where the accent and card should be connected.

## AstrBot notes
The fix stays in parser/client/daemon/post_service/publish_renderer layers rather than AstrBot command handlers. Existing async command handlers, admin checks, yield image/plain result flow, and asyncio.to_thread rendering path are preserved. No browser/HTML runtime dependency was added, keeping render latency and AstrBot plugin install size low.

## Validation
- python -m pytest tests/test_security_hardening.py::test_publish_renderer_draws_comment_section_separated_from_original -q -> passed
- $env:PYTHONDONTWRITEBYTECODE='1'; python -m pytest -p no:cacheprovider tests/test_security_hardening.py -> 53 passed
- $env:PYTHONDONTWRITEBYTECODE='1'; python -m compileall -q main.py qzone_bridge tests
- git diff --check

Preview image generated locally: data/codex_preview_comment_reference/publish_result_1779374824_af2c992281.png