### PR TITLE
[codex] Add automatic Qzone autobind retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ pip install -r requirements.txt
 /qzone autobind
 ```
 
+插件安装、下载后重载或 AstrBot 启动时会自动尝试执行一次 autobind；如果当时 OneBot 客户端稍后才就绪，插件会在首次捕获 aiocqhttp 事件后补触发。自动绑定最多尝试 3 次，仍失败时再使用上面的命令或手动 Cookie 绑定。
+
 如果平台无法提供 Cookie，可以手动绑定：
 
 ```text

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -218,7 +218,7 @@
     "description": "Auto bind cookie",
     "type": "bool",
     "default": true,
-    "hint": "检测到登录态缺失时，尝试从 OneBot 自动获取 Cookie。"
+    "hint": "插件初始化、AstrBot 加载或首次捕获 aiocqhttp 客户端时，若登录态缺失会尝试从 OneBot 自动获取 Cookie；自动绑定最多重试 3 次，仍失败时请使用 /qzone autobind 或 /qzone bind。"
   },
   "cookie_domain": {
     "description": "OneBot cookie domain",

--- a/main.py
+++ b/main.py
@@ -29,6 +29,8 @@ REQUIRED_QZONE_BRIDGE_API_VERSION = 2026052002
 LEGACY_MIGRATION_FILES = ("state.json", "drafts.json", "posts.json")
 LEGACY_MIGRATION_SENTINEL = ".legacy-qzone-migration.json"
 LEGACY_MIGRATION_LOCK = ".legacy-qzone-migration.lock"
+AUTO_BIND_RETRY_ATTEMPTS = 3
+AUTO_BIND_RETRY_DELAY_SECONDS = 1.0
 
 SENSITIVE_LOG_KEYS = {
     "cookie",
@@ -807,6 +809,8 @@ class QzoneStablePlugin(Star):
         )
         self._capture_onebot_client_from_context()
         self._daemon_warmup_task: asyncio.Task | None = None
+        self._auto_bind_bootstrap_task: asyncio.Task | None = None
+        self._auto_bind_bootstrap_succeeded = False
         self._scheduled_tasks: list[asyncio.Task] = []
         self._publisher_profile_cache: tuple[int, RenderProfile] | None = None
         self._publisher_profile_preload_task: asyncio.Task | None = None
@@ -2415,16 +2419,38 @@ class QzoneStablePlugin(Star):
             if not force and status and int(status.get("cookie_count") or 0) > 0 and not bool(status.get("needs_rebind")):
                 return status
 
-            cookie_text = await fetch_cookie_text(bot, domain=self.settings.cookie_domain)
-            if not cookie_text:
-                raise QzoneCookieAcquireError(f"OneBot 没有返回可用 Cookie。{self._cookie_binding_hint()}")
+            last_error: QzoneBridgeError | None = None
+            for attempt in range(1, AUTO_BIND_RETRY_ATTEMPTS + 1):
+                try:
+                    cookie_text = await fetch_cookie_text(bot, domain=self.settings.cookie_domain)
+                    if not cookie_text:
+                        raise QzoneCookieAcquireError(f"OneBot 没有返回可用 Cookie。{self._cookie_binding_hint()}")
 
-            try:
-                cookie_uin = normalize_uin(parse_cookie_text(cookie_text))
-            except Exception:
-                cookie_uin = 0
-            payload = await self.controller.bind_cookie_local(cookie_text, uin=cookie_uin, source=source)
-            return payload
+                    try:
+                        cookie_uin = normalize_uin(parse_cookie_text(cookie_text))
+                    except Exception:
+                        cookie_uin = 0
+                    payload = await self.controller.bind_cookie_local(cookie_text, uin=cookie_uin, source=source)
+                    if attempt > 1:
+                        logger.info("qzone auto bind succeeded on attempt %s/%s", attempt, AUTO_BIND_RETRY_ATTEMPTS)
+                    return payload
+                except QzoneBridgeError as exc:
+                    last_error = exc
+                except Exception as exc:
+                    last_error = QzoneCookieAcquireError(f"自动绑定 Cookie 失败：{exc}")
+
+                logger.warning(
+                    "qzone auto bind attempt %s/%s failed: %s",
+                    attempt,
+                    AUTO_BIND_RETRY_ATTEMPTS,
+                    last_error,
+                )
+                if attempt < AUTO_BIND_RETRY_ATTEMPTS:
+                    await asyncio.sleep(AUTO_BIND_RETRY_DELAY_SECONDS)
+
+            if last_error is not None:
+                raise last_error
+            raise QzoneCookieAcquireError(f"OneBot 没有返回可用 Cookie。{self._cookie_binding_hint()}")
 
     async def _ensure_cookie_ready(
         self,
@@ -2444,17 +2470,39 @@ class QzoneStablePlugin(Star):
         self._schedule_publish_render_asset_preload("cookie bind", event=event, status=payload)
         return payload
 
-    async def _bootstrap_auto_bind(self, trigger: str) -> None:
-        client = self._capture_onebot_client_from_context()
-        if client is None or not self.settings.auto_bind_cookie:
+    async def _bootstrap_auto_bind(self, trigger: str, event: AstrMessageEvent | None = None) -> bool:
+        client = self._capture_onebot_client(event) if event is not None else self._capture_onebot_client_from_context()
+        if client is None:
             await self._prewarm_daemon_if_cookie_ready(trigger)
-            return
+            return False
+        if not self.settings.auto_bind_cookie:
+            await self._prewarm_daemon_if_cookie_ready(trigger)
+            return True
         try:
-            await self._ensure_cookie_ready(source="aiocqhttp")
+            await self._ensure_cookie_ready(event, source="aiocqhttp")
         except QzoneBridgeError as exc:
             logger.warning("qzone auto bind on %s failed: %s", trigger, exc)
-            return
+            return False
         await self._prewarm_daemon_if_cookie_ready(trigger)
+        return True
+
+    def _schedule_bootstrap_auto_bind(self, trigger: str, event: AstrMessageEvent | None = None) -> None:
+        task = getattr(self, "_auto_bind_bootstrap_task", None)
+        if task is not None and not task.done():
+            return
+        if bool(getattr(self, "_auto_bind_bootstrap_succeeded", False)):
+            return
+        if event is not None and self._capture_onebot_client(event) is None and self.settings.auto_bind_cookie:
+            return
+
+        async def runner() -> None:
+            try:
+                if await self._bootstrap_auto_bind(trigger, event):
+                    self._auto_bind_bootstrap_succeeded = True
+            except Exception:
+                logger.warning("qzone auto bind on %s failed unexpectedly", trigger, exc_info=True)
+
+        self._auto_bind_bootstrap_task = asyncio.create_task(runner())
 
     async def _prewarm_daemon_if_cookie_ready(self, trigger: str) -> None:
         if not self.settings.auto_start_daemon:
@@ -2494,6 +2542,7 @@ class QzoneStablePlugin(Star):
             except QzoneBridgeError as exc:
                 logger.warning("qzone config cookie bind failed: %s", exc)
         self._start_scheduled_tasks()
+        self._schedule_bootstrap_auto_bind("initialize")
 
     @filter.command_group("qzone")
     def qzone(self):
@@ -2502,18 +2551,22 @@ class QzoneStablePlugin(Star):
     @filter.on_astrbot_loaded()
     async def qzone_on_astrbot_loaded(self):
         self._start_scheduled_tasks()
-        await self._bootstrap_auto_bind("astrbot load")
+        self._schedule_bootstrap_auto_bind("astrbot load")
 
     @filter.platform_adapter_type(filter.PlatformAdapterType.AIOCQHTTP)
     async def qzone_capture_aiocqhttp_client(self, event: AstrMessageEvent):
         self._capture_onebot_client(event)
-        if self.settings.read_prob <= 0 or random.random() >= self.settings.read_prob:
+        should_auto_read = self.settings.read_prob > 0 and random.random() < self.settings.read_prob
+        if not should_auto_read:
+            self._schedule_bootstrap_auto_bind("aiocqhttp capture", event)
             return
         group_id = str(self._group_id(event) or "")
         sender_id = str(self._sender_id(event) or "")
         if group_id and group_id in self.settings.ignore_groups:
+            self._schedule_bootstrap_auto_bind("aiocqhttp capture", event)
             return
         if sender_id and sender_id in self.settings.ignore_users:
+            self._schedule_bootstrap_auto_bind("aiocqhttp capture", event)
             return
         try:
             await self._ensure_cookie_ready(event)
@@ -3978,6 +4031,10 @@ class QzoneStablePlugin(Star):
             self._daemon_warmup_task.cancel()
             await asyncio.gather(self._daemon_warmup_task, return_exceptions=True)
             self._daemon_warmup_task = None
+        if self._auto_bind_bootstrap_task is not None:
+            self._auto_bind_bootstrap_task.cancel()
+            await asyncio.gather(self._auto_bind_bootstrap_task, return_exceptions=True)
+            self._auto_bind_bootstrap_task = None
         try:
             await self.controller.close()
         except Exception as exc:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 name: astrbot_plugin_qzone_ultra
-version: 0.2.0
+version: 0.2.1
 author: 雪碧bir
 desc: QQ空间Ultra，更稳定的QQ空间插件，支持自动绑定QQ空间，采用独立进程：占用极低、稳定性极高，支持看/评/赞/发/写/删说说、回评、投稿审核、自动发评和 LLM tools。
 display_name: QQ空间Ultra

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -12,7 +12,7 @@ import pytest
 
 from qzone_bridge.client import QzoneClient
 from qzone_bridge.controller import QzoneDaemonController
-from qzone_bridge.errors import QzoneBridgeError, QzoneParseError, QzoneRequestError
+from qzone_bridge.errors import QzoneBridgeError, QzoneCookieAcquireError, QzoneParseError, QzoneRequestError
 from qzone_bridge.models import BridgeState, SessionState
 from qzone_bridge.settings import PluginSettings
 from qzone_bridge.storage import StateStore
@@ -176,6 +176,337 @@ def test_main_import_tolerates_missing_optional_renderer_exports(monkeypatch: py
                 sys.modules.pop(name, None)
         sys.modules.update(saved_modules)
         sys.modules.pop("main", None)
+
+
+def test_auto_bind_cookie_retries_empty_fetch_before_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    attempts: list[str] = []
+    sleeps: list[float] = []
+    bound: dict[str, object] = {}
+
+    class _Controller:
+        async def get_status(self, *, probe_daemon=False):
+            return {"cookie_count": 0, "needs_rebind": True}
+
+        async def bind_cookie_local(self, cookie_text, *, uin=0, source="manual"):
+            bound.update({"cookie_text": cookie_text, "uin": uin, "source": source})
+            return {"cookie_count": 4, "needs_rebind": False, "login_uin": uin}
+
+    class _Event:
+        bot = object()
+
+    async def fake_fetch_cookie_text(bot, *, domain):
+        attempts.append(domain)
+        if len(attempts) < 3:
+            return ""
+        return "uin=o12345; p_uin=o12345; p_skey=secret; skey=secret"
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    plugin = object.__new__(main.QzoneStablePlugin)
+    plugin.settings = types.SimpleNamespace(auto_bind_cookie=True, cookie_domain="user.qzone.qq.com")
+    plugin.controller = _Controller()
+    plugin._onebot_client = None
+    plugin._cookie_lock = None
+    monkeypatch.setattr(main, "fetch_cookie_text", fake_fetch_cookie_text)
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+
+    result = asyncio.run(plugin._auto_bind_cookie(_Event(), source="test"))
+
+    assert len(attempts) == 3
+    assert sleeps == [main.AUTO_BIND_RETRY_DELAY_SECONDS, main.AUTO_BIND_RETRY_DELAY_SECONDS]
+    assert bound == {
+        "cookie_text": "uin=o12345; p_uin=o12345; p_skey=secret; skey=secret",
+        "uin": 12345,
+        "source": "test",
+    }
+    assert result["login_uin"] == 12345
+
+
+def test_auto_bind_cookie_fails_after_three_fetch_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    attempts = 0
+    sleeps: list[float] = []
+
+    class _Controller:
+        async def get_status(self, *, probe_daemon=False):
+            return {"cookie_count": 0, "needs_rebind": True}
+
+    class _Event:
+        bot = object()
+
+    async def fake_fetch_cookie_text(bot, *, domain):
+        nonlocal attempts
+        attempts += 1
+        return ""
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    plugin = object.__new__(main.QzoneStablePlugin)
+    plugin.settings = types.SimpleNamespace(auto_bind_cookie=True, cookie_domain="user.qzone.qq.com")
+    plugin.controller = _Controller()
+    plugin._onebot_client = None
+    plugin._cookie_lock = None
+    monkeypatch.setattr(main, "fetch_cookie_text", fake_fetch_cookie_text)
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(QzoneCookieAcquireError):
+        asyncio.run(plugin._auto_bind_cookie(_Event()))
+
+    assert attempts == 3
+    assert sleeps == [main.AUTO_BIND_RETRY_DELAY_SECONDS, main.AUTO_BIND_RETRY_DELAY_SECONDS]
+
+
+def test_aiocqhttp_capture_schedules_bootstrap_auto_bind_without_read_prob(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    captured: dict[str, object] = {}
+
+    class _Event:
+        bot = object()
+
+    plugin = object.__new__(main.QzoneStablePlugin)
+    plugin.settings = types.SimpleNamespace(auto_bind_cookie=True, read_prob=0.0)
+    plugin._onebot_client = None
+    plugin._auto_bind_bootstrap_task = None
+    plugin._auto_bind_bootstrap_succeeded = False
+
+    async def fake_bootstrap(trigger, event=None):
+        captured["trigger"] = trigger
+        captured["event"] = event
+        return True
+
+    plugin._bootstrap_auto_bind = fake_bootstrap
+
+    async def run_capture():
+        event = _Event()
+        await plugin.qzone_capture_aiocqhttp_client(event)
+        task = plugin._auto_bind_bootstrap_task
+        assert task is not None
+        await task
+        return event
+
+    event = asyncio.run(run_capture())
+
+    assert captured == {"trigger": "aiocqhttp capture", "event": event}
+    assert plugin._auto_bind_bootstrap_succeeded is True
+
+
+def test_initialize_schedules_auto_bind_without_waiting(monkeypatch: pytest.MonkeyPatch) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    bot = object()
+    started = False
+
+    async def run_initialize():
+        nonlocal started
+        blocker = asyncio.Event()
+        plugin = object.__new__(main.QzoneStablePlugin)
+        plugin.settings = types.SimpleNamespace(auto_bind_cookie=True, cookies_str="")
+        plugin._onebot_client = bot
+        plugin._auto_bind_bootstrap_task = None
+        plugin._auto_bind_bootstrap_succeeded = False
+        plugin._start_scheduled_tasks = lambda: None
+        plugin._capture_onebot_client_from_context = lambda: bot
+
+        async def fake_bootstrap(trigger, event=None):
+            nonlocal started
+            started = True
+            assert trigger == "initialize"
+            await blocker.wait()
+            return True
+
+        plugin._bootstrap_auto_bind = fake_bootstrap
+
+        await plugin.initialize()
+        task = plugin._auto_bind_bootstrap_task
+        assert task is not None
+        await asyncio.sleep(0)
+        assert started is True
+        assert not task.done()
+        blocker.set()
+        await task
+        assert plugin._auto_bind_bootstrap_succeeded is True
+
+    asyncio.run(run_initialize())
+
+
+def test_astrbot_loaded_schedules_auto_bind_without_waiting(monkeypatch: pytest.MonkeyPatch) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    bot = object()
+    started = False
+
+    async def run_loaded():
+        nonlocal started
+        blocker = asyncio.Event()
+        plugin = object.__new__(main.QzoneStablePlugin)
+        plugin.settings = types.SimpleNamespace(auto_bind_cookie=True)
+        plugin._onebot_client = bot
+        plugin._auto_bind_bootstrap_task = None
+        plugin._auto_bind_bootstrap_succeeded = False
+        plugin._start_scheduled_tasks = lambda: None
+        plugin._capture_onebot_client_from_context = lambda: bot
+
+        async def fake_bootstrap(trigger, event=None):
+            nonlocal started
+            started = True
+            assert trigger == "astrbot load"
+            await blocker.wait()
+            return True
+
+        plugin._bootstrap_auto_bind = fake_bootstrap
+
+        await plugin.qzone_on_astrbot_loaded()
+        task = plugin._auto_bind_bootstrap_task
+        assert task is not None
+        await asyncio.sleep(0)
+        assert started is True
+        assert not task.done()
+        blocker.set()
+        await task
+        assert plugin._auto_bind_bootstrap_succeeded is True
+
+    asyncio.run(run_loaded())
+
+
+def test_auto_bind_bootstrap_failure_can_be_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    bot = object()
+    attempts: list[str] = []
+
+    async def run_retries():
+        plugin = object.__new__(main.QzoneStablePlugin)
+        plugin.settings = types.SimpleNamespace(auto_bind_cookie=True)
+        plugin._onebot_client = bot
+        plugin._auto_bind_bootstrap_task = None
+        plugin._auto_bind_bootstrap_succeeded = False
+        plugin._capture_onebot_client_from_context = lambda: bot
+
+        async def fake_bootstrap(trigger, event=None):
+            attempts.append(trigger)
+            return len(attempts) > 1
+
+        plugin._bootstrap_auto_bind = fake_bootstrap
+
+        plugin._schedule_bootstrap_auto_bind("first")
+        first_task = plugin._auto_bind_bootstrap_task
+        assert first_task is not None
+        await first_task
+        assert plugin._auto_bind_bootstrap_succeeded is False
+
+        plugin._schedule_bootstrap_auto_bind("second")
+        second_task = plugin._auto_bind_bootstrap_task
+        assert second_task is not None
+        assert second_task is not first_task
+        await second_task
+        assert plugin._auto_bind_bootstrap_succeeded is True
+
+    asyncio.run(run_retries())
+    assert attempts == ["first", "second"]
+
+
+def test_aiocqhttp_capture_schedules_auto_bind_when_auto_read_is_ignored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    captured: dict[str, object] = {}
+
+    class _Event:
+        bot = object()
+
+        def get_group_id(self):
+            return 42
+
+        def get_sender_id(self):
+            return 7
+
+    plugin = object.__new__(main.QzoneStablePlugin)
+    plugin.settings = types.SimpleNamespace(
+        auto_bind_cookie=True,
+        read_prob=1.0,
+        ignore_groups=["42"],
+        ignore_users=[],
+    )
+    plugin._onebot_client = None
+    plugin._auto_bind_bootstrap_task = None
+    plugin._auto_bind_bootstrap_succeeded = False
+
+    async def fake_bootstrap(trigger, event=None):
+        captured["trigger"] = trigger
+        captured["event"] = event
+        return True
+
+    async def fail_if_called(*args, **kwargs):
+        raise AssertionError("ignored auto-read events should not synchronously bind")
+
+    plugin._bootstrap_auto_bind = fake_bootstrap
+    plugin._ensure_cookie_ready = fail_if_called
+
+    async def run_capture():
+        event = _Event()
+        await plugin.qzone_capture_aiocqhttp_client(event)
+        task = plugin._auto_bind_bootstrap_task
+        assert task is not None
+        await task
+        return event
+
+    event = asyncio.run(run_capture())
+
+    assert captured == {"trigger": "aiocqhttp capture", "event": event}
+    assert plugin._auto_bind_bootstrap_succeeded is True
+
+
+def test_terminate_cancels_auto_bind_bootstrap_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    closed = False
+
+    class _Controller:
+        async def close(self):
+            nonlocal closed
+            closed = True
+
+    async def run_terminate():
+        blocker = asyncio.Event()
+        plugin = object.__new__(main.QzoneStablePlugin)
+        plugin._scheduled_tasks = []
+        plugin._publisher_profile_preload_task = None
+        plugin._daemon_warmup_task = None
+        plugin._auto_bind_bootstrap_task = asyncio.create_task(blocker.wait())
+        plugin.controller = _Controller()
+
+        await plugin.terminate()
+
+        assert plugin._auto_bind_bootstrap_task is None
+
+    asyncio.run(run_terminate())
+    assert closed is True
+
+
+def test_auto_bind_cookie_reuses_ready_status_without_fetching(monkeypatch: pytest.MonkeyPatch) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+
+    class _Controller:
+        async def get_status(self, *, probe_daemon=False):
+            return {"cookie_count": 4, "needs_rebind": False, "login_uin": 12345}
+
+        async def bind_cookie_local(self, *args, **kwargs):
+            raise AssertionError("ready cookie state should not be rebound")
+
+    async def fail_fetch(*args, **kwargs):
+        raise AssertionError("ready cookie state should not fetch OneBot cookies")
+
+    plugin = object.__new__(main.QzoneStablePlugin)
+    plugin.settings = types.SimpleNamespace(auto_bind_cookie=True, cookie_domain="user.qzone.qq.com")
+    plugin.controller = _Controller()
+    plugin._onebot_client = object()
+    plugin._cookie_lock = None
+    monkeypatch.setattr(main, "fetch_cookie_text", fail_fetch)
+
+    result = asyncio.run(plugin._auto_bind_cookie())
+
+    assert result == {"cookie_count": 4, "needs_rebind": False, "login_uin": 12345}
 
 
 def test_remote_media_download_headers_do_not_send_qzone_cookie() -> None:


### PR DESCRIPTION
﻿## Summary
- auto-run Qzone autobind in a managed background task during plugin initialization/load and when aiocqhttp becomes available later
- retry automatic Cookie acquisition/binding up to 3 times before surfacing the failure, while allowing later events to retry after a failed bootstrap
- avoid duplicate background/synchronous binding on auto-read paths and keep ignored aiocqhttp events eligible for background autobind
- add CHANGELOG.md with a deep 0.3.0 release summary and historical capability baseline
- update config schema hints, README guidance, and bump plugin version to 0.3.0 because this is a user-visible capability expansion

## AstrBot review follow-up
- lifecycle hooks no longer await the network autobind retry loop
- bootstrap success/failure state is tracked separately so a failed first attempt does not permanently block future autobind
- terminate now cancels the autobind bootstrap task
- tests cover retry success/failure, non-blocking lifecycle scheduling, failed bootstrap retry, ignored auto-read events, task cleanup, and ready-cookie short circuiting

## Changelog / Versioning
- CHANGELOG.md now records the 0.3.0 update in Chinese, grouped by additions, optimizations, fixes, security/reliability, and validation
- metadata.yaml version is now 0.3.0 instead of 0.2.1

## Validation
- python -m py_compile main.py qzone_bridge\onebot_cookie.py qzone_bridge\controller.py qzone_bridge\daemon.py qzone_bridge\settings.py
- python -m pytest -q

Note: pytest passes with a cache warning because .pytest_cache is not writable in this local checkout.
