### PR TITLE
[codex] Improve news RSS error reporting

### DIFF
--- a/main.py
+++ b/main.py
@@ -242,12 +242,32 @@ def _public_error_detail_parts(detail: Any) -> list[str]:
         parts.append(f"地址 {_redact_url(str(url))}")
     if detail.get("log_path"):
         parts.append("daemon 日志可在插件数据目录查看")
+    trust_env = detail.get("trust_env")
+    if trust_env is False:
+        parts.append("未使用系统代理")
     attempts = detail.get("attempts")
     if isinstance(attempts, list) and attempts:
         parts.append(f"启动尝试 {len(attempts)} 次")
         last_attempt = attempts[-1]
         if isinstance(last_attempt, dict):
             parts.extend(_public_error_detail_parts(last_attempt))
+    errors = detail.get("errors")
+    if isinstance(errors, list) and errors:
+        first_error = errors[0]
+        if isinstance(first_error, dict):
+            reason = _public_error_reason(first_error.get("message"))
+            if reason:
+                parts.append(reason)
+            error_url = first_error.get("url")
+            if error_url:
+                parts.append(f"地址 {_redact_url(str(error_url))}")
+            error_status = first_error.get("status_code")
+            if error_status is not None:
+                parts.append(f"HTTP {error_status}")
+        else:
+            reason = _public_error_reason(first_error)
+            if reason:
+                parts.append(reason)
     if detail.get("text") or detail.get("raw") or detail.get("log_tail"):
         parts.append("响应详情已隐藏")
     return parts
@@ -2654,7 +2674,7 @@ class QzoneStablePlugin(Star):
         client = GoogleNewsRSSClient(
             timeout=float(getattr(self.settings, "request_timeout", 15.0) or 15.0),
             user_agent=str(getattr(self.settings, "user_agent", "") or ""),
-            trust_env=bool(getattr(self.settings, "news_trust_env", False)),
+            trust_env=bool(getattr(self.settings, "news_trust_env", True)),
         )
         items = await client.fetch_items(urls)
         recent = filter_recent_news(items, recency_hours=int(getattr(self.settings, "news_recency_hours", 36) or 36))

--- a/qzone_bridge/news.py
+++ b/qzone_bridge/news.py
@@ -218,7 +218,7 @@ class GoogleNewsRSSClient:
 
     async def fetch_items(self, urls: list[tuple[str, str]]) -> list[NewsItem]:
         items: list[NewsItem] = []
-        errors: list[Exception] = []
+        errors: list[dict[str, Any]] = []
         async with httpx.AsyncClient(
             timeout=httpx.Timeout(self.timeout),
             trust_env=self.trust_env,
@@ -232,10 +232,32 @@ class GoogleNewsRSSClient:
                     response.raise_for_status()
                     items.extend(parse_google_news_rss(response.text, scope=scope))
                 except (httpx.HTTPError, QzoneParseError) as exc:
-                    errors.append(exc)
+                    errors.append(self._error_detail(exc, url=url, scope=scope))
         if not items and errors:
-            raise QzoneRequestError("Google News RSS 获取失败", detail={"errors": [str(exc) for exc in errors[:3]]})
+            raise QzoneRequestError("Google News RSS 获取失败", detail={"errors": errors[:3], "trust_env": self.trust_env})
         return items
+
+    @staticmethod
+    def _error_detail(exc: Exception, *, url: str, scope: str) -> dict[str, Any]:
+        message = str(exc).strip()
+        if not message:
+            cause = getattr(exc, "__cause__", None)
+            if cause is not None:
+                message = str(cause).strip()
+        if not message:
+            message = exc.__class__.__name__
+        detail: dict[str, Any] = {
+            "scope": scope,
+            "url": url,
+            "message": f"{exc.__class__.__name__}: {message}",
+        }
+        request = getattr(exc, "request", None)
+        if request is not None and getattr(request, "url", None):
+            detail["url"] = str(request.url)
+        response = getattr(exc, "response", None)
+        if response is not None and getattr(response, "status_code", None):
+            detail["status_code"] = int(response.status_code)
+        return detail
 
 
 def _child_text(item: ElementTree.Element, name: str) -> str:

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -3005,6 +3005,62 @@ def test_news_copy_like_detection_rejects_titles() -> None:
     assert not is_news_copy_like("人在太空待久了，回到地面第一件小事都能变成很具体的幸福。", items)
 
 
+def test_news_candidates_default_to_trust_env_true(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    captured: dict[str, object] = {}
+
+    class _Client:
+        def __init__(self, *, timeout: float, user_agent: str, trust_env: bool) -> None:
+            captured["timeout"] = timeout
+            captured["user_agent"] = user_agent
+            captured["trust_env"] = trust_env
+
+        async def fetch_items(self, urls):
+            captured["urls"] = urls
+            return []
+
+    plugin = object.__new__(main.QzoneStablePlugin)
+    plugin.data_dir = tmp_path
+    plugin.settings = types.SimpleNamespace(
+        request_timeout=15.0,
+        user_agent="UA",
+        news_keywords=[],
+        news_custom_rss_urls=[],
+        news_recency_hours=36,
+        news_max_candidates=12,
+        news_scopes=["china"],
+    )
+    monkeypatch.setattr(main, "GoogleNewsRSSClient", _Client)
+
+    result = asyncio.run(plugin._news_candidates(seen_ids=set()))
+
+    assert result == []
+    assert captured["trust_env"] is True
+
+
+def test_public_error_text_includes_news_fetch_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    main = _import_main_with_stubs(monkeypatch)
+    plugin = object.__new__(main.QzoneStablePlugin)
+    exc = main.QzoneBridgeError(
+        "Google News RSS 获取失败",
+        detail={
+            "trust_env": False,
+            "errors": [
+                {
+                    "message": "ConnectError: [Errno 11001] getaddrinfo failed",
+                    "url": "https://news.google.com/rss?hl=zh-CN&gl=CN&ceid=CN:zh-Hans",
+                }
+            ],
+        },
+    )
+
+    text = plugin._error_text(exc)
+
+    assert "Google News RSS 获取失败" in text
+    assert "未使用系统代理" in text
+    assert "ConnectError" in text
+
+
 def test_qzone_post_nickname_prefers_matching_owner_and_never_briefs_qq_number() -> None:
     from qzone_bridge.models import FeedEntry
     from qzone_bridge.social import QzoneComment, QzonePost, extract_nickname, post_from_entry


### PR DESCRIPTION
## Summary

- make scheduled news RSS fetching honor the `news_trust_env` default in the plugin path so environments that rely on system proxy work out of the box
- surface the first real RSS fetch failure reason, URL, HTTP status, and proxy hint instead of returning a generic `Google News RSS ????`
- add regression coverage for default proxy behavior and user-facing error text

## Validation

- `python -m py_compile main.py qzone_bridge\news.py tests\test_security_hardening.py`
- `python -m pytest tests\test_security_hardening.py -q -k "news or public_error_text"`
- `python -m pytest -q` (156 passed; local `.pytest_cache` permission warning only)
