### PR TITLE
Add Qzone Pages UI, page APIs, and auto-comment pipeline

### DIFF
--- a/.astrbot-plugin/i18n/zh-CN.json
+++ b/.astrbot-plugin/i18n/zh-CN.json
@@ -1,0 +1,8 @@
+{
+  "pages": {
+    "qzone": {
+      "title": "QQ空间",
+      "description": "在 AstrBot WebUI 中查看、发布、点赞和评论说说。"
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## v0.5.0 - 2026-05-29
 
-- Added: A full AstrBot Pages surface for Qzone under `pages/qzone`, including feed browsing, detail view, publishing, image upload, likes, comments, replies, and safe self-post deletion.
-- Added: Browser-safe page APIs and controller wiring in `qzone_bridge/page_api.py`, with opaque post ids, redacted payloads, and AstrBot Pages bridge compatibility.
-- Added: An auto-comment pipeline in `qzone_bridge/auto_comment.py`, plus command/config/runtime wiring for staged judgment, reasoning, execution, and deduplicated persistence.
-- Improved: Local daemon compatibility, page/backend health checks, plugin-side security hardening, and Page-specific regression coverage across status/feed/detail/reply/upload flows.
-- Improved: The WebUI page UX with a redesigned three-pane layout, smoother detail/reply flows, round avatars, quantity-aware media layouts, and better image presentation for mixed aspect ratios.
+- 新增：`pages/qzone` AstrBot Pages 页面端能力，支持动态流浏览、详情查看、发布说说、图片上传、点赞、评论、回复，以及安全删除自己的说说。
+- 新增：`qzone_bridge/page_api.py` 页面后端接口与控制器接线，使用不透明说说标识、脱敏返回结构，并兼容 AstrBot Pages bridge。
+- 新增：`qzone_bridge/auto_comment.py` 自动评论流水线，补齐分阶段判断、推理、执行以及去重持久化相关的命令、配置和运行时接线。
+- 优化：本地 daemon 兼容性、页面与后端健康检查、插件侧安全加固，以及覆盖状态、列表、详情、回复、上传等流程的页面回归测试。
+- 优化：WebUI 页面体验，重构三栏布局、详情与回复交互、圆形头像、多图按数量自适应排版，以及混合比例图片的展示效果。
 
 ## v0.4.3 - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.5.0 - 2026-05-29
+
+- Added: A full AstrBot Pages surface for Qzone under `pages/qzone`, including feed browsing, detail view, publishing, image upload, likes, comments, replies, and safe self-post deletion.
+- Added: Browser-safe page APIs and controller wiring in `qzone_bridge/page_api.py`, with opaque post ids, redacted payloads, and AstrBot Pages bridge compatibility.
+- Added: An auto-comment pipeline in `qzone_bridge/auto_comment.py`, plus command/config/runtime wiring for staged judgment, reasoning, execution, and deduplicated persistence.
+- Improved: Local daemon compatibility, page/backend health checks, plugin-side security hardening, and Page-specific regression coverage across status/feed/detail/reply/upload flows.
+- Improved: The WebUI page UX with a redesigned three-pane layout, smoother detail/reply flows, round avatars, quantity-aware media layouts, and better image presentation for mixed aspect ratios.
+
+## v0.4.3 - 2026-05-27
+
+- Added: AstrBot WebUI Pages experience under `pages/qzone`, with feed browsing, publishing, image upload, detail view, likes, comments, replies, and self-post deletion.
+- Added: Page backend APIs that reuse the existing daemon/controller path while redacting raw Qzone internals from the browser.
+- Added: WebUI-specific regression coverage for raw-field redaction, pending like verification, sanitized publish flow, and delete safeguards.
+
 ## v0.4.2 - 2026-05-23
 
 - 修复：开启定时任务管理员反馈后，如果没有单独配置管理群或插件管理员，会自动使用 AstrBot 全局管理员作为私聊通知目标，避免任务已成功但管理员收不到渲染图。

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -35,6 +35,39 @@
         "_special": "select_provider",
         "hint": "留空时使用当前会话默认提供商。"
       },
+      "comment_pipeline_enabled": {
+        "description": "Auto-comment decision pipeline",
+        "type": "bool",
+        "default": true,
+        "hint": "Enable judgment, reasoning, and execution stages before scheduled auto-comments."
+      },
+      "comment_judgment_provider_id": {
+        "description": "Auto-comment judgment LLM provider",
+        "type": "string",
+        "default": "",
+        "_special": "select_provider",
+        "hint": "Optional provider used to decide whether a feed is appropriate to comment on."
+      },
+      "comment_reasoning_provider_id": {
+        "description": "Auto-comment reasoning LLM provider",
+        "type": "string",
+        "default": "",
+        "_special": "select_provider",
+        "hint": "Optional provider used to plan relationship stance and tone before writing."
+      },
+      "comment_execution_provider_id": {
+        "description": "Auto-comment execution LLM provider",
+        "type": "string",
+        "default": "",
+        "_special": "select_provider",
+        "hint": "Optional provider used to write the final auto-comment. Empty uses comment_provider_id."
+      },
+      "comment_skip_checkins": {
+        "description": "Skip low-signal check-ins",
+        "type": "bool",
+        "default": true,
+        "hint": "Skip short check-in style posts during the judgment stage."
+      },
       "comment_prompt": {
         "description": "评论说说提示词",
         "type": "text",

--- a/docs/qzone-pages-issue-log.md
+++ b/docs/qzone-pages-issue-log.md
@@ -1,0 +1,75 @@
+# QQ空间 Pages 问题记录
+
+这个文件记录 WebUI Pages 功能实施和验证时遇到的问题、根因、修复方式和回归用例，后续维护同类功能时先看这里。
+
+## 2026-05-27 实施阶段
+
+### 本地测试环境没有 quart
+
+- 症状：当前插件测试环境可以导入 `aiohttp` 和 `pytest`，但没有 `quart`；如果在模块顶层强依赖 `quart.request/jsonify`，单测导入会失败。
+- 根因：AstrBot WebUI 运行时提供 Web API 所需环境，但插件仓库的本地测试依赖没有直接安装 quart。
+- 修复：`main.py` 对 `quart` 做可选导入；真实 WebUI 中返回 `jsonify` 响应，本地测试中回退为普通 dict。
+- 回归用例：`python -m py_compile main.py qzone_bridge/page_api.py` 和 Page API 单测必须能在未安装 quart 的环境通过。
+
+### 浏览器不能接触 daemon secret 或 raw QQ空间字段
+
+- 症状：如果前端直连本地 daemon，必须暴露 `X-Qzone-Secret`，也容易把 `fid/raw/curkey/unikey` 带到页面。
+- 根因：AstrBot Pages 的安全模型要求 Page 通过 bridge 访问插件后端，不能绕过 Dashboard 鉴权。
+- 修复：新增 `qzone_bridge/page_api.py`，前端只拿到脱敏 `id`、展示内容和统计信息；点赞、评论、删除都通过 `id` 回到后端解码执行。
+- 回归用例：feed/detail 响应不得包含 `raw`、`fid`、`curkey`、`unikey`、`busi_param`、Cookie 或 daemon secret。
+
+### Base64 编码的 id 仍然会泄漏 fid
+
+- 症状：第一轮实现把 `{hostuin, fid, appid}` 做成 base64-url 字符串返回给前端，虽然字段名不叫 `fid`，但浏览器可以直接解码拿到真实 fid。
+- 根因：编码不是脱敏；只要令牌包含可逆载荷，就仍然属于内部字段泄漏。
+- 修复：改成服务端内存中的不透明随机 token，`fid` 只保存在 `QzonePageApi` 的后端映射中；页面刷新后如果 token 失效，会提示刷新列表重试。
+- 回归用例：Page feed 测试必须确认 `post.id` 不包含真实 `fid`、`curkey` 等内部值，同时仍能通过后端映射执行详情/点赞/评论。
+
+### 点赞读回延迟不能误报失败
+
+- 症状：QQ空间已接受点赞请求，但读取状态可能短时间未同步。
+- 根因：历史上把 `verified=false` 当成失败会造成“实际成功却报错”的坏体验。
+- 修复：Page API 保留 `ok=true`，并把 `verified=false` 映射为 `operation_status=accepted_pending_verification`；前端提示“QQ空间已接受操作，读回状态可能稍后同步”。
+- 回归用例：`page/like` 在 controller 返回 `verified: false` 时仍返回成功。
+
+### WebUI 发布不能复活 qzone post 前缀泄漏
+
+- 症状：历史命令链路曾出现 `/qzone post` 或 `qzone post` 被一起发到说说里的问题。
+- 根因：聊天命令需要剥离命令前缀，WebUI 文本框则应被视为已经是正文，两种入口混用会出错。
+- 修复：WebUI 发布直接调用 `controller.publish_post(..., content_sanitized=True)`，不再经过命令文本解析。
+- 回归用例：Page API 发布 `qzone post literal` 时传给 controller 的内容必须保持原样，且 `content_sanitized=True`。
+
+### 插件文件更新后仍显示旧 daemon 版本
+
+- 症状：实际插件目录更新后，WebUI 或 `/qzone status` 仍可能显示旧的 daemon 版本号。
+- 根因：controller 只检查 `bridge_api_version` 是否兼容，没有检查运行中的 daemon `daemon_version` 是否等于当前插件版本；API 版本未变时会复用旧 daemon。
+- 修复：`_health_payload_is_compatible()` 同时要求 `daemon_version == BRIDGE_VERSION`，版本不一致时关闭旧 daemon 并启动新进程。
+- 回归用例：插件版本升级但 `BRIDGE_API_VERSION` 不变时，重载后 daemon 也必须切换到新版本。
+
+### Page API 只记录 Permission denied，缺少 traceback
+
+- 症状：WebUI Page 能打开，但页面请求失败；AstrBot 只打印 `qzone page api failed: [Errno 13] Permission denied`，无法定位具体文件或调用点。
+- 根因：Page API 的统一异常处理只记录异常字符串，没有 `exc_info`、路由和 callback 名称；Windows 下文件/进程权限问题经常只显示 `Permission denied`。
+- 修复：`_page_json()` 记录路由、callback 和完整 traceback；`PermissionError` 返回脱敏的 `PAGE_PERMISSION_DENIED`，不把本地路径或内部细节暴露给前端。
+- 回归用例：后续 Page API 异常日志必须能直接看到堆栈；前端只能看到安全错误码和提示。
+
+### daemon.log 被占用或拒绝访问时不应拖垮 Page
+
+- 症状：运行中旧 daemon/重复 AstrBot 进程可能持有 `daemon.log`，新版本在恢复 daemon 时如果打开日志失败，会把系统 `PermissionError` 透出到 Page。
+- 根因：`_spawn_daemon()` 把 `daemon.log` 当成启动前置条件，日志不可写就无法启动 daemon；这类故障在 Windows 文件锁场景更容易出现。
+- 修复：新增 daemon 日志 fallback：优先写插件数据目录的 `daemon.log`，失败时写系统临时目录 `astrbot_qzone_daemon_logs`，再失败才退到 `os.devnull`。
+- 回归用例：`daemon.log` 是不可写路径时，`_spawn_daemon()` 仍能调用 `subprocess.Popen`，且 stdout/stderr 指向 fallback 日志。
+
+### 本地文件已是 0.4.3，但运行时仍启动 0.4.2 daemon
+
+- 症状：插件目录中的 `metadata.yaml`、`qzone_bridge/__init__.py` 已经是 `0.4.3`，但正在运行的 AstrBot 仍在 21:14 启动 `--version 0.4.2` 的 daemon。
+- 根因：AstrBot 主进程在部分文件同步前已经导入旧版 `qzone_bridge`，后续只复制文件或 WebUI 软重载没有清掉进程内旧模块；旧主进程继续用内存中的 `BRIDGE_VERSION=0.4.2` 启动 daemon。
+- 修复：本地更新后必须停止旧 daemon/重复 AstrBot 进程，清理插件 `__pycache__`，再让 AstrBot 主进程重新导入插件；代码侧保留 daemon 版本兼容检查，防止重启后继续复用旧 daemon。
+- 回归用例：更新后检查正在运行的 `daemon_main.py --version`、`state.json.runtime.version` 和 WebUI 插件版本必须同时是目标版本。
+
+### Page 一直停在“正在连接 / 未读取 / 等待状态”
+
+- 症状：Pages 页面已经能打开，后端 `page/status`、`page/feed` 也能返回成功，但 iframe 内 UI 一直停留在初始文案，像是没有读到状态。
+- 根因：AstrBot WebUI 的 Pages bridge 会把插件 API 响应的 `response.data.data` 再剥一层传给 iframe；插件前端仍按未剥开的 `{ok, data}` 判断，导致成功业务对象被误判为失败，状态渲染没有发生。
+- 修复：前端统一归一化 bridge 回包，同时兼容 `{ok, data}`、AstrBot 已剥开的业务对象和 `status:error` 形状；`bridge.ready()`、API 请求、上传请求增加超时提示，避免再次无提示卡死。
+- 回归用例：`tests/test_qzone_page_frontend.py` 用 Node 模拟 AstrBot 已剥开的 bridge 响应，要求状态、账号、动态列表和上传图片都能正常渲染。

--- a/docs/qzone-pages-performance-issue-log-2026-05-28.md
+++ b/docs/qzone-pages-performance-issue-log-2026-05-28.md
@@ -1,0 +1,70 @@
+# QQ空间 Pages 后端体验优化记录 2026-05-28
+
+## 按钮点击后会卡一下
+
+- 症状：点赞、评论、回复、发布在点击后会先等待后端状态恢复、daemon 探活或 QQ 空间读回校验，UI 体感像卡住。
+- 根因：Page API 写操作先走 `_ensure_ready()`，随后 controller 请求 daemon 又走 `ensure_running()`；点赞还会做多次读回校验。
+- 修复：Page 写操作改为本地 Cookie 快速校验，daemon 启动/探活交给 controller 请求层；Pages 点赞传 `fast=True`，先接受成功并更新 UI 与 daemon 缓存。
+- 回归：`tests/test_page_api.py` 覆盖 Page 点赞必须传 `fast=True`，且 daemon state 为 `degraded` 时不会被前置 readiness gate 卡住。
+
+## 插件加载和 Pages 首屏预热不足
+
+- 症状：AstrBot 重载或插件更新后，Pages 首次打开可能一边加载页面一边启动 daemon，首个 feed/detail 请求偏慢。
+- 根因：原有预热主要启动 daemon，没有在 Pages 入口和插件加载后预先拉取首屏 feed 填充 daemon 缓存。
+- 修复：插件 initialize/loaded 和 Page status/feed/detail 等入口去重调度后台预热：刷新 Cookie、启动 daemon、预拉 active feed，并用 45 秒节流避免频繁请求 QQ 空间。
+- 回归：预热任务失败只记 debug 日志，不阻塞 Page API 正常响应。
+
+## feed 卡片与详情点赞状态不一致
+
+- 症状：在预览卡片点赞后进入详情，或在详情点赞后回到列表，可能出现一边显示已赞、一边显示未赞。
+- 根因：前端 feed/detail 曾经各自持有对象并分开更新；daemon fast like 更新 `feed_cache` 和 `recent_feed_entries` 时，如果二者指向同一个 `FeedEntry`，like_count 可能重复加减。
+- 修复：前端统一通过 `updatePost/mergePost` 合并状态，并增加点赞并发保护；daemon fast like 只在 `liked` 真实变化时增减计数，并按对象 id 去重。
+- 回归：同一 `FeedEntry` 同时位于 `feed_cache` 与 `recent_feed_entries` 时，fast like 第一次只 +1，重复点赞不再继续 +1。
+
+## 多余换行与测试环境兼容
+
+- 症状：部分说说或评论展示会保留多余空白/换行；Node 前端烟测环境缺少 `document.querySelector` 会导致 app 初始化失败。
+- 根因：文本清洗只处理了部分行尾空格；前端初始化直接调用 DOM 查询 API，没有兼容最小测试 DOM。
+- 修复：展示文本额外清理行首空白；DOM 查询增加 `queryOne/queryAll` 安全封装。
+- 回归：`tests/test_qzone_page_frontend.py` 覆盖 AstrBot Pages bridge 解包和前端初始化。
+
+## Pages 预热不能污染聊天侧“最近说说”
+
+- 症状：如果后台预热调用普通 feed 列表接口，daemon 的 `recent_feed_entries` 会被 Pages 首屏数据覆盖，聊天命令或 LLM 工具里的“最新/第 N 条”可能指向页面预热过的内容。
+- 根因：daemon 的 `list_feeds()` 默认会把当前列表写入全局 recent 引用缓存，这个缓存是聊天选择语义的一部分，不应该被 Pages 后台预热改写。
+- 修复：feed 链路新增 `record_recent` 参数。聊天侧默认保持 `True`，Pages 和后台预热使用 `False`，只填充 `feed_cache`，不覆盖 recent 引用。
+- 回归：`tests/test_page_api.py` 覆盖 Page feed 必须传 `record_recent=False`，以及 daemon 在 `record_recent=False` 时不覆盖原 recent 列表。
+
+## 乐观评论/回复不能整表回滚
+
+- 症状：用户在评论请求未完成时切换详情，或连续发送多条评论/回复，一个请求失败可能把另一条已经成功或仍在发送的评论覆盖掉。
+- 根因：成功和失败分支读取 `state.selected.comments` 或旧 comments 整表回滚，依赖当前选中的详情面板，缺少按 temp id 的精确替换/删除。
+- 修复：前端新增按 post id 查找当前目标说说，评论/回复成功只替换自己的临时 id，失败只删除自己的临时 id，并只在确实存在临时项时回退评论计数。
+- 回归：后续修改 Pages 评论状态时，不能使用旧 comments 整表覆盖当前 post 状态。
+
+## AstrBot 软重载后 page_api 子模块仍是旧构造函数
+
+- 症状：插件加载失败，日志显示 `TypeError: QzonePageApi.__init__() got an unexpected keyword argument 'preload_scheduler'`，但磁盘上的 `qzone_bridge/page_api.py` 已经包含该参数。
+- 根因：AstrBot 软重载重新导入了 `main.py`，但 Python 进程里的 `qzone_bridge.page_api` 旧模块仍留在 `sys.modules`；已有本地包自愈加载器只检查 renderer/social 等旧契约，没有检查 Pages 新增签名。
+- 修复：把 `QzonePageApi.__init__(preload_scheduler=...)`、`QzoneDaemonController.list_feeds(record_recent=...)`、`QzoneDaemonService.list_feeds(record_recent=...)` 加入本地 `qzone_bridge` 契约检查。签名不匹配时自动驱逐旧 `qzone_bridge.*` 子模块并从当前插件目录重新导入。
+- 回归：`tests/test_security_hardening.py::test_main_import_recovers_from_stale_page_api_constructor` 模拟旧构造函数缓存，要求重新导入 `main.py` 后拿到新 `QzonePageApi`。
+
+## 评论回复按钮无反应、自己的评论昵称/布局异常、详情打开慢
+
+- 症状：Pages 详情里点击评论的“回复”没有明显反应；自己刚发的评论或回复显示成 `QQ 号` 而不是昵称；有回复按钮和没有回复按钮的评论行位置不一致；点击“查看详情”需要等后端详情接口返回后才出现内容；左上角还保留了“QQ空间Ultra / daemon 已就绪”的品牌块。
+- 根因：前端回复使用 `window.prompt()`，在 AstrBot WebUI iframe/WebView 里容易被拦截或没有可见反馈；评论布局用 `space-between`，右侧按钮会改变正文列位置；Page comment/reply 返回体没有当前登录作者，详情评论也没有用登录作者修正自己的昵称；详情打开流程先等待网络详情再渲染；头部品牌块和状态文案仍写在 HTML/JS 契约里。
+- 修复：回复改为评论下方内联表单，发送后沿用现有乐观更新和精确回滚；评论行改成固定头像/正文/操作三列网格；Page comment/reply/publish/detail 返回或修正登录作者，前端维护 `knownAuthors` 并避免把当前用户回退成 `QQ <uin>`；详情先用 feed/selected 缓存即时渲染，再后台同步详情，并用请求序号避免旧响应污染新详情；删除品牌块，账号卡只显示昵称和小号 QQ 号。
+- 回归：`tests/test_qzone_page_frontend.py` 覆盖无 `statusText` 初始化、品牌块删除、缓存详情即时渲染、回复不再调用 `window.prompt()`、内联回复表单和当前昵称复用；`tests/test_page_api.py` 覆盖 comment/reply/publish 返回当前作者以及详情里自己的评论昵称修正。
+
+## 子审查发现：详情旧响应覆盖本地操作、昵称预热耦合渲染开关
+
+- 症状：如果用户打开详情后马上点赞、评论或回复，慢返回的 `page/detail` 可能把本地刚更新的 `liked/stats/comments` 覆盖回旧状态；当 `render_publish_result=false` 时，Pages 当前账号昵称/头像预热可能被跳过。
+- 根因：详情接口返回后直接浅合并整条 post，缺少“请求期间是否发生本地修改”的版本保护；账号资料复用了发布结果图片渲染的预热任务，而该任务受发布渲染开关控制。
+- 修复：前端给每条说说维护 `localVersions`，本地点赞/评论/回复成功、失败、乐观阶段都会递增；详情返回时若版本变化，保留本地 `liked/stats/comments`，并把远端新增评论按 id 合并进来。回复提交阶段增加 `pendingReplies` 和 `replyDrafts`，慢请求时不会重复提交，失败后恢复回复框。后端新增独立登录资料预热路径，`render_publish_result=false` 时仍会通过 OneBot 快速补齐 `login_nickname/login_avatar`。
+- 回归：`tests/test_qzone_page_frontend.py` 覆盖 stale detail 不能覆盖本地回复；`tests/test_security_hardening.py::test_page_status_profile_fetch_is_independent_from_publish_rendering` 覆盖关闭发布渲染时仍能补齐 Pages 登录昵称头像。
+
+## 头像不显示、图片上传大小限制、命令无描述
+- 症状：Pages 左上角账号头像和说说头像会显示为空或露出 `Avatar` 文本；超过旧 8MB/32MB 的图片会被插件本地拦截并提示“图片大小超过限制”；AstrBot 指令列表显示“无描述”。
+- 根因：前端头像默认使用 `http://q1.qlogo.cn...`，在 WebUI 安全上下文里容易被混合内容/头像源失败拦截，且失败时没有回退；Pages API 有 8MB 固定限制，底层客户端对 base64/URL/本地图片还有 32MB 固定限制；命令函数没有 docstring，AstrBot 的 `get_handler_or_create()` 只能拿到空描述。
+- 修复：头像统一改为 HTTPS QQ 头像源，增加 qlogo 备用源和首字母回退，不再渲染 `Avatar` alt 文本；移除插件侧固定图片大小限制，仅保留空内容和图片类型校验；为所有 AstrBot 命令补充简短中文 docstring，供命令列表读取。
+- 回归：新增 `tests/test_command_descriptions.py`，并在 `tests/test_qzone_page_frontend.py`、`tests/test_page_api.py`、`tests/test_security_hardening.py` 覆盖 HTTPS 头像/失败回退、Pages 上传不限本地大小、底层 base64 不再按固定阈值拦截。

--- a/main.py
+++ b/main.py
@@ -23,10 +23,17 @@ from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, filter
 from astrbot.api.star import Context, Star
 
+try:
+    from quart import jsonify as _quart_jsonify
+    from quart import request as _quart_request
+except Exception:
+    _quart_jsonify = None
+    _quart_request = None
+
 PLUGIN_ROOT = Path(__file__).resolve().parent
 PLUGIN_DATA_NAME_FALLBACK = "astrbot_plugin_qzone_ultra"
-REQUIRED_QZONE_BRIDGE_API_VERSION = 2026052305
-LEGACY_MIGRATION_FILES = ("state.json", "drafts.json", "posts.json")
+REQUIRED_QZONE_BRIDGE_API_VERSION = 2026052901
+LEGACY_MIGRATION_FILES = ("state.json", "drafts.json", "posts.json", "auto_comment_state.json")
 LEGACY_MIGRATION_SENTINEL = ".legacy-qzone-migration.json"
 LEGACY_MIGRATION_LOCK = ".legacy-qzone-migration.lock"
 AUTO_BIND_RETRY_ATTEMPTS = 3
@@ -435,8 +442,13 @@ def _standard_data_dir(plugin_root: Path) -> Path:
     plugin_name = _read_plugin_name(plugin_root)
     data_dir = _star_tools_data_dir(plugin_name)
     if data_dir is None:
-        return plugin_root / "data" / "qzone"
+        data_dir = plugin_root / "data" / "plugin_data" / plugin_name
     _migrate_legacy_data_dir(plugin_root / "data" / "qzone", data_dir)
+    try:
+        data_dir.mkdir(parents=True, exist_ok=True)
+        _chmod_private_dir(data_dir)
+    except Exception as exc:
+        logger.warning("qzone standard data dir is not writable: %s", exc)
     return data_dir
 
 
@@ -520,6 +532,28 @@ def _qzone_bridge_contract_is_current(package_root: Path) -> bool:
             for attribute in attributes:
                 if getattr(cls, attribute, None) is None:
                     return False
+
+    signature_contracts = {
+        "qzone_bridge.controller": {"QzoneDaemonController.list_feeds": "record_recent"},
+        "qzone_bridge.daemon": {"QzoneDaemonService.list_feeds": "record_recent"},
+        "qzone_bridge.page_api": {"QzonePageApi.__init__": "preload_scheduler"},
+    }
+    for module_name, members in signature_contracts.items():
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        _verify_local_qzone_bridge_module(module_name, package_root)
+        for dotted_name, parameter in members.items():
+            target: Any = module
+            for part in dotted_name.split("."):
+                target = getattr(target, part, None)
+                if target is None:
+                    return False
+            try:
+                if parameter not in inspect.signature(target).parameters:
+                    return False
+            except (TypeError, ValueError):
+                return False
     return True
 
 
@@ -566,6 +600,12 @@ def _load_local_qzone_bridge_package() -> None:
 
 _load_local_qzone_bridge_package()
 
+from qzone_bridge.auto_comment import (
+    AutoCommentPipeline,
+    AutoCommentPipelineConfig,
+    AutoCommentPipelineResult,
+    AutoCommentStateStore,
+)
 from qzone_bridge.controller import QzoneDaemonController
 from qzone_bridge.drafts import DraftPost, DraftStore
 from qzone_bridge.errors import DaemonUnavailableError, QzoneBridgeError, QzoneCookieAcquireError, QzoneNeedsRebind
@@ -574,6 +614,7 @@ from qzone_bridge.media import PostMedia, PostPayload, collect_post_payload, nor
 from qzone_bridge.models import FeedEntry
 from qzone_bridge.onebot_cookie import fetch_cookie_text
 from qzone_bridge.parser import normalize_uin, parse_cookie_text
+from qzone_bridge.page_api import QzonePageApi, page_error_payload
 from qzone_bridge.post_service import QzonePostService
 from qzone_bridge.posts import PostStore
 import qzone_bridge.publish_renderer as _publish_renderer
@@ -795,6 +836,7 @@ class QzoneStablePlugin(Star):
         raw_config = config if config is not None else getattr(context, "get_config", lambda: {})()
         self.settings = PluginSettings.from_mapping(raw_config)
         self.root = Path(__file__).resolve().parent
+        self.plugin_name = _read_plugin_name(self.root)
         self.data_dir = _standard_data_dir(self.root)
         self._onebot_client: Any | None = None
         self._cookie_lock: asyncio.Lock | None = None
@@ -811,6 +853,9 @@ class QzoneStablePlugin(Star):
         self._capture_onebot_client_from_context()
         self._daemon_warmup_task: asyncio.Task | None = None
         self._auto_bind_bootstrap_task: asyncio.Task | None = None
+        self._page_preload_task: asyncio.Task | None = None
+        self._page_feed_preload_task: asyncio.Task | None = None
+        self._last_page_feed_preload_at = 0.0
         self._auto_bind_bootstrap_succeeded = False
         self._scheduled_tasks: list[asyncio.Task] = []
         self._publisher_profile_cache: tuple[int, RenderProfile] | None = None
@@ -818,9 +863,17 @@ class QzoneStablePlugin(Star):
         self.drafts = DraftStore(self.data_dir / "drafts.json")
         self.posts = PostStore(self.data_dir / "posts.json")
         self.llm = QzoneLLM(self._context, self.settings)
+        self.page_api = QzonePageApi(
+            controller=self.controller,
+            post_service_factory=self._post_service,
+            settings=self.settings,
+            status_provider=self._status_with_recovery,
+            preload_scheduler=self._schedule_page_preload,
+        )
         self._pillowmd_style: Any | None = None
         self._pillowmd_style_dir = ""
         preload_static_render_assets()
+        self._register_page_web_apis()
 
     def _sender_id(self, event: AstrMessageEvent) -> int:
         try:
@@ -858,6 +911,136 @@ class QzoneStablePlugin(Star):
             self._post_store(),
             max_feed_limit=self.settings.max_feed_limit,
         )
+
+    def _register_page_web_apis(self) -> None:
+        context = getattr(self, "_context", None) or getattr(self, "context", None)
+        register = getattr(context, "register_web_api", None)
+        if not callable(register):
+            return
+        routes = (
+            ("page/status", self.page_status, ["GET"], "Qzone Page status"),
+            ("page/feed", self.page_feed, ["GET"], "Qzone Page feed"),
+            ("page/detail", self.page_detail, ["GET"], "Qzone Page detail"),
+            ("page/publish", self.page_publish, ["POST"], "Qzone Page publish"),
+            ("page/like", self.page_like, ["POST"], "Qzone Page like"),
+            ("page/comment", self.page_comment, ["POST"], "Qzone Page comment"),
+            ("page/reply", self.page_reply, ["POST"], "Qzone Page reply"),
+            ("page/delete", self.page_delete, ["POST"], "Qzone Page delete"),
+            ("page/upload-media", self.page_upload_media, ["POST"], "Qzone Page upload media"),
+        )
+        for endpoint, handler, methods, description in routes:
+            path = f"/{self.plugin_name}/{endpoint}"
+            try:
+                register(path, handler, methods, description)
+            except TypeError:
+                register(path, handler, methods)
+
+    async def _page_response(self, payload: dict[str, Any], *, status: int = 200):
+        if _quart_jsonify is None:
+            return payload
+        response = _quart_jsonify(payload)
+        response.status_code = status
+        return response
+
+    async def _page_json(self, callback):
+        try:
+            payload = await callback()
+            status = 200
+        except Exception as exc:
+            payload, status = page_error_payload(exc)
+            try:
+                request_path = str(getattr(_quart_request, "path", "") or "")
+            except Exception:
+                request_path = ""
+            callback_name = getattr(callback, "__qualname__", getattr(callback, "__name__", type(callback).__name__))
+            logger.warning(
+                "qzone page api failed route=%s callback=%s: %s",
+                request_path,
+                callback_name,
+                exc,
+                exc_info=True,
+            )
+        return await self._page_response(payload, status=status)
+
+    async def _page_query_params(self) -> dict[str, Any]:
+        request = _quart_request
+        if request is None:
+            return {}
+        args = getattr(request, "args", {}) or {}
+        try:
+            items = args.items(multi=False)
+        except TypeError:
+            items = args.items() if hasattr(args, "items") else []
+        try:
+            return {str(key): value for key, value in items}
+        except TypeError:
+            return dict(args)
+
+    async def _page_json_body(self) -> dict[str, Any]:
+        request = _quart_request
+        if request is None:
+            return {}
+        getter = getattr(request, "get_json", None)
+        data: Any = None
+        if callable(getter):
+            try:
+                data = await self._maybe_await(getter(silent=True))
+            except TypeError:
+                data = await self._maybe_await(getter())
+        if data is None:
+            data = await self._maybe_await(getattr(request, "json", None))
+        return data if isinstance(data, dict) else {}
+
+    async def page_status(self):
+        return await self._page_json(self.page_api.status)
+
+    async def page_feed(self):
+        params = await self._page_query_params()
+        return await self._page_json(lambda: self.page_api.feed(params))
+
+    async def page_detail(self):
+        params = await self._page_query_params()
+        return await self._page_json(lambda: self.page_api.detail(params))
+
+    async def page_publish(self):
+        body = await self._page_json_body()
+        return await self._page_json(lambda: self.page_api.publish(body))
+
+    async def page_like(self):
+        body = await self._page_json_body()
+        return await self._page_json(lambda: self.page_api.like(body))
+
+    async def page_comment(self):
+        body = await self._page_json_body()
+        return await self._page_json(lambda: self.page_api.comment(body))
+
+    async def page_reply(self):
+        body = await self._page_json_body()
+        return await self._page_json(lambda: self.page_api.reply(body))
+
+    async def page_delete(self):
+        body = await self._page_json_body()
+        return await self._page_json(lambda: self.page_api.delete(body))
+
+    async def page_upload_media(self):
+        async def handle_upload():
+            request = _quart_request
+            if request is None:
+                raise QzoneBridgeError("当前运行环境不支持 Page 文件上传")
+            files = await self._maybe_await(getattr(request, "files", None))
+            upload = None
+            if hasattr(files, "get"):
+                upload = files.get("file") or files.get("image") or files.get("media")
+            if upload is None:
+                raise QzoneBridgeError("没有收到图片文件")
+            data = await self._maybe_await(upload.read())
+            return await self.page_api.upload_media(
+                filename=getattr(upload, "filename", "") or "image.jpg",
+                content_type=getattr(upload, "content_type", "") or "",
+                data=data or b"",
+            )
+
+        return await self._page_json(handle_upload)
 
     def _llm_adapter(self) -> QzoneLLM:
         self.llm.context = getattr(self, "_context", None) or getattr(self, "context", None)
@@ -949,6 +1132,7 @@ class QzoneStablePlugin(Star):
         *,
         status: dict[str, Any] | None = None,
         allow_network: bool = False,
+        cache_assets: bool = True,
     ) -> RenderProfile:
         profile = profile_from_event(event) if event is not None else RenderProfile(time_text=time.strftime("%H:%M"))
         if status is None:
@@ -962,7 +1146,10 @@ class QzoneStablePlugin(Star):
             return profile
 
         cached = self._cached_publisher_profile(login_uin, time_text=profile.time_text)
-        if cached is not None:
+        if cached is not None and (
+            not allow_network
+            or _clean_nickname_fallback(getattr(cached, "nickname", ""), hostuin=login_uin)
+        ):
             return cached
 
         nickname = str(
@@ -992,6 +1179,16 @@ class QzoneStablePlugin(Star):
             avatar_source=avatar_source or self._qlogo_url(login_uin, 640),
             time_text=profile.time_text,
         )
+        if not cache_assets:
+            cached_profile = RenderProfile(
+                nickname=base_profile.nickname,
+                user_id=base_profile.user_id,
+                avatar_source=base_profile.avatar_source,
+                time_text="",
+            )
+            self._publisher_profile_cache = (login_uin, cached_profile)
+            return self._clone_render_profile(cached_profile, time_text=profile.time_text)
+
         cached_avatar = cached_avatar_source(self._render_asset_dir(), base_profile)
         if cached_avatar:
             cached_profile = RenderProfile(
@@ -1050,6 +1247,39 @@ class QzoneStablePlugin(Star):
                 return result
         return {}
 
+    def _cached_profile_has_display_name(self, login_uin: int) -> bool:
+        cached = self._cached_publisher_profile(login_uin, time_text="")
+        if cached is None:
+            return False
+        return bool(_clean_nickname_fallback(getattr(cached, "nickname", ""), hostuin=login_uin))
+
+    def _schedule_login_profile_preload(
+        self,
+        trigger: str,
+        *,
+        event: AstrMessageEvent | None = None,
+        status: dict[str, Any] | None = None,
+    ) -> None:
+        login_uin = int((status or {}).get("login_uin") or (status or {}).get("uin") or 0)
+        if login_uin and self._cached_profile_has_display_name(login_uin):
+            return
+        task = getattr(self, "_publisher_profile_preload_task", None)
+        if task is not None and not task.done():
+            return
+
+        async def runner() -> None:
+            try:
+                await self._publisher_render_profile(
+                    event,
+                    status=status,
+                    allow_network=True,
+                    cache_assets=False,
+                )
+            except Exception:
+                logger.debug("qzone login profile preload on %s failed", trigger, exc_info=True)
+
+        self._publisher_profile_preload_task = asyncio.create_task(runner())
+
     def _schedule_publish_render_asset_preload(
         self,
         trigger: str,
@@ -1058,9 +1288,10 @@ class QzoneStablePlugin(Star):
         status: dict[str, Any] | None = None,
     ) -> None:
         if not self.settings.render_publish_result:
+            self._schedule_login_profile_preload(trigger, event=event, status=status)
             return
         login_uin = int((status or {}).get("login_uin") or 0)
-        if login_uin and self._cached_publisher_profile(login_uin, time_text="") is not None:
+        if login_uin and self._cached_profile_has_display_name(login_uin):
             return
         task = self._publisher_profile_preload_task
         if task is not None and not task.done():
@@ -1535,6 +1766,47 @@ class QzoneStablePlugin(Star):
             payload["detail"] = detail
         return payload
 
+    def _status_with_cached_profile(self, status: dict[str, Any]) -> dict[str, Any]:
+        enriched = dict(status or {})
+        login_uin = int(enriched.get("login_uin") or enriched.get("uin") or 0)
+        if not login_uin:
+            return enriched
+        cached = self._cached_publisher_profile(login_uin, time_text="")
+        if cached is None:
+            return enriched
+        nickname = _clean_nickname_fallback(getattr(cached, "nickname", ""), hostuin=login_uin)
+        if nickname and not _clean_nickname_fallback(enriched.get("login_nickname") or enriched.get("nickname"), hostuin=login_uin):
+            enriched["login_nickname"] = nickname
+        avatar = str(getattr(cached, "avatar_source", "") or "").strip()
+        if avatar and not str(enriched.get("login_avatar") or enriched.get("avatar") or "").strip():
+            enriched["login_avatar"] = avatar
+        return enriched
+
+    async def _status_with_live_profile(self, status: dict[str, Any]) -> dict[str, Any]:
+        enriched = self._status_with_cached_profile(status)
+        login_uin = int(enriched.get("login_uin") or enriched.get("uin") or 0)
+        if not login_uin:
+            return enriched
+        if _clean_nickname_fallback(enriched.get("login_nickname") or enriched.get("nickname"), hostuin=login_uin):
+            return enriched
+        if self._capture_onebot_client(None) is None:
+            self._schedule_login_profile_preload("status missing profile", status=enriched)
+            return enriched
+        try:
+            await asyncio.wait_for(
+                self._publisher_render_profile(
+                    None,
+                    status=enriched,
+                    allow_network=True,
+                    cache_assets=False,
+                ),
+                timeout=0.9,
+            )
+        except Exception:
+            self._schedule_login_profile_preload("status live fallback", status=enriched)
+            return enriched
+        return self._status_with_cached_profile(enriched)
+
     async def _status_with_recovery(self) -> dict[str, Any]:
         status = await self.controller.get_status()
         should_start = (
@@ -1544,10 +1816,12 @@ class QzoneStablePlugin(Star):
             and not bool(status.get("needs_rebind"))
         )
         if not should_start:
+            status = await self._status_with_live_profile(status)
             self._schedule_publish_render_asset_preload("status", status=status)
             return status
         try:
             recovered = await self.controller.ensure_running()
+            recovered = await self._status_with_live_profile(recovered)
             self._schedule_publish_render_asset_preload("status recovery", status=recovered)
             return recovered
         except QzoneBridgeError as exc:
@@ -1558,6 +1832,7 @@ class QzoneStablePlugin(Star):
             logger.warning("qzone daemon status recovery failed: %s detail=%s", exc.message, detail_text)
             fallback = await self.controller.get_status(probe_daemon=False)
             fallback["daemon_start_error"] = self._status_error_payload(exc)
+            fallback = await self._status_with_live_profile(fallback)
             self._schedule_publish_render_asset_preload("status fallback", status=fallback)
             return fallback
 
@@ -2252,26 +2527,14 @@ class QzoneStablePlugin(Star):
     def _auto_comment_state_path(self) -> Path:
         return self.data_dir / "auto_comment_state.json"
 
+    def _auto_comment_state_store(self) -> AutoCommentStateStore:
+        return AutoCommentStateStore(self._auto_comment_state_path())
+
     def _load_auto_comment_keys(self) -> set[str]:
-        path = self._auto_comment_state_path()
-        if not path.exists():
-            return set()
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except Exception:
-            return set()
-        items = payload.get("commented") if isinstance(payload, dict) else payload
-        if not isinstance(items, list):
-            return set()
-        return {str(item) for item in items if item}
+        return self._auto_comment_state_store().read_keys()
 
     def _save_auto_comment_keys(self, keys: set[str]) -> None:
-        path = self._auto_comment_state_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(
-            json.dumps({"commented": sorted(keys)[-500:]}, ensure_ascii=False, indent=2) + "\n",
-            encoding="utf-8",
-        )
+        self._auto_comment_state_store().write_keys(keys)
 
     def _auto_comment_key(self, post: QzonePost | FeedEntry) -> str:
         return f"{int(getattr(post, 'hostuin', 0) or 0)}:{getattr(post, 'fid', '')}"
@@ -2391,6 +2654,39 @@ class QzoneStablePlugin(Star):
 
     async def _generate_comment_text(self, event: AstrMessageEvent, post: QzonePost) -> str:
         return await self._llm_adapter().generate_comment_text(event, post)
+
+    async def _generate_auto_comment_pipeline(self, post: QzonePost) -> AutoCommentPipelineResult:
+        config = AutoCommentPipelineConfig(
+            enabled=bool(getattr(self.settings, "comment_pipeline_enabled", True)),
+            judgment_provider_id=str(getattr(self.settings, "comment_judgment_provider_id", "") or ""),
+            reasoning_provider_id=str(getattr(self.settings, "comment_reasoning_provider_id", "") or ""),
+            execution_provider_id=str(getattr(self.settings, "comment_execution_provider_id", "") or ""),
+            skip_checkins=bool(getattr(self.settings, "comment_skip_checkins", True)),
+            max_comment_length=int(getattr(self.settings, "comment_max_length", 60) or 60),
+        )
+        pipeline = AutoCommentPipeline(config)
+
+        async def generate_stage(prompt: str, provider_id: str, system_prompt: str) -> str:
+            try:
+                return await self._generate_text(None, prompt, provider_id=provider_id, system_prompt=system_prompt)  # type: ignore[arg-type]
+            except Exception as exc:
+                logger.debug("qzone auto-comment pipeline stage failed: %s", exc)
+                return ""
+
+        async def execute_comment(reasoning: str) -> str:
+            if config.execution_provider_id:
+                try:
+                    return await self._llm_adapter().generate_comment_text(
+                        None,  # type: ignore[arg-type]
+                        post,
+                        provider_id=config.execution_provider_id,
+                        reasoning=reasoning,
+                    )
+                except Exception as exc:
+                    logger.debug("qzone auto-comment execution provider failed: %s", exc)
+            return await self._generate_comment_text(None, post)  # type: ignore[arg-type]
+
+        return await pipeline.run(post, generate_text=generate_stage, execute_comment=execute_comment)
 
     async def _generate_reply_text(self, event: AstrMessageEvent, post: QzonePost, comment: QzoneComment) -> str:
         return await self._llm_adapter().generate_reply_text(event, post, comment)
@@ -2524,11 +2820,17 @@ class QzoneStablePlugin(Star):
                 skipped_duplicate += 1
                 continue
             await self._post_store().upsert_async(post)
-            text = await self._generate_comment_text(None, post)  # type: ignore[arg-type]
-            if not text.strip():
+            pipeline_result = await self._generate_auto_comment_pipeline(post)
+            if not pipeline_result.should_comment or not pipeline_result.comment_text.strip():
                 skipped_empty += 1
+                logger.info(
+                    "qzone scheduled comment skipped hostuin=%s fid=%s reason=%s",
+                    post.hostuin,
+                    post.fid,
+                    pipeline_result.skip_reason or "empty_comment",
+                )
                 continue
-            comment_text = text.strip()
+            comment_text = pipeline_result.comment_text.strip()
             await self._post_service().comment_post(post, comment_text)
             commented_keys.add(key)
             self._save_auto_comment_keys(commented_keys)
@@ -2697,7 +2999,28 @@ class QzoneStablePlugin(Star):
         self._schedule_publish_render_asset_preload("cookie bind", event=event, status=payload)
         return payload
 
-    async def _bootstrap_auto_bind(self, trigger: str, event: AstrMessageEvent | None = None) -> bool:
+    async def _call_bootstrap_auto_bind(
+        self,
+        trigger: str,
+        event: AstrMessageEvent | None = None,
+        *,
+        force_refresh: bool = False,
+    ) -> bool:
+        try:
+            signature = inspect.signature(self._bootstrap_auto_bind)
+            if "force_refresh" in signature.parameters:
+                return await self._bootstrap_auto_bind(trigger, event, force_refresh=force_refresh)
+        except (TypeError, ValueError):
+            pass
+        return await self._bootstrap_auto_bind(trigger, event)
+
+    async def _bootstrap_auto_bind(
+        self,
+        trigger: str,
+        event: AstrMessageEvent | None = None,
+        *,
+        force_refresh: bool = False,
+    ) -> bool:
         client = self._capture_onebot_client(event) if event is not None else self._capture_onebot_client_from_context()
         if client is None:
             await self._prewarm_daemon_if_cookie_ready(trigger)
@@ -2706,30 +3029,82 @@ class QzoneStablePlugin(Star):
             await self._prewarm_daemon_if_cookie_ready(trigger)
             return True
         try:
-            await self._ensure_cookie_ready(event, source="aiocqhttp")
+            await self._ensure_cookie_ready(event, force=force_refresh, source="aiocqhttp")
         except QzoneBridgeError as exc:
             logger.warning("qzone auto bind on %s failed: %s", trigger, exc)
             return False
         await self._prewarm_daemon_if_cookie_ready(trigger)
         return True
 
-    def _schedule_bootstrap_auto_bind(self, trigger: str, event: AstrMessageEvent | None = None) -> None:
+    def _schedule_bootstrap_auto_bind(
+        self,
+        trigger: str,
+        event: AstrMessageEvent | None = None,
+        *,
+        force_refresh: bool = False,
+    ) -> None:
         task = getattr(self, "_auto_bind_bootstrap_task", None)
         if task is not None and not task.done():
             return
-        if bool(getattr(self, "_auto_bind_bootstrap_succeeded", False)):
+        if bool(getattr(self, "_auto_bind_bootstrap_succeeded", False)) and not force_refresh:
             return
         if event is not None and self._capture_onebot_client(event) is None and self.settings.auto_bind_cookie:
             return
 
         async def runner() -> None:
             try:
-                if await self._bootstrap_auto_bind(trigger, event):
+                if await self._call_bootstrap_auto_bind(trigger, event, force_refresh=force_refresh):
                     self._auto_bind_bootstrap_succeeded = True
+                    self._schedule_page_feed_preload(trigger)
             except Exception:
                 logger.warning("qzone auto bind on %s failed unexpectedly", trigger, exc_info=True)
 
         self._auto_bind_bootstrap_task = asyncio.create_task(runner())
+
+    def _schedule_page_preload(self, trigger: str) -> None:
+        task = getattr(self, "_page_preload_task", None)
+        if task is not None and not task.done():
+            return
+
+        async def runner() -> None:
+            try:
+                if not bool(getattr(self, "_auto_bind_bootstrap_succeeded", False)):
+                    if await self._call_bootstrap_auto_bind(trigger):
+                        self._auto_bind_bootstrap_succeeded = True
+                await self._prewarm_daemon_if_cookie_ready(trigger)
+            except Exception:
+                logger.debug("qzone page preload on %s failed", trigger, exc_info=True)
+
+        self._page_preload_task = asyncio.create_task(runner())
+
+    def _schedule_page_feed_preload(self, trigger: str) -> None:
+        if not bool(getattr(self.settings, "auto_start_daemon", True)):
+            return
+        if not hasattr(self, "controller"):
+            return
+        task = getattr(self, "_page_feed_preload_task", None)
+        if task is not None and not task.done():
+            return
+        loop = asyncio.get_running_loop()
+        now = loop.time()
+        if now - float(getattr(self, "_last_page_feed_preload_at", 0.0) or 0.0) < 45.0:
+            return
+        self._last_page_feed_preload_at = now
+
+        async def runner() -> None:
+            try:
+                status = await self.controller.get_status(probe_daemon=False)
+                if int(status.get("cookie_count") or 0) <= 0 or bool(status.get("needs_rebind")):
+                    return
+                await self.controller.ensure_running()
+                limit = min(max(5, int(getattr(self.settings, "max_feed_limit", 10) or 10)), 10)
+                await self.controller.list_feeds(hostuin=0, limit=limit, scope="active", record_recent=False)
+            except QzoneBridgeError as exc:
+                logger.debug("qzone page feed preload on %s failed: %s", trigger, exc)
+            except Exception:
+                logger.debug("qzone page feed preload on %s failed unexpectedly", trigger, exc_info=True)
+
+        self._page_feed_preload_task = asyncio.create_task(runner())
 
     async def _prewarm_daemon_if_cookie_ready(self, trigger: str) -> None:
         if not self.settings.auto_start_daemon:
@@ -2766,37 +3141,46 @@ class QzoneStablePlugin(Star):
             try:
                 payload = await self.controller.bind_cookie_local(self.settings.cookies_str, source="config")
                 self._schedule_publish_render_asset_preload("config bind", status=payload)
+                self._schedule_daemon_warmup("config bind")
             except QzoneBridgeError as exc:
                 logger.warning("qzone config cookie bind failed: %s", exc)
         self._start_scheduled_tasks()
-        self._schedule_bootstrap_auto_bind("initialize")
+        self._schedule_bootstrap_auto_bind("initialize", force_refresh=True)
 
     @filter.command_group("qzone")
     def qzone(self):
+        """QQ 空间管理命令组，可绑定 Cookie、查看状态和管理说说。"""
         pass
 
     @filter.on_astrbot_loaded()
     async def qzone_on_astrbot_loaded(self):
+        """AstrBot 加载完成后启动定时任务，并预热 Qzone Cookie。"""
         self._start_scheduled_tasks()
-        self._schedule_bootstrap_auto_bind("astrbot load")
+        self._schedule_bootstrap_auto_bind("astrbot load", force_refresh=True)
 
     @filter.platform_adapter_type(filter.PlatformAdapterType.AIOCQHTTP)
     async def qzone_capture_aiocqhttp_client(self, event: AstrMessageEvent):
+        """捕获 OneBot 客户端，并按配置预热或自动读取 Qzone 说说。"""
         self._capture_onebot_client(event)
         should_auto_read = self.settings.read_prob > 0 and random.random() < self.settings.read_prob
+        force_cookie_refresh = bool(self.settings.auto_bind_cookie) and not bool(
+            getattr(self, "_auto_bind_bootstrap_succeeded", False)
+        )
         if not should_auto_read:
-            self._schedule_bootstrap_auto_bind("aiocqhttp capture", event)
+            self._schedule_bootstrap_auto_bind("aiocqhttp capture", event, force_refresh=force_cookie_refresh)
             return
         group_id = str(self._group_id(event) or "")
         sender_id = str(self._sender_id(event) or "")
         if group_id and group_id in self.settings.ignore_groups:
-            self._schedule_bootstrap_auto_bind("aiocqhttp capture", event)
+            self._schedule_bootstrap_auto_bind("aiocqhttp capture", event, force_refresh=force_cookie_refresh)
             return
         if sender_id and sender_id in self.settings.ignore_users:
-            self._schedule_bootstrap_auto_bind("aiocqhttp capture", event)
+            self._schedule_bootstrap_auto_bind("aiocqhttp capture", event, force_refresh=force_cookie_refresh)
             return
         try:
-            await self._ensure_cookie_ready(event)
+            await self._ensure_cookie_ready(event, force=force_cookie_refresh)
+            if force_cookie_refresh:
+                self._auto_bind_bootstrap_succeeded = True
             await self._ensure_daemon()
             posts = await self._posts_for_event(
                 event,
@@ -2821,6 +3205,7 @@ class QzoneStablePlugin(Star):
     @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("查看访客")
     async def view_visitor(self, event: AstrMessageEvent):
+        """查看当前 QQ 空间最近访客。"""
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
@@ -2833,6 +3218,7 @@ class QzoneStablePlugin(Star):
     @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("看说说", alias={"查看说说"})
     async def view_feed(self, event: AstrMessageEvent):
+        """查看好友或指定 QQ 的说说，并渲染成卡片。"""
         if not self._is_admin(event):
             yield self._command_result(event, "只有管理员可以查看说说。")
             return
@@ -2849,6 +3235,7 @@ class QzoneStablePlugin(Star):
     @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("读说说")
     async def read_feed(self, event: AstrMessageEvent):
+        """按序号读取说说详情，不自动评论或点赞。"""
         if not self._is_admin(event):
             yield self._command_result(event, "只有管理员可以查看说说。")
             return
@@ -2872,6 +3259,7 @@ class QzoneStablePlugin(Star):
     @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("评说说", alias={"评论说说"})
     async def comment_feed(self, event: AstrMessageEvent):
+        """给选中的说说发表评论，留空时由 AI 生成。"""
         if not self._is_admin(event):
             yield self._command_result(event, "只有管理员可以评论。")
             return
@@ -2929,6 +3317,7 @@ class QzoneStablePlugin(Star):
     @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("赞说说")
     async def like_feed(self, event: AstrMessageEvent):
+        """给选中的说说点赞。"""
         if not self._is_admin(event):
             yield self._command_result(event, "只有管理员可以点赞。")
             return
@@ -2958,6 +3347,7 @@ class QzoneStablePlugin(Star):
     @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("发说说")
     async def publish_feed(self, event: AstrMessageEvent, content: str = ""):
+        """发布一条 QQ 空间说说，支持文字和图片。"""
         self._stop_event(event)
         post = self._collect_target_post_payload(event, content, ("发说说",))
         profile_task: asyncio.Task | None = None
@@ -2989,6 +3379,7 @@ class QzoneStablePlugin(Star):
     @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("写说说", alias={"写稿"})
     async def write_feed(self, event: AstrMessageEvent):
+        """根据主题生成说说草稿，提交管理员审核。"""
         topic = self._message_after_command(self._event_text(event), ("写说说", "写稿"))
         post = self._collect_target_post_payload(event, topic, ("写说说", "写稿"))
         try:
@@ -3007,6 +3398,7 @@ class QzoneStablePlugin(Star):
     @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("删说说")
     async def delete_feed(self, event: AstrMessageEvent):
+        """删除当前账号已发布的指定说说。"""
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
@@ -3030,6 +3422,7 @@ class QzoneStablePlugin(Star):
     @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("回评", alias={"回复评论"})
     async def reply_comment(self, event: AstrMessageEvent):
+        """回复指定已发布说说下的评论。"""
         if not self._is_admin(event):
             yield self._command_result(event, "只有管理员可以回评。")
             return
@@ -3107,6 +3500,7 @@ class QzoneStablePlugin(Star):
 
     @filter.command("投稿")
     async def contribute_post(self, event: AstrMessageEvent, content: str = ""):
+        """提交一条待审核的说说投稿。"""
         post = self._collect_target_post_payload(event, content, ("投稿",))
         if not post.content.strip() and not post.media:
             yield self._command_result(event, "投稿内容或图片不能为空。")
@@ -3117,6 +3511,7 @@ class QzoneStablePlugin(Star):
 
     @filter.command("匿名投稿")
     async def anon_contribute_post(self, event: AstrMessageEvent, content: str = ""):
+        """匿名提交一条待审核的说说投稿。"""
         post = self._collect_target_post_payload(event, content, ("匿名投稿",))
         if not post.content.strip() and not post.media:
             yield self._command_result(event, "投稿内容或图片不能为空。")
@@ -3127,6 +3522,7 @@ class QzoneStablePlugin(Star):
 
     @filter.command("撤稿")
     async def recall_post(self, event: AstrMessageEvent):
+        """撤回自己尚未审核的投稿。"""
         draft_id, _ = self._draft_id_from_event(event, ("撤稿",))
         if draft_id <= 0:
             yield self._command_result(event, "请提供要撤回的稿件ID，例如：撤稿 3。")
@@ -3170,6 +3566,7 @@ class QzoneStablePlugin(Star):
     @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("看稿", alias={"查看稿件"})
     async def view_post(self, event: AstrMessageEvent):
+        """查看待审核投稿列表或指定稿件。"""
         draft_id, _ = self._draft_id_from_event(event, ("看稿", "查看稿件"))
         if draft_id > 0:
             draft = await self.drafts.get_async(draft_id)
@@ -3182,6 +3579,7 @@ class QzoneStablePlugin(Star):
     @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("过稿", alias={"通过稿件", "通过投稿"})
     async def approve_post(self, event: AstrMessageEvent):
+        """通过投稿并发布到当前 QQ 空间。"""
         draft_id, _ = self._draft_id_from_event(event, ("过稿", "通过稿件", "通过投稿"))
         if draft_id <= 0:
             yield self._command_result(event, "请提供要通过的稿件ID，例如：过稿 3。")
@@ -3259,6 +3657,7 @@ class QzoneStablePlugin(Star):
     @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("拒稿", alias={"拒绝稿件", "拒绝投稿"})
     async def reject_post(self, event: AstrMessageEvent):
+        """拒绝投稿并记录原因。"""
         draft_id, reason = self._draft_id_from_event(event, ("拒稿", "拒绝稿件", "拒绝投稿"))
         if draft_id <= 0:
             yield self._command_result(event, "请提供要拒绝的稿件ID，例如：拒稿 3 原因。")
@@ -3292,6 +3691,7 @@ class QzoneStablePlugin(Star):
 
     @qzone.command("help")
     async def qzone_help(self, event: AstrMessageEvent):
+        """查看 QQ 空间 Ultra 的命令用法。"""
         text = "\n".join(
             [
                 "QQ 空间命令",
@@ -3335,6 +3735,7 @@ class QzoneStablePlugin(Star):
 
     @qzone.command("status")
     async def qzone_status(self, event: AstrMessageEvent):
+        """查看 Cookie、daemon 和 QQ 空间连接状态。"""
         if not self._is_admin(event):
             yield self._command_result(event, "只有管理员可以查看状态。")
             return
@@ -3347,6 +3748,7 @@ class QzoneStablePlugin(Star):
 
     @qzone.command("bind")
     async def qzone_bind(self, event: AstrMessageEvent, cookie: str):
+        """手动绑定 QQ 空间 Cookie。"""
         if not self._is_admin(event):
             yield self._command_result(event, "只有管理员可以绑定 Cookie。")
             return
@@ -3366,6 +3768,7 @@ class QzoneStablePlugin(Star):
 
     @qzone.command("autobind")
     async def qzone_autobind(self, event: AstrMessageEvent):
+        """从 OneBot 自动获取并刷新 QQ 空间 Cookie。"""
         if not self._is_admin(event):
             yield self._command_result(event, "只有管理员可以自动绑定 Cookie。")
             return
@@ -3385,6 +3788,7 @@ class QzoneStablePlugin(Star):
 
     @qzone.command("unbind")
     async def qzone_unbind(self, event: AstrMessageEvent):
+        """解绑当前保存的 QQ 空间 Cookie。"""
         if not self._is_admin(event):
             yield self._command_result(event, "只有管理员可以解绑。")
             return
@@ -3397,6 +3801,7 @@ class QzoneStablePlugin(Star):
 
     @qzone.command("feed")
     async def qzone_feed(self, event: AstrMessageEvent, hostuin: int = 0, limit: int = 0, cursor: str = ""):
+        """列出 QQ 空间说说，支持目标 QQ、数量和游标。"""
         if not self._is_admin(event):
             yield self._command_result(event, "只有管理员可以查看说说。")
             return
@@ -3419,6 +3824,7 @@ class QzoneStablePlugin(Star):
 
     @qzone.command("detail")
     async def qzone_detail(self, event: AstrMessageEvent, hostuin: int, fid: str, appid: int = 311):
+        """查看指定说说详情和评论。"""
         if not self._is_admin(event):
             yield self._command_result(event, "只有管理员可以查看说说详情。")
             return
@@ -3455,6 +3861,7 @@ class QzoneStablePlugin(Star):
 
     @qzone.command("post")
     async def qzone_post(self, event: AstrMessageEvent, content: str = ""):
+        """通过 /qzone post 发布一条说说。"""
         self._stop_event(event)
         if not self._is_admin(event):
             yield self._command_result(event, "只有管理员可以发说说。")
@@ -3483,6 +3890,7 @@ class QzoneStablePlugin(Star):
 
     @qzone.command("comment")
     async def qzone_comment(self, event: AstrMessageEvent, hostuin: int, fid: str, content: str):
+        """给指定 fid 的说说发表评论。"""
         if not self._is_admin(event):
             yield self._command_result(event, "只有管理员可以评论。")
             return
@@ -3507,6 +3915,7 @@ class QzoneStablePlugin(Star):
 
     @qzone.command("like")
     async def qzone_like(self, event: AstrMessageEvent, hostuin: int, fid: str, appid: int = 311, unlike: bool = False):
+        """给指定 fid 的说说点赞或取消点赞。"""
         if not self._is_admin(event):
             yield self._command_result(event, "只有管理员可以点赞。")
             return
@@ -4262,6 +4671,16 @@ class QzoneStablePlugin(Star):
             self._auto_bind_bootstrap_task.cancel()
             await asyncio.gather(self._auto_bind_bootstrap_task, return_exceptions=True)
             self._auto_bind_bootstrap_task = None
+        page_preload_task = getattr(self, "_page_preload_task", None)
+        if page_preload_task is not None:
+            page_preload_task.cancel()
+            await asyncio.gather(page_preload_task, return_exceptions=True)
+            self._page_preload_task = None
+        page_feed_preload_task = getattr(self, "_page_feed_preload_task", None)
+        if page_feed_preload_task is not None:
+            page_feed_preload_task.cancel()
+            await asyncio.gather(page_feed_preload_task, return_exceptions=True)
+            self._page_feed_preload_task = None
         try:
             await self.controller.close()
         except Exception as exc:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 name: astrbot_plugin_qzone_ultra
-version: 0.4.2
+version: 0.5.0
 author: 雪碧bir
 desc: QQ空间Ultra，更稳定的QQ空间插件，支持自动绑定QQ空间，采用独立进程：占用极低、稳定性极高，支持看/评/赞/发/写/删说说、回评、投稿审核、自动发评和 LLM tools。
 display_name: QQ空间Ultra

--- a/pages/qzone/app.js
+++ b/pages/qzone/app.js
@@ -1,0 +1,1222 @@
+﻿const bridge = window.AstrBotPluginPage;
+const BRIDGE_READY_TIMEOUT_MS = 5000;
+const BRIDGE_REQUEST_TIMEOUT_MS = 20000;
+
+const state = {
+  context: null,
+  status: null,
+  scope: "friends",
+  targetUin: "",
+  cursor: "",
+  hasMore: false,
+  posts: [],
+  selected: null,
+  media: [],
+  loading: false,
+  pendingLikes: new Set(),
+  knownAuthors: new Map(),
+  replyTarget: null,
+  replyDrafts: new Map(),
+  pendingReplies: new Set(),
+  localVersions: new Map(),
+  detailRequestSeq: 0,
+  detailLoadingId: "",
+};
+
+function queryOne(selector) {
+  return typeof document.querySelector === "function" ? document.querySelector(selector) : null;
+}
+
+function queryAll(selector) {
+  return typeof document.querySelectorAll === "function" ? [...document.querySelectorAll(selector)] : [];
+}
+
+const el = {
+  statusText: document.getElementById("statusText"),
+  accountName: document.getElementById("accountName"),
+  accountMeta: document.getElementById("accountMeta"),
+  accountAvatar: queryOne(".account .avatar"),
+  tabs: queryAll(".tab"),
+  targetForm: document.getElementById("targetForm"),
+  targetUin: document.getElementById("targetUin"),
+  publishForm: document.getElementById("publishForm"),
+  publishContent: document.getElementById("publishContent"),
+  mediaInput: document.getElementById("mediaInput"),
+  mediaStrip: document.getElementById("mediaStrip"),
+  publishButton: document.getElementById("publishButton"),
+  refreshButton: document.getElementById("refreshButton"),
+  feedTitle: document.getElementById("feedTitle"),
+  feedMeta: document.getElementById("feedMeta"),
+  notice: document.getElementById("notice"),
+  feed: document.getElementById("feed"),
+  moreButton: document.getElementById("moreButton"),
+  detailPane: document.getElementById("detailPane"),
+  detailEmpty: document.getElementById("detailEmpty"),
+  detailContent: document.getElementById("detailContent"),
+};
+
+function text(value) {
+  return String(value ?? "");
+}
+
+function getAvatarUrl(uin) {
+  if (!uin) return "";
+  return `https://q.qlogo.cn/headimg_dl?dst_uin=${encodeURIComponent(uin)}&spec=100`;
+}
+
+function getFallbackAvatarUrl(uin) {
+  if (!uin) return "";
+  return `https://q1.qlogo.cn/g?b=qq&nk=${encodeURIComponent(uin)}&s=100`;
+}
+
+function normalizeAvatarUrl(url) {
+  const value = text(url).trim();
+  if (!value) return "";
+  if (value.startsWith("//")) return `https:${value}`;
+  if (value.startsWith("http://")) return `https://${value.slice("http://".length)}`;
+  return value;
+}
+
+function cleanDisplayText(value) {
+  return text(value)
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n[ \t]+/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function authorKey(uin) {
+  const value = Number(uin || 0);
+  if (!Number.isFinite(value) || value <= 0) return "";
+  return String(Math.trunc(value));
+}
+
+function isGenericNickname(value, uin = 0) {
+  const name = text(value).trim();
+  const key = authorKey(uin);
+  return !name
+    || name === "我"
+    || name === "用户"
+    || name === "QQ空间用户"
+    || name === "QQ 空间用户"
+    || (key && name === key)
+    || /^QQ\s*\d{5,}$/i.test(name)
+    || /^\d{5,}$/.test(name);
+}
+
+function rememberAuthor(author) {
+  const key = authorKey(author?.uin);
+  if (!key) return;
+  const nickname = text(author?.nickname).trim();
+  if (isGenericNickname(nickname, key)) return;
+  const remembered = { ...(state.knownAuthors.get(key) || {}), ...author, uin: Number(key), nickname };
+  state.knownAuthors.set(key, remembered);
+
+  const login = state.status?.login;
+  if (login && authorKey(login.uin) === key && isGenericNickname(login.nickname, key)) {
+    login.nickname = nickname;
+  }
+}
+
+function rememberPostAuthors(post) {
+  if (!post) return;
+  rememberAuthor(post.author);
+  for (const comment of post.comments || []) {
+    rememberAuthor(comment.author);
+  }
+}
+
+function rememberPosts(posts) {
+  for (const post of posts || []) {
+    rememberPostAuthors(post);
+  }
+}
+
+function loginDisplayName() {
+  const login = state.status?.login || {};
+  const key = authorKey(login.uin);
+  const known = key ? state.knownAuthors.get(key) : null;
+  if (!isGenericNickname(login.nickname, key)) return text(login.nickname).trim();
+  if (known && !isGenericNickname(known.nickname, key)) return known.nickname;
+  if (login.bound || key) return "我";
+  return "未绑定";
+}
+
+function currentLoginAuthor() {
+  const login = state.status?.login || {};
+  return {
+    uin: login.uin || 0,
+    nickname: loginDisplayName(),
+    avatar: login.avatar || "",
+  };
+}
+
+function displayAuthorName(author, fallback = "QQ空间用户") {
+  const key = authorKey(author?.uin);
+  const known = key ? state.knownAuthors.get(key) : null;
+  const login = state.status?.login || {};
+  const loginKey = authorKey(login.uin);
+  const name = text(author?.nickname).trim();
+
+  if (key && loginKey && key === loginKey) {
+    return loginDisplayName();
+  }
+  if (!isGenericNickname(name, key)) return name;
+  if (known && !isGenericNickname(known.nickname, key)) return known.nickname;
+  return fallback;
+}
+
+function mergeAuthor(base, patch) {
+  const merged = { ...(base || {}), ...(patch || {}) };
+  const key = authorKey(merged.uin || base?.uin || patch?.uin);
+  if (isGenericNickname(merged.nickname, key) && !isGenericNickname(base?.nickname, key)) {
+    merged.nickname = base.nickname;
+  }
+  if (!merged.avatar && base?.avatar) {
+    merged.avatar = base.avatar;
+  }
+  return merged;
+}
+
+function commentKey(comment) {
+  const id = text(comment?.id || comment?.commentid).trim();
+  if (id) return `id:${id}`;
+  return [
+    "body",
+    authorKey(comment?.author?.uin),
+    text(comment?.content).trim(),
+    text(comment?.created_at),
+  ].join(":");
+}
+
+function mergeComment(base, patch) {
+  const merged = { ...(base || {}), ...(patch || {}) };
+  if (base?.author || patch?.author) {
+    merged.author = mergeAuthor(base?.author, patch?.author);
+  }
+  if (!cleanDisplayText(merged.content) && cleanDisplayText(base?.content)) {
+    merged.content = base.content;
+  }
+  return merged;
+}
+
+function mergeCommentsPreservingLocal(localComments = [], remoteComments = []) {
+  const localByKey = new Map();
+  for (const item of localComments || []) {
+    localByKey.set(commentKey(item), item);
+  }
+
+  const merged = [];
+  const seen = new Set();
+  for (const remote of remoteComments || []) {
+    const key = commentKey(remote);
+    seen.add(key);
+    merged.push(mergeComment(localByKey.get(key), remote));
+  }
+  for (const local of localComments || []) {
+    const key = commentKey(local);
+    if (!seen.has(key)) {
+      merged.push(local);
+    }
+  }
+  return merged;
+}
+
+function localVersion(id) {
+  return Number(state.localVersions.get(id) || 0);
+}
+
+function markLocalChange(id) {
+  if (!id) return;
+  state.localVersions.set(id, localVersion(id) + 1);
+}
+
+function mergeRemotePost(id, remotePost, versionAtRequestStart) {
+  const current = currentPostById(id || remotePost?.id);
+  if (!current || localVersion(current.id) === versionAtRequestStart) {
+    return remotePost;
+  }
+
+  const merged = mergePost(remotePost, {
+    liked: current.liked,
+    stats: current.stats,
+    comments: mergeCommentsPreservingLocal(current.comments || [], remotePost.comments || []),
+  });
+  merged.id = remotePost.id;
+  return merged;
+}
+
+function avatarUrlsFor(author) {
+  const urls = [
+    normalizeAvatarUrl(author?.avatar),
+    getAvatarUrl(author?.uin),
+    getFallbackAvatarUrl(author?.uin),
+  ].filter(Boolean);
+  return [...new Set(urls)];
+}
+
+function renderAvatar(target, author, fallbackName = "Q") {
+  const initial = text(fallbackName || "Q").trim().slice(0, 1).toUpperCase() || "Q";
+  const fallback = () => {
+    target.classList.remove("has-image");
+    target.replaceChildren();
+    target.textContent = initial;
+  };
+  const urls = avatarUrlsFor(author);
+  if (!urls.length) {
+    fallback();
+    return;
+  }
+
+  let index = 0;
+  const img = document.createElement("img");
+  img.alt = "";
+  img.loading = "lazy";
+  img.decoding = "async";
+  img.onerror = () => {
+    index += 1;
+    if (index < urls.length) {
+      img.src = urls[index];
+      return;
+    }
+    fallback();
+  };
+  target.textContent = "";
+  target.classList.add("has-image");
+  target.replaceChildren(img);
+  img.src = urls[index];
+}
+
+function mergePost(base, patch) {
+  const merged = { ...(base || {}), ...(patch || {}) };
+  if (base?.author || patch?.author) {
+    merged.author = mergeAuthor(base?.author, patch?.author);
+  }
+  if (base?.stats || patch?.stats) {
+    merged.stats = { ...(base?.stats || {}), ...(patch?.stats || {}) };
+  }
+  return merged;
+}
+
+function updatePost(id, patch) {
+  let updated = null;
+  state.posts = state.posts.map((item) => {
+    if (item.id !== id) return item;
+    updated = mergePost(item, patch);
+    return updated;
+  });
+  if (state.selected?.id === id) {
+    state.selected = mergePost(state.selected, patch);
+    updated = state.selected;
+  }
+  return updated;
+}
+
+function currentPostById(id, fallback = null) {
+  return state.posts.find((item) => item.id === id)
+    || (state.selected?.id === id ? state.selected : null)
+    || fallback;
+}
+
+function renderSelectedIfNeeded(id) {
+  if (state.selected?.id === id) {
+    renderDetail(state.selected);
+  }
+}
+
+function setNotice(message, tone = "info") {
+  el.notice.hidden = !message;
+  el.notice.textContent = message || "";
+  el.notice.dataset.tone = tone;
+}
+
+async function withTimeout(promise, timeoutMs, message) {
+  let timeoutId;
+  const timeout = new Promise((_, reject) => {
+    timeoutId = window.setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}
+
+function normalizeBridgeResult(result, fallbackMessage) {
+  if (result && typeof result === "object") {
+    if (result.status === "error") {
+      throw new Error(result.message || fallbackMessage);
+    }
+    if (Object.prototype.hasOwnProperty.call(result, "ok")) {
+      if (!result.ok) {
+        throw new Error(result.error?.message || result.message || fallbackMessage);
+      }
+      return result.data || {};
+    }
+  }
+  return result || {};
+}
+
+async function apiGet(endpoint, params = {}) {
+  const result = await withTimeout(
+    bridge.apiGet(endpoint, params),
+    BRIDGE_REQUEST_TIMEOUT_MS,
+    "请求 AstrBot WebUI 超时，请刷新页面后重试。"
+  );
+  return normalizeBridgeResult(result, "请求失败");
+}
+
+async function apiPost(endpoint, body = {}) {
+  const result = await withTimeout(
+    bridge.apiPost(endpoint, body),
+    BRIDGE_REQUEST_TIMEOUT_MS,
+    "请求 AstrBot WebUI 超时，请刷新页面后重试。"
+  );
+  return normalizeBridgeResult(result, "请求失败");
+}
+
+function formatTime(value) {
+  const timestamp = Number(value || 0);
+  if (!timestamp) return "未知时间";
+  const date = new Date(timestamp * 1000);
+  if (Number.isNaN(date.getTime())) return "未知时间";
+  return date.toLocaleString("zh-CN", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" });
+}
+
+function scopeTitle() {
+  if (state.scope === "self") return "我的空间";
+  if (state.scope === "profile") return state.targetUin ? `${state.targetUin} 的空间` : "指定 QQ";
+  return "好友动态";
+}
+
+function mediaLayoutClass(count) {
+  const safeCount = Math.max(1, Math.min(Number(count || 0), 9));
+  return `media-layout-${safeCount}`;
+}
+
+
+
+function renderStatus() {
+  const login = state.status?.login || {};
+  rememberAuthor(login);
+  el.accountName.textContent = loginDisplayName();
+  el.accountMeta.textContent = login.uin ? `QQ ${login.uin}` : "需要先绑定 Cookie";
+  if (el.statusText) {
+    const daemon = state.status?.daemon || {};
+    el.statusText.textContent = daemon.state === "ready" ? "daemon 已就绪" : `daemon ${daemon.state || "未知"}`;
+  }
+  
+  if (login.uin && el.accountAvatar) {
+    renderAvatar(el.accountAvatar, login, loginDisplayName());
+  }
+}
+
+function renderTabs() {
+  for (const tab of el.tabs) {
+    tab.classList.toggle("active", tab.dataset.scope === state.scope);
+  }
+}
+
+function renderMedia() {
+  el.mediaStrip.replaceChildren();
+  for (const [index, item] of state.media.entries()) {
+    const chip = document.createElement("div");
+    chip.className = "media-chip";
+    const name = document.createElement("span");
+    name.textContent = item.name || `图片 ${index + 1}`;
+    const remove = document.createElement("button");
+    remove.type = "button";
+    remove.textContent = "移除";
+    remove.addEventListener("click", () => {
+      state.media.splice(index, 1);
+      renderMedia();
+    });
+    chip.append(name, remove);
+    el.mediaStrip.append(chip);
+  }
+}
+
+function renderFeed() {
+  el.feedTitle.textContent = scopeTitle();
+  el.feedMeta.textContent = state.loading ? "加载中..." : `${state.posts.length} 条`;
+  el.moreButton.hidden = !state.hasMore;
+  el.feed.replaceChildren();
+
+  if (!state.posts.length && !state.loading) {
+    const empty = document.createElement("div");
+    empty.className = "empty-feed";
+    empty.textContent = "还没有读取到说说。";
+    el.feed.append(empty);
+    return;
+  }
+
+  for (const post of state.posts) {
+    el.feed.append(renderPostCard(post));
+  }
+}
+
+function openLightbox(url) {
+  let lightbox = document.getElementById("lightbox");
+  if (!lightbox) {
+    lightbox = document.createElement("div");
+    lightbox.id = "lightbox";
+    lightbox.className = "lightbox";
+    
+    const closeBtn = document.createElement("button");
+    closeBtn.className = "lightbox-close";
+    closeBtn.innerHTML = "×";
+    closeBtn.onclick = () => {
+      lightbox.classList.remove("visible");
+      setTimeout(() => lightbox.remove(), 300);
+    };
+    
+    lightbox.onclick = (e) => {
+      if (e.target === lightbox) {
+        lightbox.classList.remove("visible");
+        setTimeout(() => lightbox.remove(), 300);
+      }
+    };
+    
+    document.body.appendChild(lightbox);
+  }
+  
+  lightbox.innerHTML = "";
+  
+  const closeBtn = document.createElement("button");
+  closeBtn.className = "lightbox-close";
+  closeBtn.innerHTML = "×";
+  closeBtn.onclick = () => {
+    lightbox.classList.remove("visible");
+    setTimeout(() => lightbox.remove(), 300);
+  };
+  
+  let mediaElement;
+  
+  if (url.match(/\.(mp4|webm|ogg)$/i)) {
+    mediaElement = document.createElement("video");
+    mediaElement.src = url;
+    mediaElement.controls = true;
+    mediaElement.autoplay = true;
+  } else {
+    mediaElement = document.createElement("img");
+    mediaElement.src = url;
+  }
+  
+  lightbox.appendChild(closeBtn);
+  lightbox.appendChild(mediaElement);
+  
+  // Force a reflow
+  void lightbox.offsetWidth;
+  lightbox.classList.add("visible");
+}
+
+function renderPostCard(post) {
+  rememberPostAuthors(post);
+  const card = document.createElement("article");
+  card.className = "post";
+  card.dataset.id = post.id;
+
+  const head = document.createElement("button");
+  head.className = "post-header";
+  head.type = "button";
+  head.addEventListener("click", () => openDetail(post.id));
+
+  const avatar = document.createElement("span");
+  avatar.className = "avatar";
+  const authorName = displayAuthorName(post.author);
+  renderAvatar(avatar, post.author, authorName);
+
+  const meta = document.createElement("span");
+  meta.className = "post-meta";
+  const name = document.createElement("strong");
+  name.textContent = authorName;
+  const time = document.createElement("span");
+  time.textContent = formatTime(post.created_at);
+  meta.append(name, time);
+  head.append(avatar, meta);
+
+  card.append(head);
+
+  const contentText = cleanDisplayText(post.content);
+  if (contentText) {
+    const body = document.createElement("p");
+    body.className = "post-content";
+    body.textContent = contentText;
+    card.append(body);
+  }
+
+  if (post.images && post.images.length > 0) {
+    const images = document.createElement("div");
+    const mediaCount = post.images.length;
+    images.className = `post-media media-grid ${mediaLayoutClass(mediaCount)}`;
+    for (const url of post.images) {
+      if (url.match(/\.(mp4|webm|ogg)$/i)) {
+        const vid = document.createElement("video");
+        vid.src = url;
+        vid.className = "preview-video";
+        vid.muted = true;
+        vid.loop = true;
+        vid.playsInline = true;
+        vid.addEventListener("mouseenter", () => vid.play().catch(()=>{}));
+        vid.addEventListener("mouseleave", () => {
+          vid.pause();
+          vid.currentTime = 0;
+        });
+        vid.addEventListener("click", (e) => {
+          e.stopPropagation();
+          openLightbox(url);
+        });
+        images.append(vid);
+      } else {
+        const img = document.createElement("img");
+        img.loading = "lazy";
+        img.alt = "说说图片";
+        img.src = url;
+        img.addEventListener("click", (e) => {
+          e.stopPropagation();
+          openLightbox(url);
+        });
+        images.append(img);
+      }
+    }
+    card.append(images);
+  }
+
+  const actions = document.createElement("div");
+  actions.className = "post-actions";
+  const like = document.createElement("button");
+  like.type = "button";
+  like.className = post.liked ? "liked" : "";
+  like.disabled = state.pendingLikes.has(post.id);
+  like.setAttribute?.("aria-busy", state.pendingLikes.has(post.id) ? "true" : "false");
+  
+  const likeIcon = document.createElement("span");
+  likeIcon.innerHTML = post.liked ? "♥" : "♡";
+  likeIcon.className = "action-icon";
+  if (post.liked) likeIcon.style.color = "var(--danger)";
+  
+  const likeText = document.createElement("span");
+  likeText.textContent = ` ${post.stats?.likes ?? 0}`;
+  
+  like.append(likeIcon, likeText);
+  like.addEventListener("click", () => toggleLike(post));
+
+  const comment = document.createElement("button");
+  comment.type = "button";
+  
+  const commentIcon = document.createElement("span");
+  commentIcon.innerHTML = "💬";
+  commentIcon.className = "action-icon";
+  
+  const commentText = document.createElement("span");
+  commentText.textContent = ` ${post.stats?.comments ?? 0}`;
+  
+  comment.append(commentIcon, commentText);
+  comment.addEventListener("click", () => openDetail(post.id, true));
+
+  const detail = document.createElement("button");
+  detail.type = "button";
+  detail.textContent = "查看详情";
+  detail.addEventListener("click", () => openDetail(post.id));
+  
+  actions.append(like, comment, detail);
+  card.append(actions);
+  
+  return card;
+}
+
+function renderDetail(post, options = {}) {
+  state.selected = mergePost(state.selected?.id === post.id ? state.selected : {}, post);
+  post = state.selected;
+  rememberPostAuthors(post);
+  const isLoading = Boolean(options.loading || state.detailLoadingId === post.id);
+  el.detailEmpty.hidden = true;
+  el.detailContent.hidden = false;
+  el.detailPane.classList.add("has-selection");
+  el.detailContent.setAttribute?.("aria-busy", isLoading ? "true" : "false");
+  el.detailContent.replaceChildren();
+
+  const title = document.createElement("div");
+  title.className = "detail-title";
+  
+  const titleHead = document.createElement("div");
+  titleHead.className = "detail-header";
+  
+  const titleAvatar = document.createElement("span");
+  titleAvatar.className = "avatar";
+  const authorName = displayAuthorName(post.author);
+  renderAvatar(titleAvatar, post.author, authorName);
+  
+  const titleMeta = document.createElement("div");
+  titleMeta.className = "detail-meta";
+  const name = document.createElement("strong");
+  name.textContent = authorName;
+  const time = document.createElement("span");
+  time.textContent = formatTime(post.created_at);
+  titleMeta.append(name, time);
+  
+  titleHead.append(titleAvatar, titleMeta);
+  title.append(titleHead);
+
+  el.detailContent.append(title);
+
+  const contentText = cleanDisplayText(post.content);
+  if (contentText) {
+    const content = document.createElement("p");
+    content.className = "post-content detail-text";
+    content.textContent = contentText;
+    el.detailContent.append(content);
+  }
+
+  const actions = document.createElement("div");
+    actions.className = "detail-actions";
+    titleHead.append(actions);
+  const like = document.createElement("button");
+  like.type = "button";
+  like.textContent = post.liked ? "取消点赞" : "点赞";
+  like.disabled = state.pendingLikes.has(post.id);
+  like.setAttribute?.("aria-busy", state.pendingLikes.has(post.id) ? "true" : "false");
+  like.addEventListener("click", () => toggleLike(post));
+  actions.append(like);
+  if (post.can_delete) {
+    const del = document.createElement("button");
+    del.type = "button";
+    del.className = "danger";
+    del.textContent = "删除";
+    del.addEventListener("click", () => deletePost(post));
+    actions.append(del);
+  }
+
+  // // // el.detailContent.append(actions);
+
+  const comments = document.createElement("div");
+  comments.className = "comments";
+  const commentsTitle = document.createElement("h2");
+  commentsTitle.textContent = "全部评论";
+  comments.append(commentsTitle);
+  if (isLoading) {
+    const loading = document.createElement("div");
+    loading.className = "detail-loading";
+    loading.textContent = "正在同步详情...";
+    comments.append(loading);
+  }
+  for (const item of post.comments || []) {
+    comments.append(renderComment(post, item));
+  }
+  if (!post.comments?.length && !isLoading) {
+    const empty = document.createElement("p");
+    empty.className = "muted";
+    empty.textContent = "还没有人评论，快来抢沙发。";
+    comments.append(empty);
+  }
+
+  const form = document.createElement("form");
+  form.className = "comment-form";
+  const input = document.createElement("textarea");
+  input.rows = 3;
+  input.placeholder = "写下你的评论...";
+  const submit = document.createElement("button");
+  submit.type = "submit";
+  submit.textContent = "发送";
+  form.append(input, submit);
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    await sendComment(post, input.value);
+    input.value = "";
+  });
+
+  el.detailContent.append(comments, form);
+}
+
+function renderComment(post, comment) {
+  rememberAuthor(comment.author);
+  const row = document.createElement("div");
+  row.className = "comment";
+  const targetKey = `${post.id}:${text(comment.id)}`;
+  
+  const avatar = document.createElement("span");
+  avatar.className = "avatar";
+  const authorName = displayAuthorName(comment.author);
+  renderAvatar(avatar, comment.author, authorName);
+  
+  const body = document.createElement("div");
+  body.className = "comment-body";
+  
+  const name = document.createElement("strong");
+  name.textContent = authorName;
+  const content = document.createElement("p");
+  content.textContent = cleanDisplayText(comment.content);
+  body.append(name, content);
+  row.append(avatar, body);
+  if (comment.can_reply) {
+    const reply = document.createElement("button");
+    reply.type = "button";
+    reply.className = "reply-btn";
+    reply.textContent = "回复";
+    reply.addEventListener("click", () => {
+      const commentId = text(comment.id);
+      const isSameTarget = state.replyTarget?.postId === post.id
+        && state.replyTarget?.commentId === commentId;
+      state.replyTarget = isSameTarget ? null : { postId: post.id, commentId };
+      renderSelectedIfNeeded(post.id);
+      if (!isSameTarget) {
+        setTimeout(() => {
+          el.detailContent.querySelector(".reply-form textarea")?.focus();
+        }, 0);
+      }
+    });
+    row.append(reply);
+  }
+  if (state.replyTarget?.postId === post.id && state.replyTarget?.commentId === text(comment.id)) {
+    const form = document.createElement("form");
+    form.className = "reply-form";
+    const input = document.createElement("textarea");
+    input.rows = 2;
+    input.placeholder = `回复 ${authorName}`;
+    input.value = state.replyDrafts.get(targetKey) || "";
+    input.addEventListener("input", () => {
+      state.replyDrafts.set(targetKey, input.value);
+    });
+    const actions = document.createElement("div");
+    actions.className = "reply-form-actions";
+    const cancel = document.createElement("button");
+    cancel.type = "button";
+    cancel.className = "ghost";
+    cancel.textContent = "取消";
+    cancel.addEventListener("click", () => {
+      state.replyDrafts.delete(targetKey);
+      state.replyTarget = null;
+      renderSelectedIfNeeded(post.id);
+    });
+    const submit = document.createElement("button");
+    submit.type = "submit";
+    submit.className = "primary";
+    submit.textContent = "发送回复";
+    actions.append(cancel, submit);
+    form.append(input, actions);
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      submit.disabled = true;
+      const sent = await sendReply(post, comment, input.value);
+      if (sent) {
+        state.replyDrafts.delete(targetKey);
+      } else {
+        submit.disabled = false;
+      }
+    });
+    row.append(form);
+  }
+  return row;
+}
+
+async function loadStatus() {
+  const data = await apiGet("page/status");
+  state.status = data;
+  renderStatus();
+}
+
+function feedParams(next = false) {
+  const params = { limit: 10 };
+  if (next && state.cursor) params.cursor = state.cursor;
+  if (state.scope === "friends") params.scope = "friends";
+  if (state.scope === "self") params.scope = "self";
+  if (state.scope === "profile") {
+    params.scope = "profile";
+    params.hostuin = state.targetUin;
+  }
+  return params;
+}
+
+async function loadFeed({ append = false } = {}) {
+  if (state.scope === "profile" && !state.targetUin) {
+    state.posts = [];
+    state.cursor = "";
+    state.hasMore = false;
+    setNotice("输入 QQ 号后查看指定空间。", "warn");
+    renderFeed();
+    return;
+  }
+  
+  // Only show loading if we're completely empty, otherwise let the spinner handle it gracefully
+  if (!append) {
+    state.loading = true;
+    renderFeed();
+  } else {
+    el.moreButton.textContent = "加载中...";
+    el.moreButton.disabled = true;
+  }
+  
+  try {
+    const data = await apiGet("page/feed", feedParams(append));
+    state.cursor = data.cursor || "";
+    state.hasMore = Boolean(data.has_more);
+    state.posts = append ? [...state.posts, ...(data.items || [])] : data.items || [];
+    rememberPosts(state.posts);
+    renderStatus();
+    setNotice("");
+  } catch (error) {
+    setNotice(error.message || "动态加载失败", "error");
+  } finally {
+    state.loading = false;
+    if (append) {
+      el.moreButton.textContent = "加载更多";
+      el.moreButton.disabled = false;
+    }
+    renderFeed();
+  }
+}
+
+async function openDetail(id, focusComment = false) {
+  const cached = currentPostById(id);
+  const requestSeq = ++state.detailRequestSeq;
+  const versionAtRequestStart = localVersion(id);
+  if (state.selected?.id !== id) {
+    state.replyTarget = null;
+  }
+  state.detailLoadingId = id;
+  if (cached) {
+    renderDetail(cached, { loading: true });
+    renderFeed();
+    if (focusComment) {
+      setTimeout(() => {
+        el.detailContent.querySelector(".comment-form textarea")?.focus();
+      }, 0);
+    }
+  }
+  try {
+    const data = await apiGet("page/detail", { id });
+    if (requestSeq !== state.detailRequestSeq) return;
+    state.detailLoadingId = "";
+    const incoming = mergeRemotePost(data.post.id, data.post, versionAtRequestStart);
+    const merged = updatePost(incoming.id, incoming) || incoming;
+    rememberPostAuthors(merged);
+    renderDetail(merged);
+    renderFeed();
+    if (focusComment) {
+      setTimeout(() => {
+        el.detailContent.querySelector(".comment-form textarea")?.focus();
+      }, 0);
+    }
+  } catch (error) {
+    if (requestSeq !== state.detailRequestSeq) return;
+    state.detailLoadingId = "";
+    if (cached) {
+      renderDetail(currentPostById(id, cached));
+    }
+    setNotice(error.message || "详情加载失败", "error");
+  }
+}
+
+async function toggleLike(post) {
+  if (state.pendingLikes.has(post.id)) return;
+  state.pendingLikes.add(post.id);
+  const current = state.posts.find((item) => item.id === post.id) || state.selected || post;
+  const oldLiked = Boolean(current.liked);
+  const oldStats = { ...(current.stats || { likes: 0, comments: 0 }) };
+  const nextLiked = !oldLiked;
+  const nextLikes = Math.max(0, Number(oldStats.likes || 0) + (nextLiked ? 1 : -1));
+  updatePost(post.id, {
+    liked: nextLiked,
+    stats: { ...oldStats, likes: nextLikes },
+  });
+  markLocalChange(post.id);
+  renderFeed();
+  renderSelectedIfNeeded(post.id);
+  try {
+    const data = await apiPost("page/like", { id: post.id, unlike: oldLiked });
+    const finalLiked = Boolean(data.liked);
+    const finalLikes = finalLiked === nextLiked
+      ? nextLikes
+      : Math.max(0, nextLikes + (finalLiked ? 1 : -1));
+    updatePost(post.id, {
+      liked: finalLiked,
+      stats: { ...oldStats, likes: finalLikes },
+    });
+    markLocalChange(post.id);
+    if (data.verified === false || data.operation_status === "accepted_pending_verification") {
+      setNotice("QQ空间已接受操作，读回状态可能稍后同步。", "warn");
+    } else {
+      setNotice("");
+    }
+  } catch (error) {
+    updatePost(post.id, { liked: oldLiked, stats: oldStats });
+    markLocalChange(post.id);
+    setNotice(error.message || "点赞失败", "error");
+  } finally {
+    state.pendingLikes.delete(post.id);
+    renderFeed();
+    renderSelectedIfNeeded(post.id);
+  }
+}
+
+async function sendComment(post, content) {
+  const textValue = text(content).trim();
+  if (!textValue) return;
+  const postId = post.id;
+  const current = currentPostById(postId, post);
+  const comments = [...(current.comments || [])];
+  const tempId = `pending_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+  const optimisticComment = {
+    id: tempId,
+    author: currentLoginAuthor(),
+    content: textValue,
+    created_at: Math.floor(Date.now() / 1000),
+    can_reply: false,
+  };
+  const oldStats = { ...(current.stats || { likes: 0, comments: 0 }) };
+  updatePost(postId, {
+    comments: [...comments, optimisticComment],
+    stats: { ...oldStats, comments: Number(oldStats.comments || 0) + 1 },
+  });
+  markLocalChange(postId);
+  renderFeed();
+  renderSelectedIfNeeded(postId);
+  try {
+    const data = await apiPost("page/comment", { id: postId, content: textValue });
+    const serverComment = data.comment || {};
+    const author = mergeAuthor(optimisticComment.author, serverComment.author);
+    rememberAuthor(author);
+    const target = currentPostById(postId, post);
+    const nextComments = [...(target?.comments || [])].map((item) => (
+      item.id === tempId
+        ? {
+          ...item,
+          id: serverComment.id || tempId,
+          author,
+          content: serverComment.content || item.content,
+          can_reply: Boolean(serverComment.id),
+        }
+        : item
+    ));
+    updatePost(postId, { comments: nextComments });
+    markLocalChange(postId);
+    setNotice("评论已发送。", "success");
+  } catch (error) {
+    const target = currentPostById(postId, post);
+    const currentComments = [...(target?.comments || [])];
+    const hadTemp = currentComments.some((item) => item.id === tempId);
+    const currentStats = { ...(target?.stats || oldStats) };
+    updatePost(postId, {
+      comments: currentComments.filter((item) => item.id !== tempId),
+      stats: hadTemp
+        ? { ...currentStats, comments: Math.max(0, Number(currentStats.comments || 0) - 1) }
+        : currentStats,
+    });
+    markLocalChange(postId);
+    setNotice(error.message || "评论失败", "error");
+  } finally {
+    renderFeed();
+    renderSelectedIfNeeded(postId);
+  }
+}
+
+async function sendReply(post, comment, content) {
+  const replyText = text(content).trim();
+  if (!replyText) return false;
+  const postId = post.id;
+  const pendingKey = `${postId}:${text(comment.id)}`;
+  if (state.pendingReplies.has(pendingKey)) return false;
+  state.pendingReplies.add(pendingKey);
+  const current = currentPostById(postId, post);
+  const comments = [...(current.comments || [])];
+  const oldStats = { ...(current.stats || { likes: 0, comments: 0 }) };
+  const tempId = `pending_reply_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+  const targetName = displayAuthorName(comment.author, "评论");
+  const previousReplyTarget = state.replyTarget;
+  const optimisticReply = {
+    id: tempId,
+    author: currentLoginAuthor(),
+    content: `回复 ${targetName}：${replyText}`,
+    created_at: Math.floor(Date.now() / 1000),
+    can_reply: false,
+  };
+  updatePost(postId, {
+    comments: [...comments, optimisticReply],
+    stats: { ...oldStats, comments: Number(oldStats.comments || 0) + 1 },
+  });
+  markLocalChange(postId);
+  if (state.replyTarget?.postId === postId && state.replyTarget?.commentId === text(comment.id)) {
+    state.replyTarget = null;
+  }
+  renderFeed();
+  renderSelectedIfNeeded(postId);
+  try {
+    const data = await apiPost("page/reply", {
+      id: postId,
+      commentid: comment.id,
+      comment_uin: comment.author?.uin,
+      content: replyText,
+    });
+    const serverReply = data.reply || {};
+    const author = mergeAuthor(optimisticReply.author, serverReply.author);
+    rememberAuthor(author);
+    const target = currentPostById(postId, post);
+    const nextComments = [...(target?.comments || [])].map((item) => (
+      item.id === tempId
+        ? {
+          ...item,
+          id: serverReply.id || tempId,
+          author,
+          content: serverReply.content ? `回复 ${targetName}：${serverReply.content}` : item.content,
+        }
+        : item
+    ));
+    updatePost(postId, { comments: nextComments });
+    markLocalChange(postId);
+    setNotice("回复已发送。", "success");
+    return true;
+  } catch (error) {
+    const target = currentPostById(postId, post);
+    const currentComments = [...(target?.comments || [])];
+    const hadTemp = currentComments.some((item) => item.id === tempId);
+    const currentStats = { ...(target?.stats || oldStats) };
+    updatePost(postId, {
+      comments: currentComments.filter((item) => item.id !== tempId),
+      stats: hadTemp
+        ? { ...currentStats, comments: Math.max(0, Number(currentStats.comments || 0) - 1) }
+        : currentStats,
+    });
+    markLocalChange(postId);
+    state.replyTarget = previousReplyTarget;
+    setNotice(error.message || "回复失败", "error");
+  } finally {
+    state.pendingReplies.delete(pendingKey);
+    renderFeed();
+    renderSelectedIfNeeded(postId);
+  }
+  return false;
+}
+
+async function deletePost(post) {
+  if (!window.confirm("确定删除这条说说吗？")) return;
+  try {
+    await apiPost("page/delete", { id: post.id });
+    state.posts = state.posts.filter((item) => item.id !== post.id);
+    state.selected = null;
+    el.detailContent.hidden = true;
+    el.detailEmpty.hidden = false;
+    el.detailPane.classList.remove("has-selection");
+    setNotice("说说已删除。", "success");
+    renderFeed();
+  } catch (error) {
+    setNotice(error.message || "删除失败", "error");
+  }
+}
+
+async function publish(event) {
+  event.preventDefault();
+  const content = el.publishContent.value;
+  if (!content.trim() && !state.media.length) {
+    setNotice("写点文字或添加图片再发布。", "warn");
+    return;
+  }
+  el.publishButton.disabled = true;
+  const originalText = el.publishButton.textContent;
+  el.publishButton.textContent = "发布中...";
+  try {
+    const data = await apiPost("page/publish", { content, media: state.media });
+    el.publishContent.value = "";
+    state.media = [];
+    renderMedia();
+    if (data.post) {
+      data.post.author = mergeAuthor(currentLoginAuthor(), data.post.author);
+      rememberPostAuthors(data.post);
+      state.posts = [data.post, ...state.posts];
+      renderFeed();
+    } else {
+      await loadFeed();
+    }
+    setNotice("说说已发布。", "success");
+  } catch (error) {
+    setNotice(error.message || "发布失败", "error");
+  } finally {
+    el.publishButton.disabled = false;
+    el.publishButton.textContent = originalText;
+  }
+}
+
+async function uploadFiles(files) {
+  const maxImages = state.status?.limits?.images || 9;
+  for (const file of files) {
+    if (state.media.length >= maxImages) {
+      setNotice(`最多只能添加 ${maxImages} 张图片。`, "warn");
+      break;
+    }
+    try {
+      const result = await withTimeout(
+        bridge.upload("page/upload-media", file),
+        BRIDGE_REQUEST_TIMEOUT_MS,
+        "上传图片超时，请刷新页面后重试。"
+      );
+      const data = normalizeBridgeResult(result, "上传失败");
+      if (!data.media) throw new Error("上传失败");
+      state.media.push(data.media);
+    } catch (error) {
+      setNotice(error.message || "图片上传失败", "error");
+    }
+  }
+  renderMedia();
+}
+
+function bindEvents() {
+  for (const tab of el.tabs) {
+    tab.addEventListener("click", async () => {
+      state.scope = tab.dataset.scope;
+      state.cursor = "";
+      state.posts = [];
+      renderTabs();
+      await loadFeed();
+    });
+  }
+  el.targetForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    state.targetUin = el.targetUin.value.trim();
+    state.scope = "profile";
+    state.cursor = "";
+    state.posts = [];
+    renderTabs();
+    await loadFeed();
+  });
+  el.refreshButton.addEventListener("click", () => {
+    state.cursor = "";
+    state.posts = [];
+    loadFeed();
+  });
+  el.moreButton.addEventListener("click", () => loadFeed({ append: true }));
+  el.publishForm.addEventListener("submit", publish);
+  el.mediaInput.addEventListener("change", async () => {
+    await uploadFiles(el.mediaInput.files || []);
+    el.mediaInput.value = "";
+  });
+}
+
+async function init() {
+  if (!bridge) {
+    setNotice("没有检测到 AstrBot Pages bridge，请从 AstrBot WebUI 插件页面进入。", "error");
+    return;
+  }
+  
+  try {
+    state.context = await withTimeout(
+      bridge.ready(),
+      BRIDGE_READY_TIMEOUT_MS,
+      "初始化 AstrBot WebUI 桥接超时，请刷新页面后重试。"
+    );
+  } catch (error) {
+    setNotice(error.message || "桥接初始化失败", "error");
+    return;
+  }
+
+  bindEvents();
+  renderTabs();
+  
+  try {
+    await loadStatus();
+    await loadFeed();
+  } catch (error) {
+    setNotice(error.message || "初始化失败", "error");
+  }
+}
+
+init();

--- a/pages/qzone/index.html
+++ b/pages/qzone/index.html
@@ -1,0 +1,87 @@
+﻿<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>QQ空间Ultra</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="rail">
+        <div class="account" id="accountBox">
+          <span class="avatar"></span>
+          <div>
+            <strong id="accountName">未读号</strong>
+            <span id="accountMeta">等待状态</span>
+          </div>
+        </div>
+
+        <nav class="tabs" aria-label="动态范围">
+          <button class="tab active" data-scope="friends" type="button">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle><path d="M23 21v-2a4 4 0 0 0-3-3.87"></path><path d="M16 3.13a4 4 0 0 1 0 7.75"></path></svg>
+            好友动态
+          </button>
+          <button class="tab" data-scope="self" type="button">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+            我的空间
+          </button>
+          <button class="tab" data-scope="profile" type="button">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+            指定 QQ
+          </button>
+        </nav>
+
+        <form class="target-form" id="targetForm">
+          <label for="targetUin">QQ 号</label>
+          <div class="target-row">
+            <input id="targetUin" inputmode="numeric" autocomplete="off" placeholder="输入 QQ 号" />
+            <button type="submit" aria-label="查询">
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"></polyline></svg>
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section class="timeline">
+        <form class="composer" id="publishForm">
+          <textarea id="publishContent" rows="4" maxlength="1200" placeholder="写点什么，发到 QQ 空间"></textarea>
+          <div class="media-strip" id="mediaStrip"></div>
+          <div class="composer-actions">
+            <label class="upload-button">
+              <input id="mediaInput" type="file" accept="image/*" multiple />
+              <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><circle cx="8.5" cy="8.5" r="1.5"></circle><polyline points="21 15 16 10 5 21"></polyline></svg>
+              <span>添加图片</span>
+            </label>
+            <button id="publishButton" class="primary" type="submit">发布说说</button>
+          </div>
+        </form>
+
+        <div class="toolbar">
+          <div>
+            <strong id="feedTitle">好友动态</strong>
+            <span id="feedMeta">准备加载</span>
+          </div>
+          <button id="refreshButton" class="icon-button" type="button" title="刷新" aria-label="刷新">
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>
+          </button>
+        </div>
+
+        <div class="notice" id="notice" hidden></div>
+        <div class="feed" id="feed"></div>
+        <button id="moreButton" class="load-more" type="button" hidden>加载更多</button>
+      </section>
+
+      <aside class="detail" id="detailPane" aria-label="说说详情">
+        <div class="detail-empty" id="detailEmpty">
+          <svg viewBox="0 0 24 24" width="48" height="48" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.3; margin-bottom: 12px;"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
+          <strong>选择一条说说</strong>
+          <span>详情、评论和回复会显示在这里。</span>
+        </div>
+        <div id="detailContent" hidden></div>
+      </aside>
+    </main>
+
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/pages/qzone/style.css
+++ b/pages/qzone/style.css
@@ -1,0 +1,963 @@
+﻿/* Modern UI CSS for QQ Zone Ultra */
+:root {
+  --bg-color: #f3f6f9;
+  --surface: #ffffff;
+  --surface-hover: #f9fbfc;
+  --text-primary: #1e2022;
+  --text-secondary: #747b81;
+  --border: #eaedf1;
+  --accent: #1877f2;
+  --accent-hover: #1664d0;
+  --accent-glow: rgba(24, 119, 242, 0.15);
+  --success: #17a05d;
+  --danger: #e23e3e;
+  
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 16px 40px rgba(0, 0, 0, 0.08);
+  
+  --radius-sm: 12px;
+  --radius-md: 20px;
+  --radius-lg: 28px;
+  --radius-full: 9999px;
+  
+  --spring: all 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  --transition: all 0.2s ease-out;
+}
+
+body {
+  margin: 0;
+  background-color: var(--bg-color);
+  color: var(--text-primary);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  min-height: 100vh;
+}
+
+button, input, textarea {
+  font-family: inherit;
+  font-size: 14px;
+  border: none;
+  outline: none;
+  background: none;
+  color: inherit;
+  transition: var(--transition);
+}
+
+button {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+button:active {
+  transform: scale(0.96) !important;
+}
+
+/* Base shell layout */
+.shell {
+  display: grid;
+  grid-template-columns: 280px minmax(400px, 1fr) 400px;
+  gap: 24px;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 32px 24px;
+  align-items: start;
+}
+
+/* Cards */
+.account, .composer, .toolbar, .post, .detail, .notice, .empty-feed, .target-form, .tabs {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  transition: var(--spring);
+}
+
+.account:hover, .composer:focus-within, .post:hover, .detail:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+}
+
+.rail, .timeline, .detail {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.rail {
+  position: sticky;
+  top: 32px;
+}
+
+/* Account styling */
+.account {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 20px;
+}
+
+.avatar {
+  width: 52px;
+  height: 52px;
+  background: var(--bg-color);
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.05);
+  flex-shrink: 0;
+}
+
+.avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: var(--spring);
+}
+
+.account:hover .avatar img {
+  transform: scale(1.05);
+}
+
+.account div {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.account strong {
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.account span, .toolbar span, .post-meta span, .detail-title span {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+/* Tabs */
+.tabs {
+  display: flex;
+  flex-direction: column;
+  padding: 8px;
+  gap: 4px;
+}
+
+.tab {
+  padding: 12px 16px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  text-align: left;
+  color: var(--text-secondary);
+  justify-content: flex-start;
+}
+
+.tab svg {
+  width: 18px;
+  height: 18px;
+  opacity: 0.7;
+}
+
+.tab:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+  transform: translateX(4px);
+}
+
+.tab.active {
+  background: var(--accent-glow);
+  color: var(--accent);
+}
+
+.tab.active svg {
+  opacity: 1;
+}
+
+/* Target form */
+.target-form {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.target-form label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.target-row {
+  display: flex;
+  gap: 8px;
+}
+
+.target-row input {
+  flex: 1;
+  background: var(--bg-color);
+  border: 2px solid transparent;
+  padding: 10px 16px;
+  border-radius: var(--radius-full);
+  font-weight: 500;
+  min-width: 0;
+}
+
+.target-row input:focus {
+  background: var(--surface);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.target-row button {
+  background: var(--accent);
+  color: white;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border-radius: 50%;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.target-row button:hover {
+  background: var(--accent-hover);
+  transform: scale(1.05);
+}
+
+/* Composer */
+.composer {
+  padding: 24px;
+}
+
+.composer textarea {
+  width: 100%;
+  min-height: 80px;
+  max-height: 180px;
+  resize: none;
+  font-size: 15px;
+  color: var(--text-primary);
+  background: transparent;
+}
+
+.composer textarea::placeholder {
+  color: var(--text-secondary);
+  opacity: 0.7;
+}
+
+.composer-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.upload-button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--accent);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 8px 16px;
+  border-radius: var(--radius-full);
+  background: var(--accent-glow);
+  transition: var(--transition);
+}
+
+.upload-button:hover {
+  background: var(--accent);
+  color: white;
+}
+
+.upload-button input {
+  display: none;
+}
+
+#publishButton {
+  background: var(--text-primary);
+  color: white;
+  padding: 10px 24px;
+  border-radius: var(--radius-full);
+  font-weight: 600;
+}
+
+#publishButton:hover {
+  background: #000;
+  transform: translateY(-2px);
+}
+
+#publishButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+/* Media preview in composer */
+.media-strip {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+.media-strip:empty {
+  display: none;
+}
+
+.media-strip img {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+
+.media-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--bg-color);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  font-size: 13px;
+}
+
+.media-chip button {
+  color: var(--text-secondary);
+  padding: 0;
+}
+
+.media-chip button:hover {
+  color: var(--danger);
+}
+
+/* Toolbar */
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+}
+
+.toolbar strong {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.icon-button {
+  color: var(--text-secondary);
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border-radius: 50%;
+  background: var(--bg-color);
+}
+
+.icon-button:hover {
+  color: var(--text-primary);
+  background: var(--border);
+  transform: rotate(45deg);
+}
+
+/* Post */
+.feed {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.empty-feed {
+  padding: 40px;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.post {
+  padding: 24px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.post > button {
+  padding: 0;
+  width: 100%;
+  background: transparent;
+  text-align: left;
+  justify-content: flex-start;
+}
+
+.post.selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent), var(--shadow-md);
+  transform: scale(1.01);
+}
+
+.post-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.post-header .avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+}
+
+.post-meta {
+  display: flex;
+  flex-direction: column;
+}
+
+.post-meta strong {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.post-content {
+  font-size: 15px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  color: var(--text-primary);
+}
+
+/* Media grids */
+.post-media {
+  margin-top: 8px;
+}
+
+.media-grid {
+  display: grid;
+  gap: 6px;
+  border-radius: var(--radius-sm);
+  overflow: visible;
+  align-items: start;
+}
+
+.media-grid img, .media-grid video {
+  width: 100%;
+  height: auto;
+  aspect-ratio: auto;
+  object-fit: contain;
+  border-radius: 12px;
+  cursor: zoom-in;
+  border: none;
+  display: block;
+  background: transparent;
+}
+
+.media-layout-1 {
+  grid-template-columns: 1fr;
+  max-width: min(100%, 560px);
+}
+
+.media-layout-1 img, .media-layout-1 video {
+  aspect-ratio: auto;
+  width: auto;
+  max-width: 100%;
+  max-height: 420px;
+  object-fit: contain;
+  background: transparent;
+}
+
+.media-layout-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  max-width: min(100%, 560px);
+}
+
+.media-layout-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.media-layout-4 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  max-width: min(100%, 560px);
+}
+
+.media-layout-5,
+.media-layout-6,
+.media-layout-7,
+.media-layout-8,
+.media-layout-9 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.media-layout-2 img, .media-layout-2 video,
+.media-layout-3 img, .media-layout-3 video,
+.media-layout-4 img, .media-layout-4 video,
+.media-layout-5 img, .media-layout-5 video,
+.media-layout-6 img, .media-layout-6 video,
+.media-layout-7 img, .media-layout-7 video,
+.media-layout-8 img, .media-layout-8 video,
+.media-layout-9 img, .media-layout-9 video {
+  width: 100%;
+  max-height: 320px;
+}
+
+.media-layout-5,
+.media-layout-8 {
+  max-width: min(100%, 820px);
+}
+
+.media-layout-5 > :nth-child(4),
+.media-layout-5 > :nth-child(5),
+.media-layout-8 > :nth-child(7),
+.media-layout-8 > :nth-child(8) {
+  grid-column: span 1;
+}
+
+.media-layout-5 > :nth-child(4) {
+  grid-column: 1 / 2;
+}
+
+.media-layout-5 > :nth-child(5) {
+  grid-column: 2 / 3;
+}
+
+.media-layout-6,
+.media-layout-7,
+.media-layout-8,
+.media-layout-9 {
+  max-width: min(100%, 820px);
+}
+
+.preview-video {
+  background: #000;
+}
+
+/* Post stats */
+.post-stats {
+  display: flex;
+  gap: 24px;
+  padding-top: 16px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.post-stats button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.post-stats button:hover {
+  color: var(--accent);
+}
+
+.post-stats .liked {
+  color: var(--danger);
+}
+
+.post-stats .liked:hover {
+  color: var(--danger);
+  transform: scale(1.1);
+}
+
+/* Detail Pane */
+.detail {
+  position: sticky;
+  top: 32px;
+  max-height: calc(100vh - 64px);
+  overflow-y: auto;
+  padding: 24px;
+  overscroll-behavior: contain;
+}
+
+.detail.has-selection {
+  justify-content: flex-start;
+}
+
+.detail::-webkit-scrollbar {
+  width: 4px;
+}
+.detail::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 4px;
+}
+
+.detail-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 300px;
+  text-align: center;
+  gap: 12px;
+  color: var(--text-secondary);
+}
+
+.detail-empty[hidden] {
+  display: none !important;
+}
+
+.detail > #detailContent[hidden] {
+  display: none !important;
+}
+
+.detail-empty strong {
+  font-size: 16px;
+  color: var(--text-primary);
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.detail-header .avatar {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+}
+
+.detail-title {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.detail-title strong {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.detail-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.detail-meta strong {
+  line-height: 1.1;
+}
+
+.detail-meta span {
+  line-height: 1.1;
+}
+
+.detail-actions {
+  margin-left: auto;
+}
+
+.detail-actions button {
+  padding: 6px 12px;
+  border-radius: var(--radius-full);
+  background: var(--bg-color);
+  font-size: 13px;
+  font-weight: 600;
+}
+.detail-actions button:hover {
+  background: var(--border);
+}
+.detail-actions .danger {
+  color: var(--danger);
+}
+.detail-actions .danger:hover {
+  background: #ffe3e3;
+}
+
+/* Comments */
+.comments {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 24px;
+  padding-top: 24px;
+  border-top: 1px solid var(--border);
+}
+.comments > h2 {
+  font-size: 16px;
+  margin: 0;
+}
+
+.muted {
+  color: var(--text-secondary);
+  font-size: 14px;
+  margin: 0;
+}
+
+.comment {
+  display: grid;
+  grid-template-columns: 36px 1fr auto;
+  gap: 12px;
+  padding: 16px;
+  background: var(--bg-color);
+  border-radius: var(--radius-sm);
+  transition: var(--transition);
+}
+
+.comment:hover {
+  background: var(--surface-hover);
+  border-color: var(--border);
+}
+
+.comment .avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+}
+
+.comment-meta {
+  display: flex;
+  flex-direction: column;
+}
+
+.comment-meta strong {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.comment-content {
+  grid-column: 2 / -1;
+  font-size: 14px;
+  margin-top: 4px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.reply-btn {
+  grid-column: 3;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  background: transparent;
+}
+
+.reply-btn:hover {
+  background: var(--border);
+  color: var(--text-primary);
+}
+
+.reply-form {
+  grid-column: 2 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 12px;
+  background: var(--surface);
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+
+.reply-form textarea {
+  background: var(--bg-color);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  min-height: 60px;
+  max-height: 140px;
+  font-size: 14px;
+  resize: none;
+}
+
+.reply-form textarea:focus {
+  background: var(--surface);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.reply-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.reply-form-actions button {
+  padding: 8px 16px;
+  border-radius: var(--radius-full);
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.reply-form-actions .primary {
+  background: var(--accent);
+  color: white;
+}
+.reply-form-actions .primary:hover {
+  background: var(--accent-hover);
+}
+
+.reply-form-actions .ghost {
+  background: transparent;
+  color: var(--text-secondary);
+}
+.reply-form-actions .ghost:hover {
+  background: var(--bg-color);
+  color: var(--text-primary);
+}
+
+.comment-form {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.comment-form textarea {
+  background: var(--bg-color);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: 16px;
+  min-height: 80px;
+  max-height: 160px;
+  font-size: 14px;
+  resize: none;
+}
+.comment-form textarea:focus {
+  background: var(--surface);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.comment-form button {
+  align-self: flex-end;
+  background: var(--text-primary);
+  color: white;
+  padding: 10px 24px;
+  border-radius: var(--radius-full);
+  font-weight: 600;
+}
+.comment-form button:hover {
+  background: #000;
+  transform: translateY(-2px);
+}
+.comment-form button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+/* Notice */
+.notice {
+  padding: 12px 16px;
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+  margin-bottom: 16px;
+}
+
+.notice.success { background: #e3f5ec; color: var(--success); }
+.notice.error { background: #fce8e8; color: var(--danger); }
+.notice.warn { background: #fff8e1; color: #b7860b; }
+
+/* Load more */
+.load-more {
+  width: 100%;
+  padding: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+.load-more:hover {
+  background: var(--surface-hover);
+}
+.load-more:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}
+
+.detail-loading {
+  padding: 12px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+/* Responsive */
+@media (max-width: 1200px) {
+  .shell {
+    grid-template-columns: 240px 1fr;
+    padding: 24px;
+  }
+  .detail {
+    grid-column: 1 / -1;
+    position: static;
+    max-height: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .shell {
+    display: flex;
+    flex-direction: column;
+    padding: 16px;
+    gap: 16px;
+  }
+  .rail {
+    position: static;
+  }
+}
+
+/* Lightbox */
+.lightbox {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.9);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.3s;
+  pointer-events: none;
+}
+.lightbox.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+.lightbox img, .lightbox video {
+  max-width: 95vw;
+  max-height: 95vh;
+  border-radius: 8px;
+  transform: scale(0.95);
+  transition: var(--spring);
+}
+.lightbox.visible img, .lightbox.visible video {
+  transform: scale(1);
+}
+.lightbox-close {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  width: 48px;
+  height: 48px;
+  background: rgba(255,255,255,0.1);
+  color: white;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 28px;
+}
+.lightbox-close:hover {
+  background: rgba(255,255,255,0.2);
+  transform: scale(1.1);
+}

--- a/qzone_bridge/__init__.py
+++ b/qzone_bridge/__init__.py
@@ -1,4 +1,4 @@
 """QQ空间 AstrBot bridge."""
 
-__version__ = "0.4.2"
-BRIDGE_API_VERSION = 2026052305
+__version__ = "0.5.0"
+BRIDGE_API_VERSION = 2026052901

--- a/qzone_bridge/auto_comment.py
+++ b/qzone_bridge/auto_comment.py
@@ -1,0 +1,247 @@
+"""Auto-comment persistence and decision pipeline."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from .json_store import AtomicItemStoreFile
+from .social import QzonePost
+from .utils import truncate
+
+
+GenerateStageText = Callable[[str, str, str], Awaitable[str]]
+ExecuteCommentText = Callable[[str], Awaitable[str]]
+
+SERIOUS_KEYWORDS = (
+    "rip",
+    "funeral",
+    "surgery",
+    "hospital",
+    "accident",
+    "cancer",
+    "depression",
+    "\u53bb\u4e16",
+    "\u8ba3\u544a",
+    "\u846c\u793c",
+    "\u60bc\u5ff5",
+    "\u54c0\u60bc",
+    "\u4e00\u8def\u8d70\u597d",
+    "\u4f4f\u9662",
+    "\u624b\u672f",
+    "\u751f\u75c5",
+    "\u764c",
+    "\u6291\u90c1",
+    "\u96be\u8fc7",
+    "\u5d29\u6e83",
+    "\u5206\u624b",
+    "\u5931\u4e1a",
+    "\u4e8b\u6545",
+    "\u8f66\u7978",
+)
+CHECKIN_KEYWORDS = (
+    "\u6253\u5361",
+    "\u7b7e\u5230",
+    "\u65e9\u5b89",
+    "\u665a\u5b89",
+    "\u4e0a\u73ed",
+    "\u4e0b\u73ed",
+)
+
+
+@dataclass(slots=True)
+class AutoCommentPipelineConfig:
+    enabled: bool = True
+    judgment_provider_id: str = ""
+    reasoning_provider_id: str = ""
+    execution_provider_id: str = ""
+    skip_checkins: bool = True
+    max_comment_length: int = 60
+
+
+@dataclass(slots=True)
+class AutoCommentPipelineResult:
+    should_comment: bool
+    comment_text: str = ""
+    judgment: str = ""
+    reasoning: str = ""
+    skip_reason: str = ""
+
+
+class AutoCommentStateStore:
+    def __init__(self, path: Path, *, max_items: int = 500):
+        self.path = Path(path)
+        self.max_items = max(1, int(max_items or 500))
+        self._store = AtomicItemStoreFile(self.path)
+
+    def read_keys(self) -> set[str]:
+        payload = self._store.read()
+        items = payload.get("commented") if isinstance(payload, dict) else []
+        if items is None:
+            items = payload.get("items") if isinstance(payload, dict) else []
+        if not isinstance(items, list):
+            return set()
+        keys: set[str] = set()
+        for item in items:
+            if isinstance(item, dict):
+                value = item.get("key")
+            else:
+                value = item
+            if value:
+                keys.add(str(value))
+        return keys
+
+    def write_keys(self, keys: set[str]) -> None:
+        self._store.write({"commented": sorted(str(key) for key in keys if key)[-self.max_items :]})
+
+
+def _compact_text(value: str) -> str:
+    return re.sub(r"[\s\u3000]+", "", str(value or "")).strip()
+
+
+def _post_context(post: QzonePost) -> str:
+    comments = [comment.content for comment in post.comments if comment.content][:5]
+    parts = [
+        f"author={post.nickname or post.hostuin}",
+        f"text={truncate(post.summary or '', 500)}",
+        f"images={len(post.images)}",
+        f"likes={post.like_count}",
+        f"comments={post.comment_count}",
+    ]
+    if comments:
+        parts.append("visible_comments=" + " | ".join(truncate(item, 80) for item in comments))
+    return "\n".join(parts)
+
+
+def _heuristic_skip_reason(post: QzonePost, *, skip_checkins: bool = True) -> str:
+    text = " ".join(
+        part
+        for part in (
+            post.summary,
+            post.nickname,
+            " ".join(comment.content for comment in post.comments if comment.content),
+        )
+        if part
+    )
+    compact = _compact_text(text)
+    lowered = compact.lower()
+    if not compact and not post.images:
+        return "empty_post"
+    if any(keyword in lowered or keyword in compact for keyword in SERIOUS_KEYWORDS):
+        return "serious_or_sensitive_context"
+    if skip_checkins and not post.images and len(compact) <= 16:
+        if any(keyword in compact for keyword in CHECKIN_KEYWORDS):
+            return "low_signal_checkin"
+    return ""
+
+
+def _strip_code_fence(text: str) -> str:
+    value = str(text or "").strip()
+    match = re.fullmatch(r"```(?:\w+)?\s*(.*?)\s*```", value, flags=re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    return value
+
+
+def _parse_judgment(text: str) -> tuple[bool | None, str]:
+    raw = _strip_code_fence(text)
+    if not raw:
+        return None, ""
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        payload = None
+    if isinstance(payload, dict):
+        action = str(payload.get("action") or payload.get("decision") or "").strip().lower()
+        should_comment = payload.get("should_comment")
+        reason = str(payload.get("reason") or payload.get("risk") or "").strip()
+        if isinstance(should_comment, bool):
+            return should_comment, reason
+        if action in {"comment", "reply", "yes", "true"}:
+            return True, reason
+        if action in {"skip", "ignore", "no", "false"}:
+            return False, reason or "llm_judgment_skip"
+    lowered = raw.lower()
+    if re.search(r"\b(skip|ignore|do not comment|no comment)\b", lowered):
+        return False, raw[:120]
+    if re.search(r"\b(comment|reply|safe|yes)\b", lowered):
+        return True, raw[:120]
+    return None, raw[:120]
+
+
+def _clean_reasoning(text: str) -> str:
+    value = _strip_code_fence(text)
+    value = re.sub(r"\s+", " ", value).strip()
+    return truncate(value, 500)
+
+
+def clean_comment_text(text: str, *, max_length: int = 60) -> str:
+    value = _strip_code_fence(text)
+    try:
+        payload = json.loads(value)
+    except Exception:
+        payload = None
+    if isinstance(payload, dict):
+        for key in ("comment", "content", "text", "message"):
+            item = payload.get(key)
+            if isinstance(item, str) and item.strip():
+                value = item
+                break
+    value = re.sub(r"^\s*(?:comment|content|text|message)\s*[:=]\s*", "", value, flags=re.I)
+    value = re.sub(r"[\r\n\t]+", " ", value)
+    value = value.strip().strip("\"'")
+    return truncate(value, max(1, int(max_length or 60))).strip()
+
+
+class AutoCommentPipeline:
+    def __init__(self, config: AutoCommentPipelineConfig):
+        self.config = config
+
+    async def run(
+        self,
+        post: QzonePost,
+        *,
+        generate_text: GenerateStageText,
+        execute_comment: ExecuteCommentText,
+    ) -> AutoCommentPipelineResult:
+        if not self.config.enabled:
+            text = clean_comment_text(await execute_comment(""), max_length=self.config.max_comment_length)
+            return AutoCommentPipelineResult(bool(text), comment_text=text, judgment="disabled")
+
+        heuristic_reason = _heuristic_skip_reason(post, skip_checkins=self.config.skip_checkins)
+        if heuristic_reason:
+            return AutoCommentPipelineResult(False, judgment="heuristic", skip_reason=heuristic_reason)
+
+        judgment_prompt = (
+            "You are judging whether an automatic QQ Zone comment is socially appropriate.\n"
+            "Return compact JSON only: {\"action\":\"comment|skip\",\"reason\":\"...\"}.\n"
+            "Skip sad, serious, crisis, medical, grief, conflict, private, political, or low-signal check-in posts.\n\n"
+            f"{_post_context(post)}"
+        )
+        judgment_text = await generate_text(
+            judgment_prompt,
+            self.config.judgment_provider_id,
+            "Decide whether to comment. Be conservative.",
+        )
+        should_comment, reason = _parse_judgment(judgment_text)
+        if should_comment is False:
+            return AutoCommentPipelineResult(False, judgment=judgment_text, skip_reason=reason or "llm_judgment_skip")
+
+        reasoning_prompt = (
+            "Plan one natural QQ Zone comment.\n"
+            "Describe relationship stance, emotional tone, and one content angle in one short sentence.\n"
+            "Do not write the final comment yet.\n\n"
+            f"{_post_context(post)}"
+        )
+        reasoning = _clean_reasoning(
+            await generate_text(
+                reasoning_prompt,
+                self.config.reasoning_provider_id,
+                "Reason about tone and relationship before writing.",
+            )
+        )
+        text = clean_comment_text(await execute_comment(reasoning), max_length=self.config.max_comment_length)
+        return AutoCommentPipelineResult(bool(text), comment_text=text, judgment=judgment_text, reasoning=reasoning)

--- a/qzone_bridge/client.py
+++ b/qzone_bridge/client.py
@@ -58,11 +58,25 @@ QZONE_UNLIKE_URL = QZONE_UNLIKE_DIRECT_URL
 QZONE_VISITOR_URL = "https://h5.qzone.qq.com/proxy/domain/g.qzone.qq.com/cgi-bin/friendshow/cgi_get_visitor_more"
 QZONE_REPLY_URL = "https://h5.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_re_feeds"
 QZONE_DELETE_URL = "https://h5.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_delete_v6"
-MAX_UPLOAD_IMAGE_BYTES = 32 * 1024 * 1024
+MAX_UPLOAD_IMAGE_BYTES: int | None = None
 IMAGE_SOURCE_CACHE_TTL_SECONDS = 10 * 60
 IMAGE_SOURCE_CACHE_MAX_ITEMS = 16
 IMAGE_SOURCE_CACHE_MAX_ITEM_BYTES = 8 * 1024 * 1024
 IMAGE_SOURCE_CACHE_MAX_TOTAL_BYTES = 64 * 1024 * 1024
+
+
+def _looks_like_supported_image_bytes(data: bytes) -> bool:
+    if data.startswith(b"\xff\xd8\xff"):
+        return True
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return True
+    if data.startswith((b"GIF87a", b"GIF89a")):
+        return True
+    if data.startswith(b"BM"):
+        return True
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return True
+    return False
 
 
 @dataclass(slots=True)
@@ -163,17 +177,10 @@ class QzoneClient:
     @staticmethod
     def _decode_upload_image_base64(encoded: str, *, label: str) -> bytes:
         text = str(encoded or "").strip()
-        # A cheap preflight avoids allocating very large decoded buffers from
-        # data/base64 sources that can be supplied through LLM tool arguments.
-        estimated_size = (len(text) * 3) // 4
-        if estimated_size > MAX_UPLOAD_IMAGE_BYTES + 3:
-            raise QzoneParseError(f"{label}大小超过限制")
         try:
             data = base64.b64decode(text, validate=False)
         except Exception as exc:
             raise QzoneParseError(f"{label}解码失败") from exc
-        if len(data) > MAX_UPLOAD_IMAGE_BYTES:
-            raise QzoneParseError(f"{label}大小超过限制")
         return data
 
     @staticmethod
@@ -750,20 +757,10 @@ class QzoneClient:
                                 status_code=response.status_code,
                                 detail={"url": current_url, "text": text[:500]},
                             )
-                        length = response.headers.get("content-length")
-                        try:
-                            if length and int(length) > MAX_UPLOAD_IMAGE_BYTES:
-                                raise QzoneParseError("图片大小超过限制", detail={"url": current_url})
-                        except ValueError:
-                            pass
                         chunks: list[bytes] = []
-                        total = 0
                         async for chunk in response.aiter_bytes():
                             if not chunk:
                                 continue
-                            total += len(chunk)
-                            if total > MAX_UPLOAD_IMAGE_BYTES:
-                                raise QzoneParseError("图片大小超过限制", detail={"url": current_url})
                             chunks.append(chunk)
                         content_type = response.headers.get("content-type", "").split(";", 1)[0]
                         data = b"".join(chunks)
@@ -781,9 +778,6 @@ class QzoneClient:
         def read_local_image() -> bytes:
             if not path.exists() or not path.is_file():
                 raise QzoneParseError("图片文件不存在", detail={"path": source})
-            stat = path.stat()
-            if stat.st_size > MAX_UPLOAD_IMAGE_BYTES:
-                raise QzoneParseError("图片大小超过限制", detail={"path": source})
             return path.read_bytes()
 
         data = await asyncio.to_thread(read_local_image)
@@ -824,6 +818,11 @@ class QzoneClient:
         data, filename, mime_type = await self._load_image_source(item.to_dict())
         if not data:
             raise QzoneParseError("图片内容为空或无法读取", detail={"name": filename})
+        if not _looks_like_supported_image_bytes(data):
+            raise QzoneParseError(
+                "图片内容不是可上传的图片文件",
+                detail={"name": filename, "mime_type": mime_type},
+            )
 
         encoded_bytes = await asyncio.to_thread(base64.b64encode, data)
         encoded = encoded_bytes.decode("ascii")

--- a/qzone_bridge/controller.py
+++ b/qzone_bridge/controller.py
@@ -9,6 +9,7 @@ import signal
 import socket
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
@@ -240,6 +241,10 @@ class QzoneDaemonController:
         self._incompatible_daemon: tuple[int, str] | None = None
 
     def _runtime(self):
+        state = self.store.read()
+        if state.runtime.secret and state.runtime.daemon_port:
+            return state.runtime
+
         def update(state):
             ensure_state_secret(state)
             if not state.runtime.daemon_port:
@@ -290,6 +295,29 @@ class QzoneDaemonController:
             detail["log_tail"] = log_tail
         return detail
 
+    def _open_daemon_log_file(self):
+        try:
+            log_path = self._daemon_log_path()
+            return log_path, log_path.open("a", encoding="utf-8", buffering=1)
+        except OSError as primary_exc:
+            fallback_dir = Path(tempfile.gettempdir()) / "astrbot_qzone_daemon_logs"
+            fallback_path = fallback_dir / f"daemon-{os.getpid()}.log"
+            try:
+                fallback_dir.mkdir(parents=True, exist_ok=True)
+                log.warning(
+                    "qzone daemon log is not writable, using fallback log %s: %s",
+                    fallback_path,
+                    primary_exc,
+                )
+                return fallback_path, fallback_path.open("a", encoding="utf-8", buffering=1)
+            except OSError as fallback_exc:
+                log.warning(
+                    "qzone daemon log is not writable and fallback log failed; using os.devnull: primary=%s fallback=%s",
+                    primary_exc,
+                    fallback_exc,
+                )
+                return None, open(os.devnull, "w", encoding="utf-8", buffering=1)
+
     def _record_daemon_start_error(self, exc: DaemonUnavailableError, *, port: int) -> None:
         self._invalidate_health_cache()
 
@@ -329,16 +357,18 @@ class QzoneDaemonController:
             return 0
 
     def _health_payload_is_compatible(self, payload: dict[str, Any]) -> bool:
+        data = self._health_data(payload)
         return (
             self._health_payload_is_qzone_daemon(payload)
             and self._bridge_api_version_from_health(payload) >= BRIDGE_API_VERSION
+            and str(data.get("daemon_version") or "") == BRIDGE_VERSION
         )
 
     async def _stop_incompatible_daemon(self, port: int, secret: str) -> None:
         if self._incompatible_daemon != (int(port or 0), secret):
             return
         self._incompatible_daemon = None
-        log.warning("qzone daemon bridge API is stale; restarting daemon on port %s", port)
+        log.warning("qzone daemon version or bridge API is stale; restarting daemon on port %s", port)
         if await self._request_daemon_shutdown(port, secret):
             await self._wait_for_port_release(port, 3.0)
         self._invalidate_health_cache()
@@ -370,10 +400,11 @@ class QzoneDaemonController:
         env["QZONE_BRIDGE_PLUGIN_ROOT"] = str(self.plugin_root)
         env["QZONE_BRIDGE_SECRET"] = runtime.secret
         kwargs["env"] = env
-        log_path = self._daemon_log_path()
-        log_file = log_path.open("a", encoding="utf-8", buffering=1)
+        log_path, log_file = self._open_daemon_log_file()
         try:
             log_file.write(f"\n[{now_iso()}] starting qzone daemon on 127.0.0.1:{port}\n")
+            if log_path is not None:
+                log_file.write(f"log_path={log_path}\n")
             kwargs["stdout"] = log_file
             kwargs["stderr"] = log_file
             return subprocess.Popen(cmd, cwd=str(self.plugin_root), **kwargs)
@@ -708,11 +739,25 @@ class QzoneDaemonController:
             self.store.update(update)
             return await self.get_status()
 
-    async def list_feeds(self, *, hostuin: int = 0, limit: int = 5, cursor: str = "", scope: str = "") -> dict[str, Any]:
+    async def list_feeds(
+        self,
+        *,
+        hostuin: int = 0,
+        limit: int = 5,
+        cursor: str = "",
+        scope: str = "",
+        record_recent: bool = True,
+    ) -> dict[str, Any]:
         return await self._request(
             "GET",
             "/feeds",
-            params={"hostuin": hostuin, "limit": limit, "cursor": cursor, "scope": scope},
+            params={
+                "hostuin": hostuin,
+                "limit": limit,
+                "cursor": cursor,
+                "scope": scope,
+                "record_recent": str(bool(record_recent)).lower(),
+            },
         )
 
     async def detail_feed(self, *, hostuin: int, fid: str, appid: int = 311, busi_param: str = "") -> dict[str, Any]:
@@ -812,6 +857,7 @@ class QzoneDaemonController:
         unlike: bool = False,
         latest: bool = False,
         index: int = 0,
+        fast: bool = False,
     ) -> dict[str, Any]:
         return await self._request(
             "POST",
@@ -824,6 +870,7 @@ class QzoneDaemonController:
                 "unlike": unlike,
                 "latest": latest,
                 "index": index,
+                "fast": fast,
             },
         )
 

--- a/qzone_bridge/daemon.py
+++ b/qzone_bridge/daemon.py
@@ -90,6 +90,10 @@ def _query_int(request: web.Request, key: str, default: int = 0) -> int:
     return _coerce_int(request.query.get(key), default, field=key)
 
 
+def _query_bool(request: web.Request, key: str, default: bool = False) -> bool:
+    return _coerce_bool(request.query.get(key), default)
+
+
 def _body_int(body: dict[str, Any], key: str, default: int = 0) -> int:
     return _coerce_int(body.get(key), default, field=key)
 
@@ -364,7 +368,15 @@ class QzoneDaemonService:
             return True
         return exc.status_code is not None and exc.status_code >= 500
 
-    async def list_feeds(self, *, hostuin: int = 0, limit: int = 5, cursor: str = "", scope: str = "") -> dict[str, Any]:
+    async def list_feeds(
+        self,
+        *,
+        hostuin: int = 0,
+        limit: int = 5,
+        cursor: str = "",
+        scope: str = "",
+        record_recent: bool = True,
+    ) -> dict[str, Any]:
         self._ensure_session_ready()
         if limit <= 0:
             limit = 5
@@ -428,7 +440,8 @@ class QzoneDaemonService:
             page_round += 1
 
         visible_items = items[:limit]
-        self.recent_feed_entries = visible_items
+        if record_recent:
+            self.recent_feed_entries = visible_items
         return {
             "scope": scope,
             "hostuin": hostuin,
@@ -824,6 +837,7 @@ class QzoneDaemonService:
         unlike: bool = False,
         latest: bool = False,
         index: int = 0,
+        fast: bool = False,
     ) -> dict[str, Any]:
         self._ensure_session_ready()
         hostuin, fid, appid, curkey = await self._resolve_recent_feed_reference(
@@ -838,6 +852,45 @@ class QzoneDaemonService:
             raise QzoneParseError("没有指定要点赞的说说")
 
         target_liked = not unlike
+        if fast:
+            payload = self._normalize_action_payload(
+                await self.client.like_post(hostuin, fid, appid=appid, curkey=curkey, like=target_liked)
+            )
+
+            touched_entries: set[int] = set()
+
+            def apply_fast_like(entry: FeedEntry | None) -> None:
+                if entry is None:
+                    return
+                entry_id = id(entry)
+                if entry_id in touched_entries:
+                    return
+                touched_entries.add(entry_id)
+                was_liked = bool(entry.liked)
+                if was_liked != target_liked:
+                    entry.like_count = max(
+                        0,
+                        int(entry.like_count or 0) + (1 if target_liked else -1),
+                    )
+                entry.liked = target_liked
+
+            cached_entry = self.client.feed_cache.get((hostuin, fid))
+            apply_fast_like(cached_entry)
+            for entry in self.recent_feed_entries:
+                if entry.hostuin == hostuin and entry.fid == fid:
+                    apply_fast_like(entry)
+                    break
+            self._set_success(defer_save=True)
+            return {
+                "action": "unlike" if unlike else "like",
+                "liked": target_liked,
+                "verified": False,
+                "already": False,
+                "operation_status": "accepted_pending_verification",
+                "message": payload.get("msg") or payload.get("message") or "",
+                "raw": payload,
+            }
+
         before_entry = await self._refresh_like_entry(hostuin, fid, appid)
         if before_entry is not None and before_entry.liked == target_liked:
             self._set_success(defer_save=True)
@@ -1028,6 +1081,7 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
                 limit=_query_int(request, "limit", 5),
                 cursor=cursor,
                 scope=scope,
+                record_recent=_query_bool(request, "record_recent", True),
             ),
         )
 
@@ -1124,6 +1178,7 @@ def create_app(service: QzoneDaemonService, shutdown_event: asyncio.Event | None
                 unlike=_body_bool(body, "unlike", False),
                 latest=_body_bool(body, "latest", False),
                 index=_body_int(body, "index", 0),
+                fast=_body_bool(body, "fast", False),
             ),
         )
 

--- a/qzone_bridge/llm.py
+++ b/qzone_bridge/llm.py
@@ -310,12 +310,21 @@ class QzoneLLM:
         max_len = int(getattr(self.settings, "comment_max_length", 60) or 60)
         return truncate(cleaned, max_len)
 
-    async def generate_comment_text(self, event: Any, post: QzonePost) -> str:
+    async def generate_comment_text(
+        self,
+        event: Any,
+        post: QzonePost,
+        *,
+        provider_id: str = "",
+        reasoning: str = "",
+    ) -> str:
         prompt = f"{self.settings.comment_prompt}\n\n{COMMENT_OUTPUT_RULES}\n\n{self._comment_context(post)}"
+        if reasoning:
+            prompt = f"{prompt}\n\nPipeline reasoning:\n{truncate(reasoning, 500)}"
         text = await self.generate_text(
             event,
             prompt,
-            provider_id=self.settings.comment_provider_id,
+            provider_id=provider_id or self.settings.comment_provider_id,
             system_prompt=PERSONA_SYSTEM_PROMPT,
             prefer_current_provider=True,
         )

--- a/qzone_bridge/models.py
+++ b/qzone_bridge/models.py
@@ -62,7 +62,7 @@ class RuntimeState:
     secret: str = ""
     started_at: str = ""
     last_seen_at: str = ""
-    version: str = "0.4.2"
+    version: str = "0.5.0"
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -76,7 +76,7 @@ class RuntimeState:
             secret=str(data.get("secret") or ""),
             started_at=str(data.get("started_at") or ""),
             last_seen_at=str(data.get("last_seen_at") or ""),
-            version=str(data.get("version") or "0.4.2"),
+            version=str(data.get("version") or "0.5.0"),
         )
 
 

--- a/qzone_bridge/page_api.py
+++ b/qzone_bridge/page_api.py
@@ -1,0 +1,524 @@
+"""WebUI Page API adapter for the Qzone plugin.
+
+This module keeps the AstrBot Pages surface separate from chat commands and
+LLM tools. It returns browser-friendly, redacted payloads and delegates all
+real Qzone operations to the existing controller/service layer.
+"""
+
+from __future__ import annotations
+
+import base64
+import mimetypes
+import secrets
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Awaitable
+
+from .errors import DaemonUnavailableError, QzoneBridgeError, QzoneNeedsRebind, QzoneParseError
+from .media import QZONE_IMAGE_SUFFIXES, QZONE_MAX_IMAGES, guess_mime_type, is_supported_image
+from .models import FeedEntry
+from .social import QzoneComment, QzonePost, post_from_entry
+from .utils import truncate
+
+
+PAGE_UPLOAD_MAX_BYTES: int | None = None
+PAGE_DEFAULT_LIMIT = 10
+PAGE_MAX_LIMIT = 30
+
+
+@dataclass(slots=True)
+class PagePostRef:
+    hostuin: int
+    fid: str
+    appid: int = 311
+
+
+def _to_int(value: Any, default: int = 0) -> int:
+    try:
+        if value in (None, ""):
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value in (None, ""):
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _clean_text(value: Any, limit: int = 500) -> str:
+    return truncate(str(value or "").strip(), limit)
+
+
+def _is_generic_nickname(value: Any, uin: int = 0) -> bool:
+    name = str(value or "").strip()
+    compact = name.replace(" ", "")
+    return (
+        not name
+        or name in {"QQ空间用户", "QQ 空间用户", "用户"}
+        or (uin and name == str(uin))
+        or (len(name) >= 5 and name.isdigit())
+        or (compact.lower().startswith("qq") and compact[2:].isdigit())
+    )
+
+
+def _success(data: Any = None, *, message: str = "") -> dict[str, Any]:
+    payload: dict[str, Any] = {"ok": True, "data": data if data is not None else {}}
+    if message:
+        payload["message"] = message
+    return payload
+
+
+def page_error_payload(exc: Exception) -> tuple[dict[str, Any], int]:
+    code = getattr(exc, "code", "PAGE_ERROR") or "PAGE_ERROR"
+    message = getattr(exc, "message", str(exc)) or "操作失败，请稍后再试。"
+    status = 400
+    if isinstance(exc, PermissionError):
+        code = "PAGE_PERMISSION_DENIED"
+        message = "本地文件或进程权限被系统拒绝，请重启 AstrBot 后再试。"
+        status = 503
+    elif isinstance(exc, QzoneNeedsRebind):
+        status = 409
+    elif isinstance(exc, DaemonUnavailableError):
+        status = 503
+    elif isinstance(exc, QzoneBridgeError):
+        status = 400
+    return (
+        {
+            "ok": False,
+            "error": {
+                "code": str(code),
+                "message": _clean_text(message, 180),
+            },
+        },
+        status,
+    )
+
+
+class QzonePageApi:
+    def __init__(
+        self,
+        *,
+        controller: Any,
+        post_service_factory: Callable[[], Any],
+        settings: Any,
+        status_provider: Callable[[], Awaitable[dict[str, Any]]] | None = None,
+        preload_scheduler: Callable[[str], None] | None = None,
+    ):
+        self.controller = controller
+        self.post_service_factory = post_service_factory
+        self.settings = settings
+        self.status_provider = status_provider
+        self.preload_scheduler = preload_scheduler
+        self._refs_by_id: dict[str, PagePostRef] = {}
+        self._ids_by_ref: dict[tuple[int, str, int], str] = {}
+
+    @property
+    def max_feed_limit(self) -> int:
+        configured = _to_int(getattr(self.settings, "max_feed_limit", 20), 20)
+        return max(1, min(configured, PAGE_MAX_LIMIT))
+
+    async def _status(self, *, recover: bool = False) -> dict[str, Any]:
+        if recover and self.status_provider is not None:
+            return await self.status_provider()
+        return await self.controller.get_status(probe_daemon=False)
+
+    def _schedule_preload(self, trigger: str) -> None:
+        if self.preload_scheduler is not None:
+            self.preload_scheduler(trigger)
+
+    async def _ensure_ready(self) -> dict[str, Any]:
+        status = await self._status(recover=True)
+        if status.get("needs_rebind") or not _to_int(status.get("cookie_count"), 0):
+            raise QzoneNeedsRebind()
+        if status.get("daemon_state") != "ready":
+            raise DaemonUnavailableError("Qzone daemon is not ready", detail={"daemon_state": status.get("daemon_state")})
+        return status
+
+    async def _ensure_cookie_bound(self) -> dict[str, Any]:
+        status = await self._status(recover=False)
+        if status.get("needs_rebind") or not _to_int(status.get("cookie_count"), 0):
+            raise QzoneNeedsRebind()
+        return status
+
+    def _limit(self, value: Any, default: int = PAGE_DEFAULT_LIMIT) -> int:
+        limit = _to_int(value, default)
+        if limit <= 0:
+            limit = default
+        return max(1, min(limit, self.max_feed_limit))
+
+    def _post_ref_id(self, hostuin: int, fid: str, appid: int = 311) -> str:
+        ref = PagePostRef(hostuin=int(hostuin or 0), fid=str(fid or ""), appid=int(appid or 311))
+        if not ref.hostuin or not ref.fid:
+            raise QzoneParseError("说说引用无效，请刷新页面后重试。")
+        key = (ref.hostuin, ref.fid, ref.appid)
+        existing = self._ids_by_ref.get(key)
+        if existing:
+            return existing
+        token = "post_" + secrets.token_urlsafe(18)
+        while token in self._refs_by_id:
+            token = "post_" + secrets.token_urlsafe(18)
+        self._refs_by_id[token] = ref
+        self._ids_by_ref[key] = token
+        return token
+
+    def _decode_post_ref(self, value: Any) -> PagePostRef:
+        token = str(value or "").strip()
+        if not token:
+            raise QzoneParseError("缺少说说引用。")
+        ref = self._refs_by_id.get(token)
+        if ref is None:
+            raise QzoneParseError("说说引用已过期，请刷新页面后重试。")
+        return ref
+
+    @staticmethod
+    def _comment_payload(
+        comment: QzoneComment,
+        index: int,
+        *,
+        login_author: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        author = {
+            "uin": comment.uin,
+            "nickname": comment.nickname or "QQ空间用户",
+        }
+        if login_author and comment.uin and comment.uin == _to_int(login_author.get("uin"), 0):
+            login_nickname = str(login_author.get("nickname") or "").strip()
+            if login_nickname and _is_generic_nickname(author.get("nickname"), comment.uin):
+                author["nickname"] = login_nickname
+            login_avatar = str(login_author.get("avatar") or "").strip()
+            if login_avatar:
+                author["avatar"] = login_avatar
+        return {
+            "id": comment.commentid,
+            "index": index,
+            "author": author,
+            "content": comment.content,
+            "created_at": comment.created_at,
+            "parent_id": comment.parent_id,
+            "can_reply": bool(comment.commentid and comment.uin),
+        }
+
+    @staticmethod
+    def _entry_to_post(entry: FeedEntry, index: int) -> QzonePost:
+        return post_from_entry(entry, local_id=index)
+
+    @staticmethod
+    def _login_author_payload(status: dict[str, Any]) -> dict[str, Any]:
+        login_uin = _to_int(status.get("login_uin") or status.get("uin"), 0)
+        return {
+            "uin": login_uin,
+            "nickname": (
+                status.get("login_nickname")
+                or status.get("nickname")
+                or status.get("publisher_nickname")
+                or ""
+            ),
+            "avatar": status.get("login_avatar") or status.get("avatar") or "",
+        }
+
+    def _post_payload(
+        self,
+        post: QzonePost,
+        *,
+        login_uin: int = 0,
+        login_author: dict[str, Any] | None = None,
+        include_comments: bool = False,
+    ) -> dict[str, Any]:
+        author = {
+            "uin": post.hostuin,
+            "nickname": post.nickname or "QQ空间用户",
+        }
+        if login_author and login_uin and post.hostuin == login_uin:
+            login_nickname = str(login_author.get("nickname") or "").strip()
+            if login_nickname and _is_generic_nickname(author.get("nickname"), post.hostuin):
+                author["nickname"] = login_nickname
+            login_avatar = str(login_author.get("avatar") or "").strip()
+            if login_avatar:
+                author["avatar"] = login_avatar
+        payload = {
+            "id": self._post_ref_id(post.hostuin, post.fid, post.appid),
+            "local_id": post.local_id,
+            "author": author,
+            "content": post.summary,
+            "created_at": post.created_at,
+            "appid": post.appid,
+            "stats": {
+                "likes": post.like_count,
+                "comments": post.comment_count,
+            },
+            "liked": bool(post.liked),
+            "images": list(post.images[:9]),
+            "can_comment": bool(post.fid and post.hostuin),
+            "can_like": bool(post.fid and post.hostuin),
+            "can_delete": bool(login_uin and post.hostuin == login_uin),
+        }
+        if include_comments:
+            payload["comments"] = [
+                QzonePageApi._comment_payload(comment, index, login_author=login_author)
+                for index, comment in enumerate(post.comments, start=1)
+            ]
+        return payload
+
+    async def status(self) -> dict[str, Any]:
+        self._schedule_preload("page status")
+        status = await self._status(recover=True)
+        login_uin = _to_int(status.get("login_uin") or status.get("uin"), 0)
+        data = {
+            "daemon": {
+                "state": status.get("daemon_state") or "unknown",
+                "port": _to_int(status.get("daemon_port"), 0),
+                "version": status.get("daemon_version") or status.get("version") or "",
+            },
+            "login": {
+                "bound": bool(_to_int(status.get("cookie_count"), 0) and not status.get("needs_rebind")),
+                "uin": login_uin,
+                "nickname": status.get("login_nickname") or status.get("nickname") or "",
+                "avatar": status.get("login_avatar") or status.get("avatar") or "",
+                "needs_rebind": bool(status.get("needs_rebind")),
+            },
+            "limits": {
+                "feed": self.max_feed_limit,
+                "images": QZONE_MAX_IMAGES,
+                "upload_bytes": None,
+            },
+        }
+        return _success(data)
+
+    async def feed(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        self._schedule_preload("page feed")
+        status = await self._ensure_ready()
+        params = params or {}
+        hostuin = _to_int(params.get("hostuin") or params.get("target_uin"), 0)
+        limit = self._limit(params.get("limit"))
+        cursor = str(params.get("cursor") or "")
+        scope = str(params.get("scope") or "").strip().lower()
+        if scope == "friends":
+            scope = "active"
+        payload = await self.controller.list_feeds(
+            hostuin=hostuin,
+            limit=limit,
+            cursor=cursor,
+            scope=scope,
+            record_recent=False,
+        )
+        login_uin = _to_int(status.get("login_uin") or status.get("uin"), 0)
+        login_author = self._login_author_payload(status)
+        posts: list[dict[str, Any]] = []
+        for index, item in enumerate(payload.get("items") or [], start=1):
+            if not isinstance(item, dict):
+                continue
+            entry = FeedEntry(**item)
+            post = self._entry_to_post(entry, index)
+            posts.append(self._post_payload(post, login_uin=login_uin, login_author=login_author))
+        return _success(
+            {
+                "scope": payload.get("scope") or scope or "auto",
+                "hostuin": _to_int(payload.get("hostuin"), hostuin),
+                "items": posts,
+                "cursor": payload.get("cursor") or "",
+                "has_more": bool(payload.get("has_more")),
+                "count": len(posts),
+            }
+        )
+
+    async def detail(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        self._schedule_preload("page detail")
+        status = await self._ensure_ready()
+        params = params or {}
+        ref = self._decode_post_ref(params.get("id") or params.get("post_id"))
+        payload = await self.controller.detail_feed(hostuin=ref.hostuin, fid=ref.fid, appid=ref.appid)
+        entry_data = payload.get("entry") if isinstance(payload, dict) else None
+        entry = (
+            FeedEntry(**entry_data)
+            if isinstance(entry_data, dict)
+            else FeedEntry(hostuin=ref.hostuin, fid=ref.fid, appid=ref.appid, summary="")
+        )
+        post = post_from_entry(entry, detail=payload.get("raw") if isinstance(payload, dict) else None, local_id=1)
+        comments = []
+        for item in payload.get("comments") or []:
+            if not isinstance(item, dict):
+                continue
+            comments.append(
+                QzoneComment(
+                    commentid=str(item.get("commentid") or ""),
+                    uin=_to_int(item.get("uin"), 0),
+                    nickname=str(item.get("nickname") or ""),
+                    content=str(item.get("content") or ""),
+                    created_at=_to_int(item.get("created_at") or item.get("date"), 0),
+                    parent_id=str(item.get("parent_id") or ""),
+                )
+            )
+        if comments:
+            post.comments = comments
+            post.comment_count = max(post.comment_count, len(comments))
+        login_uin = _to_int(status.get("login_uin") or status.get("uin"), 0)
+        return _success(
+            {
+                "post": self._post_payload(
+                    post,
+                    login_uin=login_uin,
+                    login_author=self._login_author_payload(status),
+                    include_comments=True,
+                )
+            }
+        )
+
+    async def publish(self, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        self._schedule_preload("page publish")
+        status = await self._ensure_cookie_bound()
+        body = body or {}
+        content = str(body.get("content") or "")
+        media = body.get("media") or []
+        if not isinstance(media, list):
+            raise QzoneParseError("图片列表格式不正确。")
+        if len(media) > QZONE_MAX_IMAGES:
+            raise QzoneParseError(f"QQ空间一次最多只能上传 {QZONE_MAX_IMAGES} 张图片。")
+        payload = await self.controller.publish_post(
+            content=content,
+            sync_weibo=_to_bool(body.get("sync_weibo"), False),
+            media=media,
+            content_sanitized=True,
+        )
+        data = {
+            "message": payload.get("message") or "说说已发布。",
+            "media_count": _to_int(payload.get("media_count"), len(media)),
+            "photo_count": _to_int(payload.get("photo_count"), len(media)),
+        }
+        fid = str(payload.get("fid") or "")
+        login_uin = _to_int(status.get("login_uin") or status.get("uin"), 0)
+        if fid and login_uin:
+            data["post"] = {
+                "id": self._post_ref_id(login_uin, fid, 311),
+                "author": self._login_author_payload(status),
+                "content": content,
+                "created_at": int(time.time()),
+                "appid": 311,
+                "stats": {"likes": 0, "comments": 0},
+                "liked": False,
+                "images": [],
+                "can_comment": True,
+                "can_like": True,
+                "can_delete": True,
+            }
+        return _success(data, message="说说已发布。")
+
+    async def like(self, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        self._schedule_preload("page like")
+        await self._ensure_cookie_bound()
+        body = body or {}
+        ref = self._decode_post_ref(body.get("id") or body.get("post_id"))
+        unlike = _to_bool(body.get("unlike"), False)
+        payload = await self.controller.like_post(
+            hostuin=ref.hostuin,
+            fid=ref.fid,
+            appid=ref.appid,
+            unlike=unlike,
+            fast=True,
+        )
+        verified = payload.get("verified", True) is not False
+        data = {
+            "action": "unlike" if unlike else "like",
+            "liked": bool(payload.get("liked", not unlike)),
+            "verified": verified,
+            "already": bool(payload.get("already")),
+            "operation_status": payload.get("operation_status") or ("done" if verified else "accepted_pending_verification"),
+            "summary": _clean_text(payload.get("summary"), 160),
+        }
+        return _success(data, message="已提交到 QQ空间。")
+
+    async def comment(self, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        self._schedule_preload("page comment")
+        status = await self._ensure_cookie_bound()
+        body = body or {}
+        ref = self._decode_post_ref(body.get("id") or body.get("post_id"))
+        content = str(body.get("content") or "").strip()
+        if not content:
+            raise QzoneParseError("评论内容不能为空。")
+        payload = await self.controller.comment_post(
+            hostuin=ref.hostuin,
+            fid=ref.fid,
+            content=content,
+            appid=ref.appid,
+            private=_to_bool(body.get("private"), False),
+        )
+        return _success(
+            {
+                "comment": {
+                    "id": str(payload.get("commentid") or ""),
+                    "content": content,
+                    "author": self._login_author_payload(status),
+                },
+                "message": payload.get("message") or "评论已发送。",
+            },
+            message="评论已发送。",
+        )
+
+    async def reply(self, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        self._schedule_preload("page reply")
+        status = await self._ensure_cookie_bound()
+        body = body or {}
+        ref = self._decode_post_ref(body.get("id") or body.get("post_id"))
+        content = str(body.get("content") or "").strip()
+        commentid = str(body.get("commentid") or body.get("comment_id") or "")
+        comment_uin = _to_int(body.get("comment_uin") or body.get("commentUin"), 0)
+        if not content:
+            raise QzoneParseError("回复内容不能为空。")
+        if not commentid or not comment_uin:
+            raise QzoneParseError("缺少要回复的评论。")
+        payload = await self.controller.reply_comment(
+            hostuin=ref.hostuin,
+            fid=ref.fid,
+            commentid=commentid,
+            comment_uin=comment_uin,
+            content=content,
+            appid=ref.appid,
+        )
+        return _success(
+            {
+                "reply": {
+                    "id": str(payload.get("commentid") or ""),
+                    "content": content,
+                    "author": self._login_author_payload(status),
+                },
+                "message": payload.get("message") or "回复已发送。",
+            },
+            message="回复已发送。",
+        )
+
+    async def delete(self, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        self._schedule_preload("page delete")
+        status = await self._ensure_cookie_bound()
+        body = body or {}
+        ref = self._decode_post_ref(body.get("id") or body.get("post_id"))
+        login_uin = _to_int(status.get("login_uin") or status.get("uin"), 0)
+        if not login_uin or ref.hostuin != login_uin:
+            raise QzoneParseError("只能删除自己发布的说说。")
+        payload = await self.controller.delete_post(fid=ref.fid, appid=ref.appid)
+        return _success({"message": payload.get("message") or "说说已删除。"}, message="说说已删除。")
+
+    async def upload_media(self, *, filename: str, content_type: str = "", data: bytes) -> dict[str, Any]:
+        if not data:
+            raise QzoneParseError("图片内容为空。")
+        name = Path(filename or "image.jpg").name
+        mime_type = (content_type or mimetypes.guess_type(name)[0] or guess_mime_type(name) or "").split(";", 1)[0]
+        suffix = Path(name).suffix.lower()
+        if suffix not in QZONE_IMAGE_SUFFIXES and not mime_type.lower().startswith("image/"):
+            raise QzoneParseError("只支持上传图片文件。")
+        media = {
+            "kind": "image",
+            "source": "base64://" + base64.b64encode(data).decode("ascii"),
+            "name": name,
+            "mime_type": mime_type,
+            "size": len(data),
+        }
+        if not is_supported_image(media):
+            raise QzoneParseError("只支持上传图片文件。")
+        return _success({"media": media}, message="图片已加入发布队列。")

--- a/qzone_bridge/settings.py
+++ b/qzone_bridge/settings.py
@@ -102,6 +102,11 @@ class PluginSettings:
     post_prompt: str = "找出一个你感兴趣的主题来写一段适合 QQ 空间的说说，简短、有个性、不要解释。"
     comment_provider_id: str = ""
     comment_prompt: str = "生成一句简短、直接、贴题的评论，不要解释。"
+    comment_pipeline_enabled: bool = True
+    comment_judgment_provider_id: str = ""
+    comment_reasoning_provider_id: str = ""
+    comment_execution_provider_id: str = ""
+    comment_skip_checkins: bool = True
     comment_max_length: int = 60
     reply_provider_id: str = ""
     reply_prompt: str = "这条帖子收到了一条评论，请自然回复此条评论，不要解释。"
@@ -153,6 +158,11 @@ class PluginSettings:
             post_prompt=str(_nested(mapping, "llm", "post_prompt", cls.post_prompt) or cls.post_prompt),
             comment_provider_id=str(_nested(mapping, "llm", "comment_provider_id", "") or ""),
             comment_prompt=str(_nested(mapping, "llm", "comment_prompt", cls.comment_prompt) or cls.comment_prompt),
+            comment_pipeline_enabled=_as_bool(_nested(mapping, "llm", "comment_pipeline_enabled", True), True),
+            comment_judgment_provider_id=str(_nested(mapping, "llm", "comment_judgment_provider_id", "") or ""),
+            comment_reasoning_provider_id=str(_nested(mapping, "llm", "comment_reasoning_provider_id", "") or ""),
+            comment_execution_provider_id=str(_nested(mapping, "llm", "comment_execution_provider_id", "") or ""),
+            comment_skip_checkins=_as_bool(_nested(mapping, "llm", "comment_skip_checkins", True), True),
             comment_max_length=int(_nested(mapping, "llm", "comment_max_length", 60) or 60),
             reply_provider_id=str(_nested(mapping, "llm", "reply_provider_id", "") or ""),
             reply_prompt=str(_nested(mapping, "llm", "reply_prompt", cls.reply_prompt) or cls.reply_prompt),

--- a/tests/test_command_descriptions.py
+++ b/tests/test_command_descriptions.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _decorator_name(node: ast.expr) -> str:
+    call = node if isinstance(node, ast.Call) else None
+    target = call.func if call is not None else node
+    if isinstance(target, ast.Attribute):
+        prefix = target.value.id if isinstance(target.value, ast.Name) else ""
+        return f"{prefix}.{target.attr}" if prefix else target.attr
+    if isinstance(target, ast.Name):
+        return target.id
+    return ""
+
+
+def test_all_astrbot_commands_have_readable_descriptions() -> None:
+    tree = ast.parse((ROOT / "main.py").read_text(encoding="utf-8"))
+    command_decorators = {"filter.command", "filter.command_group", "qzone.command"}
+    missing: list[str] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not any(_decorator_name(item) in command_decorators for item in node.decorator_list):
+            continue
+        doc = ast.get_docstring(node) or ""
+        if not doc.strip():
+            missing.append(node.name)
+
+    assert missing == []
+
+
+def test_all_astrbot_filter_handlers_have_readable_descriptions() -> None:
+    tree = ast.parse((ROOT / "main.py").read_text(encoding="utf-8"))
+    missing: list[str] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not any(_decorator_name(item).startswith("filter.") for item in node.decorator_list):
+            continue
+        doc = ast.get_docstring(node) or ""
+        if not doc.strip():
+            missing.append(node.name)
+
+    assert missing == []

--- a/tests/test_controller_log_fallback.py
+++ b/tests/test_controller_log_fallback.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from qzone_bridge.controller import QzoneDaemonController
+
+
+def test_spawn_daemon_falls_back_when_daemon_log_is_not_writable(tmp_path, monkeypatch):
+    blocked_log = tmp_path / "daemon.log"
+    blocked_log.mkdir()
+    temp_root = tmp_path / "temp"
+    captured = {}
+
+    def fake_popen(cmd, cwd=None, **kwargs):
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        captured["stdout_name"] = getattr(kwargs["stdout"], "name", "")
+        captured["stderr_name"] = getattr(kwargs["stderr"], "name", "")
+
+        class _Process:
+            pid = 12345
+
+            def poll(self):
+                return None
+
+        return _Process()
+
+    monkeypatch.setattr("qzone_bridge.controller.tempfile.gettempdir", lambda: str(temp_root))
+    monkeypatch.setattr("qzone_bridge.controller.subprocess.Popen", fake_popen)
+    controller = QzoneDaemonController(plugin_root=tmp_path, data_dir=tmp_path / "data")
+    monkeypatch.setattr(controller, "_daemon_log_path", lambda: blocked_log)
+
+    controller._spawn_daemon(18999)
+
+    assert "daemon_main.py" in str(captured["cmd"][1])
+    assert str(blocked_log) not in captured["stdout_name"]
+    assert captured["stdout_name"] == captured["stderr_name"]
+    assert str(temp_root / "astrbot_qzone_daemon_logs") in captured["stdout_name"]

--- a/tests/test_page_api.py
+++ b/tests/test_page_api.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from qzone_bridge.errors import DaemonUnavailableError, QzoneParseError
+from qzone_bridge.page_api import QzonePageApi
+from qzone_bridge import controller as controller_module
+from qzone_bridge.daemon import QzoneDaemonService
+from qzone_bridge.models import BridgeState, FeedEntry, SessionState
+from qzone_bridge.storage import StateStore
+
+
+class _Controller:
+    def __init__(self):
+        self.published = None
+        self.deleted = None
+        self.liked = None
+        self.list_record_recent_values = []
+        self.status_probe_values = []
+        self.status = {
+            "daemon_state": "ready",
+            "daemon_port": 18999,
+            "daemon_version": "test",
+            "cookie_count": 2,
+            "needs_rebind": False,
+            "login_uin": 10001,
+            "login_nickname": "Tester",
+        }
+
+    async def get_status(self, *, probe_daemon=False):
+        self.status_probe_values.append(probe_daemon)
+        return dict(self.status)
+
+    async def list_feeds(self, *, hostuin=0, limit=5, cursor="", scope="", record_recent=True):
+        self.list_record_recent_values.append(record_recent)
+        return {
+            "scope": scope or "active",
+            "hostuin": hostuin or 10001,
+            "cursor": "next-cursor",
+            "has_more": True,
+            "items": [
+                {
+                    "hostuin": 20002,
+                    "fid": "fid-secret",
+                    "appid": 311,
+                    "summary": "hello from qzone",
+                    "nickname": "Friend",
+                    "created_at": 1710000000,
+                    "like_count": 3,
+                    "comment_count": 1,
+                    "liked": False,
+                    "curkey": "curkey-secret",
+                    "unikey": "unikey-secret",
+                    "busi_param": {"private": "secret"},
+                    "raw": {"raw_secret": "hidden"},
+                }
+            ],
+        }
+
+    async def detail_feed(self, *, hostuin, fid, appid=311, busi_param=""):
+        return {
+            "entry": {
+                "hostuin": hostuin,
+                "fid": fid,
+                "appid": appid,
+                "summary": "detail text",
+                "nickname": "Friend",
+                "created_at": 1710000000,
+                "like_count": 3,
+                "comment_count": 1,
+                "liked": False,
+                "raw": {"raw_secret": "hidden"},
+            },
+            "comments": [
+                {
+                    "commentid": "comment-1",
+                    "uin": 30003,
+                    "nickname": "Commenter",
+                    "content": "nice",
+                    "created_at": 1710000100,
+                },
+                {
+                    "commentid": "comment-self",
+                    "uin": 10001,
+                    "nickname": "QQ 10001",
+                    "content": "self comment",
+                    "created_at": 1710000200,
+                }
+            ],
+            "raw": {"raw_secret": "hidden"},
+        }
+
+    async def publish_post(self, **kwargs):
+        self.published = kwargs
+        return {"fid": "new-fid", "message": "ok", "media_count": len(kwargs.get("media") or []), "photo_count": 0}
+
+    async def like_post(self, **kwargs):
+        self.liked = kwargs
+        return {
+            "liked": True,
+            "verified": False,
+            "summary": "accepted",
+            "operation_status": "accepted_pending_verification",
+        }
+
+    async def comment_post(self, **kwargs):
+        return {"commentid": "comment-new", "message": "ok"}
+
+    async def reply_comment(self, **kwargs):
+        return {"commentid": "reply-new", "message": "ok"}
+
+    async def delete_post(self, **kwargs):
+        self.deleted = kwargs
+        return {"message": "ok"}
+
+
+def _api(controller: _Controller | None = None) -> QzonePageApi:
+    controller = controller or _Controller()
+    return QzonePageApi(
+        controller=controller,
+        post_service_factory=lambda: None,
+        settings=SimpleNamespace(max_feed_limit=20),
+    )
+
+
+def test_page_feed_redacts_internal_qzone_fields() -> None:
+    api = _api()
+    payload = asyncio.run(api.feed({"scope": "friends", "limit": 5}))
+
+    post = payload["data"]["items"][0]
+    assert payload["ok"] is True
+    assert post["content"] == "hello from qzone"
+    assert "id" in post
+    assert "fid" not in post
+    assert "raw" not in post
+    assert "curkey" not in post
+    assert "unikey" not in post
+    assert "busi_param" not in post
+    assert "fid-secret" not in post["id"]
+    assert "curkey-secret" not in post["id"]
+
+    ref = api._decode_post_ref(post["id"])
+    assert ref.hostuin == 20002
+    assert ref.fid == "fid-secret"
+    assert api.controller.list_record_recent_values == [False]
+
+
+def test_page_detail_redacts_raw_but_keeps_comments() -> None:
+    api = _api()
+    feed_payload = asyncio.run(api.feed({}))
+    post_id = feed_payload["data"]["items"][0]["id"]
+
+    detail_payload = asyncio.run(api.detail({"id": post_id}))
+
+    post = detail_payload["data"]["post"]
+    assert detail_payload["ok"] is True
+    assert post["comments"][0]["content"] == "nice"
+    assert post["comments"][1]["author"]["nickname"] == "Tester"
+    assert "raw" not in post
+    assert "fid" not in post
+
+
+def test_page_like_preserves_pending_verification_as_success() -> None:
+    api = _api()
+    feed_payload = asyncio.run(api.feed({}))
+    post_id = feed_payload["data"]["items"][0]["id"]
+
+    payload = asyncio.run(api.like({"id": post_id}))
+
+    assert payload["ok"] is True
+    assert payload["data"]["verified"] is False
+    assert payload["data"]["operation_status"] == "accepted_pending_verification"
+
+
+def test_page_like_uses_fast_path_and_skips_daemon_readiness_gate() -> None:
+    controller = _Controller()
+    controller.status["daemon_state"] = "degraded"
+    api = _api(controller)
+    post_id = api._post_ref_id(20002, "fid-secret", 311)
+
+    payload = asyncio.run(api.like({"id": post_id}))
+
+    assert payload["ok"] is True
+    assert controller.liked["fast"] is True
+    assert controller.liked["hostuin"] == 20002
+    assert controller.status_probe_values == [False]
+
+
+def test_page_like_propagates_daemon_request_errors_after_fast_cookie_check() -> None:
+    class _FailingController(_Controller):
+        async def like_post(self, **kwargs):
+            raise DaemonUnavailableError("daemon down")
+
+    controller = _FailingController()
+    controller.status["daemon_state"] = "degraded"
+    api = _api(controller)
+    post_id = api._post_ref_id(20002, "fid-secret", 311)
+
+    with pytest.raises(DaemonUnavailableError):
+        asyncio.run(api.like({"id": post_id}))
+
+
+def test_page_publish_passes_webui_content_as_already_sanitized() -> None:
+    controller = _Controller()
+
+    payload = asyncio.run(_api(controller).publish({"content": "qzone post literal", "media": []}))
+
+    assert payload["ok"] is True
+    assert controller.published["content"] == "qzone post literal"
+    assert controller.published["content_sanitized"] is True
+    assert payload["data"]["post"]["author"]["uin"] == 10001
+    assert payload["data"]["post"]["author"]["nickname"] == "Tester"
+
+
+def test_page_comment_and_reply_return_current_author() -> None:
+    api = _api()
+    post_id = api._post_ref_id(20002, "fid-secret", 311)
+
+    comment_payload = asyncio.run(api.comment({"id": post_id, "content": "nice"}))
+    reply_payload = asyncio.run(
+        api.reply({
+            "id": post_id,
+            "commentid": "comment-1",
+            "comment_uin": 30003,
+            "content": "thanks",
+        })
+    )
+
+    assert comment_payload["data"]["comment"]["author"] == {
+        "uin": 10001,
+        "nickname": "Tester",
+        "avatar": "",
+    }
+    assert reply_payload["data"]["reply"]["author"] == {
+        "uin": 10001,
+        "nickname": "Tester",
+        "avatar": "",
+    }
+
+
+def test_page_status_reports_unlimited_upload_bytes() -> None:
+    payload = asyncio.run(_api().status())
+
+    assert payload["ok"] is True
+    assert payload["data"]["limits"]["upload_bytes"] is None
+
+
+def test_page_upload_accepts_images_above_old_page_limit() -> None:
+    data = b"\x89PNG\r\n\x1a\n" + (b"x" * (8 * 1024 * 1024))
+
+    payload = asyncio.run(_api().upload_media(filename="large.png", content_type="image/png", data=data))
+
+    assert payload["ok"] is True
+    assert payload["data"]["media"]["name"] == "large.png"
+    assert payload["data"]["media"]["size"] == len(data)
+
+
+def test_page_delete_rejects_other_users_posts() -> None:
+    api = _api()
+    feed_payload = asyncio.run(api.feed({}))
+    post_id = feed_payload["data"]["items"][0]["id"]
+
+    with pytest.raises(QzoneParseError):
+        asyncio.run(api.delete({"id": post_id}))
+
+
+def test_page_upload_rejects_non_images() -> None:
+    with pytest.raises(QzoneParseError):
+        asyncio.run(_api().upload_media(filename="note.txt", content_type="text/plain", data=b"not-image"))
+
+
+def test_controller_rejects_same_api_but_stale_daemon_version() -> None:
+    controller = object.__new__(controller_module.QzoneDaemonController)
+    payload = {
+        "ok": True,
+        "data": {
+            "daemon_state": "ready",
+            "daemon_port": 18999,
+            "daemon_version": "0.4.2",
+            "bridge_api_version": controller_module.BRIDGE_API_VERSION,
+        },
+    }
+
+    assert controller._health_payload_is_compatible(payload) is False
+
+    payload["data"]["daemon_version"] = controller_module.BRIDGE_VERSION
+    assert controller._health_payload_is_compatible(payload) is True
+
+
+def test_daemon_fast_like_updates_shared_feed_cache_once(tmp_path) -> None:
+    async def scenario() -> FeedEntry:
+        store = StateStore(tmp_path)
+        state = BridgeState()
+        state.session = SessionState(uin=10001, cookies={"uin": "o10001", "p_skey": "token"})
+        store.write(state)
+        service = QzoneDaemonService(store, secret="secret", port=18999)
+        await service.client.close()
+
+        entry = FeedEntry(hostuin=20002, fid="fid-secret", appid=311, summary="", liked=False, like_count=3)
+
+        class _Client:
+            def __init__(self):
+                self.feed_cache = {(20002, "fid-secret"): entry}
+
+            async def like_post(self, *args, **kwargs):
+                return {"ok": True}
+
+        service.client = _Client()
+        service.recent_feed_entries = [entry]
+        service._set_success = lambda *, defer_save=False: None
+
+        await service.like_post(hostuin=20002, fid="fid-secret", appid=311, fast=True)
+        assert entry.liked is True
+        assert entry.like_count == 4
+
+        await service.like_post(hostuin=20002, fid="fid-secret", appid=311, fast=True)
+        return entry
+
+    entry = asyncio.run(scenario())
+
+    assert entry.liked is True
+    assert entry.like_count == 4
+
+
+def test_daemon_list_feeds_can_fill_cache_without_overwriting_recent(tmp_path) -> None:
+    async def scenario() -> list[FeedEntry]:
+        store = StateStore(tmp_path)
+        state = BridgeState()
+        state.session = SessionState(uin=10001, cookies={"uin": "o10001", "p_skey": "token"})
+        store.write(state)
+        service = QzoneDaemonService(store, secret="secret", port=18999)
+        await service.client.close()
+        previous = FeedEntry(hostuin=30003, fid="old-fid", appid=311, summary="old")
+        service.recent_feed_entries = [previous]
+
+        class _Client:
+            def __init__(self):
+                self.feed_cache = {}
+
+            async def index(self):
+                return {"data": [{"hostuin": 10001, "fid": "new-fid", "content": "new"}]}
+
+            def cache_feed_page(self, hostuin, items):
+                for item in items:
+                    self.feed_cache[(hostuin or item.hostuin, item.fid)] = item
+
+        service.client = _Client()
+        await service.list_feeds(hostuin=10001, limit=5, scope="self", record_recent=False)
+        return service.recent_feed_entries
+
+    recent = asyncio.run(scenario())
+
+    assert [entry.fid for entry in recent] == ["old-fid"]

--- a/tests/test_qzone_page_frontend.py
+++ b/tests/test_qzone_page_frontend.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_page_header_removes_brand_block() -> None:
+    html = (ROOT / "pages" / "qzone" / "index.html").read_text(encoding="utf-8")
+
+    assert 'class="brand"' not in html
+    assert 'id="statusText"' not in html
+    assert 'id="accountName"' in html
+    assert 'id="accountMeta"' in html
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required for the frontend smoke test")
+def test_page_frontend_reply_uses_inline_form_and_cached_detail(tmp_path: Path) -> None:
+    harness = tmp_path / "qzone_page_harness.mjs"
+    harness.write_text(
+        r'''
+import { pathToFileURL } from "node:url";
+
+class Element {
+  constructor(id = "") {
+    this.id = id;
+    this.hidden = false;
+    this.textContent = "";
+    this.innerHTML = "";
+    this.value = "";
+    this.disabled = false;
+    this.files = [];
+    this.children = [];
+    this.dataset = {};
+    this.className = "";
+    this.type = "";
+    this.rows = 0;
+    this.placeholder = "";
+    this.maxlength = 0;
+    this.inputmode = "";
+    this.autocomplete = "";
+    this.loading = "";
+    this.alt = "";
+    this.src = "";
+    this.style = {};
+    this.handlers = {};
+    this.tagName = "";
+    this.parentNode = null;
+    this.classList = {
+      add: (name) => {
+        if (!this.className.split(/\s+/).includes(name)) {
+          this.className = `${this.className} ${name}`.trim();
+        }
+      },
+      remove: (name) => {
+        this.className = this.className.split(/\s+/).filter((item) => item && item !== name).join(" ");
+      },
+      toggle: (name, enabled) => {
+        this[`class:${name}`] = Boolean(enabled);
+        if (enabled) this.classList.add(name);
+        else this.classList.remove(name);
+      },
+      contains: (name) => this.className.split(/\s+/).includes(name),
+    };
+  }
+
+  append(...nodes) {
+    for (const node of nodes) {
+      if (node && typeof node === "object") node.parentNode = this;
+      this.children.push(node);
+    }
+  }
+
+  appendChild(node) {
+    this.append(node);
+    return node;
+  }
+
+  replaceChildren(...nodes) {
+    this.children = [];
+    this.append(...nodes);
+  }
+
+  remove() {
+    if (!this.parentNode) return;
+    this.parentNode.children = this.parentNode.children.filter((item) => item !== this);
+  }
+
+  addEventListener(name, handler) {
+    this.handlers[name] = handler;
+  }
+
+  setAttribute(name, value) {
+    this[name] = String(value);
+  }
+
+  focus() {
+    this.focused = true;
+  }
+
+  querySelector(selector) {
+    return find(this, selector);
+  }
+}
+
+function matches(element, selector) {
+  if (!(element instanceof Element)) return false;
+  if (selector.startsWith(".")) {
+    return element.className.split(/\s+/).includes(selector.slice(1));
+  }
+  return element.tagName.toLowerCase() === selector.toLowerCase();
+}
+
+function find(root, selector) {
+  if (selector.includes(" ")) {
+    const [head, ...tail] = selector.split(/\s+/);
+    const parent = find(root, head);
+    return parent ? find(parent, tail.join(" ")) : null;
+  }
+  for (const child of root.children) {
+    if (matches(child, selector)) return child;
+    const nested = child instanceof Element ? find(child, selector) : null;
+    if (nested) return nested;
+  }
+  return null;
+}
+
+function byText(root, value) {
+  for (const child of root.children) {
+    if (child instanceof Element && child.textContent === value) return child;
+    const nested = child instanceof Element ? byText(child, value) : null;
+    if (nested) return nested;
+  }
+  return null;
+}
+
+const elements = new Map();
+for (const id of [
+  "accountName",
+  "accountMeta",
+  "targetForm",
+  "targetUin",
+  "publishForm",
+  "publishContent",
+  "mediaInput",
+  "mediaStrip",
+  "publishButton",
+  "refreshButton",
+  "feedTitle",
+  "feedMeta",
+  "notice",
+  "feed",
+  "moreButton",
+  "detailPane",
+  "detailEmpty",
+  "detailContent",
+]) {
+  elements.set(id, new Element(id));
+}
+
+const account = new Element("account");
+account.className = "account";
+const accountAvatar = new Element("account-avatar");
+accountAvatar.className = "avatar";
+account.append(accountAvatar);
+
+const tabs = ["friends", "self", "profile"].map((scope) => {
+  const tab = new Element(`tab-${scope}`);
+  tab.dataset.scope = scope;
+  return tab;
+});
+
+globalThis.document = {
+  body: new Element("body"),
+  getElementById(id) {
+    return elements.get(id) || null;
+  },
+  querySelector(selector) {
+    return selector === ".account .avatar" ? accountAvatar : null;
+  },
+  querySelectorAll(selector) {
+    return selector === ".tab" ? tabs : [];
+  },
+  createElement(tag) {
+    const element = new Element();
+    element.tagName = tag.toUpperCase();
+    return element;
+  },
+};
+
+let promptCalls = 0;
+let replyPayload = null;
+let detailResolve;
+const detailPromise = new Promise((resolve) => {
+  detailResolve = resolve;
+});
+
+const feedPost = {
+  id: "post_1",
+  author: { uin: 10001, nickname: "Tester" },
+  content: "hello from qzone",
+  created_at: 1710000000,
+  stats: { likes: 3, comments: 1 },
+  liked: false,
+  images: [],
+  comments: [
+    {
+      id: "comment-1",
+      author: { uin: 20002, nickname: "Friend" },
+      content: "nice",
+      created_at: 1710000100,
+      can_reply: true,
+    },
+  ],
+};
+
+globalThis.window = {
+  setTimeout,
+  clearTimeout,
+  prompt() {
+    promptCalls += 1;
+    return "should not be used";
+  },
+  confirm() {
+    return true;
+  },
+  AstrBotPluginPage: {
+    ready() {
+      return Promise.resolve({ pluginName: "astrbot_plugin_qzone_ultra", pageName: "qzone" });
+    },
+    apiGet(endpoint) {
+      if (endpoint === "page/status") {
+        return Promise.resolve({
+          daemon: { state: "ready", version: "0.4.3" },
+          login: { bound: true, uin: 10001, nickname: "" },
+          limits: { images: 9 },
+        });
+      }
+      if (endpoint === "page/feed") {
+        return Promise.resolve({
+          items: [feedPost],
+          cursor: "",
+          has_more: false,
+        });
+      }
+      if (endpoint === "page/detail") {
+        return detailPromise;
+      }
+      throw new Error(`unexpected GET ${endpoint}`);
+    },
+    apiPost(endpoint, body) {
+      if (endpoint === "page/reply") {
+        replyPayload = body;
+        return Promise.resolve({
+          reply: {
+            id: "reply-new",
+            content: body.content,
+            author: { uin: 10001, nickname: "" },
+          },
+        });
+      }
+      return Promise.resolve({});
+    },
+    upload(endpoint, file) {
+      if (endpoint !== "page/upload-media") {
+        throw new Error(`unexpected upload ${endpoint}`);
+      }
+      return Promise.resolve({
+        media: {
+          name: file.name,
+          data_url: "data:image/png;base64,AA==",
+        },
+      });
+    },
+  },
+};
+
+await import(pathToFileURL(process.argv[2]).href);
+await new Promise((resolve) => setTimeout(resolve, 30));
+
+if (elements.get("accountName").textContent !== "Tester") {
+  throw new Error(`account nickname fallback failed: ${elements.get("accountName").textContent}`);
+}
+if (elements.get("accountMeta").textContent !== "QQ 10001") {
+  throw new Error(`account QQ meta failed: ${elements.get("accountMeta").textContent}`);
+}
+const accountImg = accountAvatar.children.find((child) => child.tagName === "IMG");
+if (!accountImg) {
+  throw new Error("account avatar image was not rendered");
+}
+if (!String(accountImg.src).startsWith("https://")) {
+  throw new Error(`account avatar must use https: ${accountImg.src}`);
+}
+if (accountImg.alt === "Avatar") {
+  throw new Error("account avatar leaked the placeholder alt text");
+}
+accountImg.onerror();
+accountImg.onerror();
+if (accountAvatar.textContent !== "T") {
+  throw new Error(`account avatar fallback was wrong: ${accountAvatar.textContent}`);
+}
+if (elements.get("feedMeta").textContent !== "1 条") {
+  throw new Error(`feed was not rendered: ${elements.get("feedMeta").textContent}`);
+}
+
+const detailButton = byText(elements.get("feed"), "查看详情");
+if (!detailButton) throw new Error("detail button was not rendered");
+detailButton.handlers.click();
+
+if (elements.get("detailContent").hidden) {
+  throw new Error("cached detail was not rendered immediately");
+}
+if (!byText(elements.get("detailContent"), "回复")) {
+  throw new Error("cached comments were not rendered before network detail finished");
+}
+
+const replyButton = byText(elements.get("detailContent"), "回复");
+replyButton.handlers.click();
+if (promptCalls !== 0) {
+  throw new Error("reply still used window.prompt");
+}
+
+const replyForm = elements.get("detailContent").querySelector(".reply-form");
+const textarea = replyForm?.querySelector("textarea");
+if (!replyForm || !textarea) {
+  throw new Error("inline reply form was not rendered");
+}
+textarea.value = "谢谢";
+await replyForm.handlers.submit({ preventDefault() {} });
+await new Promise((resolve) => setTimeout(resolve, 0));
+
+if (!replyPayload || replyPayload.commentid !== "comment-1" || replyPayload.content !== "谢谢") {
+  throw new Error(`reply payload was wrong: ${JSON.stringify(replyPayload)}`);
+}
+if (!byText(elements.get("detailContent"), "Tester")) {
+  throw new Error("self reply did not reuse the current nickname");
+}
+
+detailResolve({
+  post: {
+    ...feedPost,
+    stats: { likes: 3, comments: 1 },
+    comments: [...feedPost.comments],
+  },
+});
+await new Promise((resolve) => setTimeout(resolve, 30));
+
+if (!byText(elements.get("detailContent"), "回复 Friend：谢谢")) {
+  throw new Error("stale detail response overwrote the local reply");
+}
+
+const mediaInput = elements.get("mediaInput");
+mediaInput.files = [{ name: "photo.png" }];
+await mediaInput.handlers.change();
+await new Promise((resolve) => setTimeout(resolve, 30));
+
+if (elements.get("mediaStrip").children.length !== 1) {
+  throw new Error("unwrapped upload payload was not accepted");
+}
+''',
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        ["node", str(harness), str(ROOT / "pages" / "qzone" / "app.js")],
+        check=True,
+        cwd=ROOT,
+    )

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import importlib
 import inspect
 from dataclasses import asdict
@@ -12,10 +13,16 @@ import types
 import pytest
 
 from qzone_bridge.client import QzoneClient
+from qzone_bridge.auto_comment import (
+    AutoCommentPipeline,
+    AutoCommentPipelineConfig,
+    AutoCommentStateStore,
+)
 from qzone_bridge.controller import QzoneDaemonController
 from qzone_bridge.errors import QzoneBridgeError, QzoneCookieAcquireError, QzoneParseError, QzoneRequestError
 from qzone_bridge.models import BridgeState, SessionState
 from qzone_bridge.settings import PluginSettings
+from qzone_bridge.social import QzonePost
 from qzone_bridge.storage import StateStore
 from qzone_bridge import source_policy
 
@@ -139,6 +146,33 @@ def test_main_import_recovers_from_renderer_with_false_comment_section_contract(
 
         assert main.QzoneStablePlugin.__name__ == "QzoneStablePlugin"
         assert getattr(main._publish_renderer, "SUPPORTS_COMMENT_RESULT_SECTIONS", False) is True
+    finally:
+        for name in list(sys.modules):
+            if name == "qzone_bridge" or name.startswith("qzone_bridge."):
+                sys.modules.pop(name, None)
+        sys.modules.update(saved_modules)
+        sys.modules.pop("main", None)
+
+
+def test_main_import_recovers_from_stale_page_api_constructor(monkeypatch: pytest.MonkeyPatch) -> None:
+    saved_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "qzone_bridge" or name.startswith("qzone_bridge.")
+    }
+    import qzone_bridge.page_api as page_api
+
+    class _OldQzonePageApi:
+        def __init__(self, *, controller, post_service_factory, settings, status_provider=None):
+            self.controller = controller
+
+    try:
+        monkeypatch.setattr(page_api, "QzonePageApi", _OldQzonePageApi)
+
+        main = _import_main_with_stubs(monkeypatch)
+
+        assert main.QzonePageApi is not _OldQzonePageApi
+        assert "preload_scheduler" in inspect.signature(main.QzonePageApi).parameters
     finally:
         for name in list(sys.modules):
             if name == "qzone_bridge" or name.startswith("qzone_bridge."):
@@ -604,12 +638,36 @@ def test_remote_media_policy_blocks_localhost_and_private_dns(monkeypatch: pytes
     assert not source_policy.is_remote_media_url_allowed("https://media.example.test/a.png")
 
 
-def test_base64_upload_sources_are_size_limited_before_decode(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_base64_upload_sources_do_not_apply_plugin_size_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     import qzone_bridge.client as client_module
 
-    monkeypatch.setattr(client_module, "MAX_UPLOAD_IMAGE_BYTES", 8)
-    with pytest.raises(QzoneParseError, match="大小超过限制"):
-        QzoneClient._decode_upload_image_base64("A" * 20, label="图片")
+    monkeypatch.setattr(client_module, "MAX_UPLOAD_IMAGE_BYTES", 8, raising=False)
+
+    assert QzoneClient._decode_upload_image_base64("A" * 20, label="图片") == b"\x00" * 15
+
+
+def test_upload_photo_rejects_forged_image_kind_before_network() -> None:
+    async def scenario() -> None:
+        client = QzoneClient(SessionState(uin=12345, cookies={"uin": "o12345", "p_skey": "secret"}))
+        try:
+            async def fail_request(*args, **kwargs):
+                raise AssertionError("invalid image bytes should not reach QQ upload")
+
+            client._request_json = fail_request  # type: ignore[method-assign]
+            encoded = base64.b64encode(b"not really an image").decode("ascii")
+            with pytest.raises(QzoneParseError, match="图片内容"):
+                await client.upload_photo(
+                    {
+                        "kind": "image",
+                        "source": f"base64://{encoded}",
+                        "name": "fake.png",
+                        "mime_type": "image/png",
+                    }
+                )
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
 
 
 def test_daemon_secret_is_not_passed_in_argv(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2322,6 +2380,73 @@ def test_auto_comment_skips_candidate_when_detail_check_fails(
     assert any("no eligible posts" in item for item in captured["logs"])
 
 
+def test_auto_comment_once_skips_sensitive_posts_before_comment_generation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    captured: dict[str, object] = {"comments": [], "logs": []}
+    entry = main.FeedEntry(
+        hostuin=11111,
+        fid="fid-sensitive",
+        appid=311,
+        summary="\u4f4f\u9662\u624b\u672f",
+        nickname="tester",
+    )
+
+    class _Logger:
+        def debug(self, *args, **kwargs): ...
+
+        def exception(self, *args, **kwargs): ...
+
+        def info(self, message, *args, **kwargs):
+            captured["logs"].append(message % args if args else str(message))
+
+        def warning(self, message, *args, **kwargs):
+            captured["logs"].append(message % args if args else str(message))
+
+    class _Controller:
+        async def list_feeds(self, *, hostuin=0, limit=5, cursor="", scope=""):
+            return {"items": [asdict(entry)]}
+
+        async def get_status(self, *, probe_daemon=False):
+            return {"login_uin": 99999}
+
+        async def detail_feed(self, *, hostuin: int, fid: str, appid: int = 311):
+            return {"entry": asdict(entry), "comments": [], "raw": entry.raw}
+
+    class _PostStore:
+        async def upsert_async(self, post):
+            return None
+
+    class _PostService:
+        async def comment_post(self, post, text):
+            captured["comments"].append((post.hostuin, post.fid, text))
+
+    async def fake_ready(*args, **kwargs):
+        return None
+
+    async def fake_generate(event, post):
+        raise AssertionError("sensitive post should be skipped before comment generation")
+
+    plugin = object.__new__(main.QzoneStablePlugin)
+    plugin.settings = types.SimpleNamespace(comment_latest_count=1, max_feed_limit=20, like_when_comment=False)
+    plugin.data_dir = tmp_path
+    plugin.controller = _Controller()
+    plugin._ensure_cookie_ready = fake_ready
+    plugin._ensure_daemon = fake_ready
+    plugin._generate_comment_text = fake_generate
+    plugin._post_store = lambda: _PostStore()
+    plugin._post_service = lambda: _PostService()
+    monkeypatch.setattr(main, "logger", _Logger())
+
+    asyncio.run(plugin._auto_comment_once())
+
+    assert captured["comments"] == []
+    assert not (tmp_path / "auto_comment_state.json").exists()
+    assert any("serious_or_sensitive_context" in item for item in captured["logs"])
+
+
 def test_active_feed_scope_uses_home_timeline_without_defaulting_items_to_login_uin() -> None:
     from qzone_bridge.daemon import QzoneDaemonService
     from qzone_bridge.models import BridgeState
@@ -2368,9 +2493,163 @@ def test_render_feed_card_limit_is_loaded_from_config() -> None:
     assert settings.render_feed_card_limit == 3
 
 
+def test_page_status_profile_fetch_is_independent_from_publish_rendering(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+
+    class _Bot:
+        async def get_stranger_info(self, **kwargs):
+            return {"nickname": "Tester", "avatar": "https://example.test/avatar.png"}
+
+    plugin = object.__new__(main.QzoneStablePlugin)
+    plugin.settings = types.SimpleNamespace(render_publish_result=False, render_remote_timeout=0.01)
+    plugin._publisher_profile_cache = None
+    plugin._publisher_profile_preload_task = None
+    plugin._onebot_client = _Bot()
+    plugin._context = None
+
+    enriched = asyncio.run(plugin._status_with_live_profile({"login_uin": 10001, "cookie_count": 2}))
+
+    assert enriched["login_nickname"] == "Tester"
+    assert enriched["login_avatar"] == "https://example.test/avatar.png"
+    assert plugin._cached_profile_has_display_name(10001) is True
+
+
 def test_comment_latest_count_is_loaded_from_trigger_config() -> None:
     settings = PluginSettings.from_mapping({"trigger": {"comment_latest_count": 3}})
     assert settings.comment_latest_count == 3
+
+
+def test_auto_comment_pipeline_config_is_loaded_from_webui_schema_mapping() -> None:
+    settings = PluginSettings.from_mapping(
+        {
+            "llm": {
+                "comment_pipeline_enabled": False,
+                "comment_judgment_provider_id": "judge-provider",
+                "comment_reasoning_provider_id": "reason-provider",
+                "comment_execution_provider_id": "execute-provider",
+                "comment_skip_checkins": False,
+            }
+        }
+    )
+
+    assert settings.comment_pipeline_enabled is False
+    assert settings.comment_judgment_provider_id == "judge-provider"
+    assert settings.comment_reasoning_provider_id == "reason-provider"
+    assert settings.comment_execution_provider_id == "execute-provider"
+    assert settings.comment_skip_checkins is False
+
+
+def test_standard_data_dir_falls_back_to_plugin_data_and_migrates_auto_comment_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    plugin_root = tmp_path / "plugin"
+    legacy_dir = plugin_root / "data" / "qzone"
+    legacy_dir.mkdir(parents=True)
+    (plugin_root / "metadata.yaml").write_text("name: astrbot_plugin_qzone_ultra\n", encoding="utf-8")
+    (legacy_dir / "auto_comment_state.json").write_text('{"commented":["111:fid"]}\n', encoding="utf-8")
+
+    monkeypatch.setattr(main, "_star_tools_data_dir", lambda plugin_name: None)
+
+    data_dir = main._standard_data_dir(plugin_root)
+
+    assert data_dir == plugin_root / "data" / "plugin_data" / "astrbot_plugin_qzone_ultra"
+    assert (data_dir / "auto_comment_state.json").read_text(encoding="utf-8") == '{"commented":["111:fid"]}\n'
+    assert (data_dir / ".legacy-qzone-migration.json").exists()
+
+
+def test_auto_comment_state_store_uses_atomic_json_payload(tmp_path: Path) -> None:
+    store = AutoCommentStateStore(tmp_path / "auto_comment_state.json", max_items=2)
+
+    store.write_keys({"333:fid-3", "111:fid-1", "222:fid-2"})
+
+    assert store.read_keys() == {"222:fid-2", "333:fid-3"}
+    saved = (tmp_path / "auto_comment_state.json").read_text(encoding="utf-8")
+    assert "commented" in saved
+    assert "111:fid-1" not in saved
+
+
+def test_auto_comment_pipeline_runs_judgment_reasoning_and_execution() -> None:
+    post = QzonePost(hostuin=11111, fid="fid-1", summary="normal day", nickname="tester")
+    calls: list[tuple[str, str]] = []
+    pipeline = AutoCommentPipeline(
+        AutoCommentPipelineConfig(
+            judgment_provider_id="judge-provider",
+            reasoning_provider_id="reason-provider",
+            execution_provider_id="execute-provider",
+        )
+    )
+
+    async def generate_text(prompt: str, provider_id: str, system_prompt: str) -> str:
+        calls.append((provider_id, prompt))
+        if provider_id == "judge-provider":
+            return '{"action":"comment","reason":"safe"}'
+        return "friendly classmate tone"
+
+    async def execute_comment(reasoning: str) -> str:
+        calls.append(("execute", reasoning))
+        return "Looks nice"
+
+    result = asyncio.run(
+        pipeline.run(
+            post,
+            generate_text=generate_text,
+            execute_comment=execute_comment,
+        )
+    )
+
+    assert result.should_comment is True
+    assert result.comment_text == "Looks nice"
+    assert calls[0][0] == "judge-provider"
+    assert calls[1][0] == "reason-provider"
+    assert calls[2] == ("execute", "friendly classmate tone")
+
+
+def test_auto_comment_pipeline_skips_sensitive_context_before_execution() -> None:
+    post = QzonePost(hostuin=11111, fid="fid-1", summary="\u4f4f\u9662\u624b\u672f", nickname="tester")
+
+    async def generate_text(prompt: str, provider_id: str, system_prompt: str) -> str:
+        raise AssertionError("judgment provider should not be called for heuristic skip")
+
+    async def execute_comment(reasoning: str) -> str:
+        raise AssertionError("execution should not run for heuristic skip")
+
+    result = asyncio.run(
+        AutoCommentPipeline(AutoCommentPipelineConfig()).run(
+            post,
+            generate_text=generate_text,
+            execute_comment=execute_comment,
+        )
+    )
+
+    assert result.should_comment is False
+    assert result.skip_reason == "serious_or_sensitive_context"
+
+
+def test_disabled_auto_comment_pipeline_keeps_legacy_direct_generation() -> None:
+    post = QzonePost(hostuin=11111, fid="fid-1", summary="\u4f4f\u9662\u624b\u672f", nickname="tester")
+
+    async def generate_text(prompt: str, provider_id: str, system_prompt: str) -> str:
+        raise AssertionError("disabled pipeline should not call judgment or reasoning providers")
+
+    async def execute_comment(reasoning: str) -> str:
+        assert reasoning == ""
+        return "legacy direct comment"
+
+    result = asyncio.run(
+        AutoCommentPipeline(AutoCommentPipelineConfig(enabled=False)).run(
+            post,
+            generate_text=generate_text,
+            execute_comment=execute_comment,
+        )
+    )
+
+    assert result.should_comment is True
+    assert result.comment_text == "legacy direct comment"
+    assert result.judgment == "disabled"
 
 
 def test_qzone_post_nickname_prefers_matching_owner_and_never_briefs_qq_number() -> None:


### PR DESCRIPTION
## Summary
- add the new AstrBot Pages Qzone experience with feed/detail/publish/reply flows and the associated browser-safe page APIs
- add the auto-comment pipeline, related settings/schema wiring, and supporting controller/daemon/runtime changes
- bump the plugin to v0.5.0, update changelog/docs/i18n, and add focused regression coverage for pages and security behavior

## Testing
- python -m pytest tests/test_security_hardening.py tests/test_page_api.py tests/test_qzone_page_frontend.py tests/test_command_descriptions.py tests/test_controller_log_fallback.py
- python -m py_compile main.py qzone_bridge/__init__.py qzone_bridge/page_api.py qzone_bridge/auto_comment.py