### PR TITLE
docs: 添加 qzone_publish_post 工具的 media 参数文档

### DIFF
--- a/main.py
+++ b/main.py
@@ -6086,6 +6086,7 @@ class QzoneStablePlugin(Star):
         Args:
             content (string): 说说内容。
             sync_weibo (boolean): 是否同步到微博。
+            media (list[string]): 可选的图片或视频 URL 列表。支持 HTTP/HTTPS URL、本地文件路径或 data:image/... 格式的 Data URL。
         """
         if not self._is_admin(event):
             text = await self._ask_llm_tool_reply(


### PR DESCRIPTION
# PR: astrbot_plugin_qzone_ultra

## 标题
docs: 添加 qzone_publish_post 工具的 media 参数文档

## 描述

### 概述
在 `qzone_publish_post` LLM 工具的文档字符串中补充 `media` 参数说明，使 LLM 能够正确使用该参数传递图片，实现跨插件联动功能。

### 问题背景

`qzone_publish_post` 工具虽然在函数签名中定义了 `media: list[str] | None = None` 参数，但 docstring 中**完全没有提及**，导致 LLM 不知道可以传递图片参数。

**修改前：**
```python
"""发布 QQ 空间说说。

Args:
    content (string): 说说内容。
    sync_weibo (boolean): 是否同步到微博。
"""
```

### 主要改动

**修改后：**
```python
"""发布 QQ 空间说说。

Args:
    content (string): 说说内容。
    sync_weibo (boolean): 是否同步到微博。
    media (list[string]): 可选的图片或视频 URL 列表。支持 HTTP/HTTPS URL、本地文件路径或 data:image/... 格式的 Data URL。
"""
```

### 支持的 media 格式

根据代码分析（`media.py` 模块），`media` 参数支持以下三种格式：

1. **HTTP/HTTPS URL**
   ```python
   media=["https://example.com/image.png"]
   ```

2. **本地文件路径**
   ```python
   media=["/path/to/image.jpg"]
   ```

3. **Data URL（base64 编码）**
   ```python
   media=["data:image/png;base64,iVBORw0KGgoAAAA..."]
   ```

### 使用场景

**跨插件联动示例：**
```python
# LLM 工具调用流程
result = await generate_selfie(action="微笑自拍")
# 返回: {"status": "success", "images": ["data:image/png;base64,..."]}

await qzone_publish_post(
    content="今天的自拍～", 
    media=result["images"]  # 现在 LLM 知道可以传递这个参数了
)
```

### 测试验证

- LLM 现在能正确识别 `media` 参数
- 可以与 omnidraw 插件联动生成并发布图片
- 不影响现有功能（纯文字说说仍然可用）

### 相关 PR

此 PR 需要配合 `astrbot_plugin_omnidraw` 的工具改进使用：
- omnidraw PR: https://github.com/diaomin66/astrbot_plugin_omnidraw/pull/45

### 影响范围

- **不影响**：现有功能和 API
- **改进**：LLM 工具文档完整性
- **改进**：支持跨插件图片传递
