### PR TITLE
修复定时任务重复触发

### DIFF
--- a/main.py
+++ b/main.py
@@ -695,7 +695,7 @@ from qzone_bridge.render import (
     format_llm_feed_list,
     format_status,
 )
-from qzone_bridge.scheduler import cron_delay_seconds
+from qzone_bridge.scheduler import cron_schedule
 import qzone_bridge.selection as _selection
 from qzone_bridge.settings import PluginSettings
 import qzone_bridge.social as _social
@@ -923,6 +923,7 @@ class QzoneStablePlugin(Star):
         self._last_page_feed_preload_at = 0.0
         self._auto_bind_bootstrap_succeeded = False
         self._scheduled_tasks: list[asyncio.Task] = []
+        self._scheduled_task_slots: dict[str, datetime] = {}
         self._publisher_profile_cache: tuple[int, RenderProfile] | None = None
         self._publisher_profile_preload_task: asyncio.Task | None = None
         self.drafts = DraftStore(self.data_dir / "drafts.json")
@@ -3061,7 +3062,7 @@ class QzoneStablePlugin(Star):
 
     @staticmethod
     def _cron_delay_seconds(cron: str, offset_seconds: int) -> float:
-        return cron_delay_seconds(cron, offset_seconds, now=datetime.now(), randint=random.randint)
+        return cron_schedule(cron, offset_seconds, now=datetime.now(), randint=random.randint).delay_seconds
 
     @staticmethod
     def _scheduled_task_label(name: str) -> str:
@@ -3080,6 +3081,7 @@ class QzoneStablePlugin(Star):
     def _create_scheduled_task(self, name: str, cron: str, offset: int, action: Any) -> None:
         if self._has_active_scheduled_task(name):
             return
+        self._scheduled_task_slots.pop(name, None)
         coro = self._scheduled_loop(name, cron, offset, action)
         label = self._scheduled_task_label(name)
         try:
@@ -3113,11 +3115,22 @@ class QzoneStablePlugin(Star):
             )
 
     async def _scheduled_loop(self, name: str, cron: str, offset: int, action: Any) -> None:
+        last_slot = self._scheduled_task_slots.get(name)
         while True:
-            delay = self._cron_delay_seconds(cron, offset)
+            schedule = cron_schedule(
+                cron,
+                offset,
+                now=datetime.now(),
+                randint=random.randint,
+                after=last_slot,
+            )
+            delay = schedule.delay_seconds
             if delay <= 0:
                 logger.info("qzone scheduled %s disabled: invalid cron=%s", name, cron)
                 return
+            last_slot = schedule.slot
+            if last_slot is not None:
+                self._scheduled_task_slots[name] = last_slot
             logger.info("qzone scheduled %s next run in %.1fs cron=%s offset=%s", name, delay, cron, offset)
             await asyncio.sleep(delay)
             try:
@@ -5263,6 +5276,7 @@ class QzoneStablePlugin(Star):
         if self._scheduled_tasks:
             await asyncio.gather(*self._scheduled_tasks, return_exceptions=True)
             self._scheduled_tasks.clear()
+        self._scheduled_task_slots.clear()
         if self._publisher_profile_preload_task is not None:
             self._publisher_profile_preload_task.cancel()
             await asyncio.gather(self._publisher_profile_preload_task, return_exceptions=True)

--- a/qzone_bridge/scheduler.py
+++ b/qzone_bridge/scheduler.py
@@ -5,6 +5,34 @@ from __future__ import annotations
 import random
 from collections.abc import Callable
 from datetime import datetime, timedelta
+from typing import NamedTuple
+
+
+class CronSchedule(NamedTuple):
+    delay_seconds: float
+    slot: datetime | None
+
+
+def cron_schedule(
+    cron: str,
+    offset_seconds: int,
+    *,
+    now: datetime | None = None,
+    randint: Callable[[int, int], int] = random.randint,
+    after: datetime | None = None,
+) -> CronSchedule:
+    current = now or datetime.now()
+    base = after or current
+    slot = cron_next_after(cron, base)
+    if slot is None:
+        return CronSchedule(0.0, None)
+    target = slot
+    offset = int(offset_seconds or 0)
+    if offset > 0:
+        target += timedelta(seconds=randint(-offset, offset))
+        if target <= current:
+            target = current + timedelta(seconds=1)
+    return CronSchedule(max(1.0, (target - current).total_seconds()), slot)
 
 
 def cron_delay_seconds(
@@ -14,16 +42,7 @@ def cron_delay_seconds(
     now: datetime | None = None,
     randint: Callable[[int, int], int] = random.randint,
 ) -> float:
-    current = now or datetime.now()
-    target = cron_next_after(cron, current)
-    if target is None:
-        return 0.0
-    offset = int(offset_seconds or 0)
-    if offset > 0:
-        target += timedelta(seconds=randint(-offset, offset))
-        if target <= current:
-            target = current + timedelta(seconds=1)
-    return max(1.0, (target - current).total_seconds())
+    return cron_schedule(cron, offset_seconds, now=now, randint=randint).delay_seconds
 
 
 def cron_next_after(cron: str, now: datetime) -> datetime | None:

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -3208,6 +3208,31 @@ def test_start_scheduled_tasks_can_add_news_after_existing_task(
     asyncio.run(run_case())
 
 
+def test_cron_schedule_skips_consumed_offset_slot() -> None:
+    from qzone_bridge.scheduler import cron_schedule
+
+    first = cron_schedule(
+        "30 8 * * *",
+        500,
+        now=datetime(2026, 5, 31, 8, 26, 17),
+        randint=lambda _start, _end: -500,
+    )
+
+    assert first.delay_seconds == 1.0
+    assert first.slot == datetime(2026, 5, 31, 8, 30)
+
+    second = cron_schedule(
+        "30 8 * * *",
+        500,
+        now=datetime(2026, 5, 31, 8, 26, 18),
+        randint=lambda _start, _end: -500,
+        after=first.slot,
+    )
+
+    assert second.slot == datetime(2026, 6, 1, 8, 30)
+    assert second.delay_seconds > 23 * 60 * 60
+
+
 def test_google_news_rss_parser_cleans_titles_and_sources() -> None:
     from qzone_bridge.news import parse_google_news_rss
 


### PR DESCRIPTION
## 变更说明

- 为定时调度引入 cron slot 记录，避免同一 cron 基准点因随机偏移被重复触发
- 移除不再需要的 cron_delay_seconds 兼容入口
- 补充 slot 重建保持状态的测试

## 验证

- 本地通过 py_compile 
- GitHub Actions CI 通过