### PR TITLE
fix: qzone_list_feed 工具结果回传给 LLM(而非直接发给用户)

### DIFF
--- a/main.py
+++ b/main.py
@@ -6531,14 +6531,11 @@ class QzoneStablePlugin(Star):
             hostuin (number): 兼容旧参数，优先级低于 target_uin。
         """
         if not self._is_admin(event):
-            yield event.plain_result(
-                await self._ask_llm_tool_reply(
-                    event,
-                    {"ok": False, "tool": "qzone_list_feed", "public_reason": "没有权限"},
-                    self._llm_error_fallback_text("没有权限"),
-                )
+            return await self._ask_llm_tool_reply(
+                event,
+                {"ok": False, "tool": "qzone_list_feed", "public_reason": "没有权限"},
+                self._llm_error_fallback_text("没有权限"),
             )
-            return
         try:
             await self._ensure_cookie_ready(event)
             await self._ensure_daemon()
@@ -6551,10 +6548,9 @@ class QzoneStablePlugin(Star):
                 scope=effective_scope,
             )
         except QzoneBridgeError as exc:
-            yield event.plain_result(self._error_text(exc))
-            return
+            return self._error_text(exc)
         entries = self._to_feed_entries(payload)
-        yield event.plain_result(format_llm_feed_list(entries))
+        return format_llm_feed_list(entries)
 
     @filter.llm_tool(name="qzone_detail_feed")
     async def tool_detail_feed(self, event: AstrMessageEvent, hostuin: int, fid: str, appid: int = 311):


### PR DESCRIPTION
## 问题
LLM 调用 qzone_list_feed 工具时,运行日志出现:

    qzone_list_feed 没有返回值，或者已将结果直接发送给用户。

工具查询到的说说列表被直接发送给用户,没有回传给 LLM,导致 LLM 拿不到
列表内容,无法据此继续对话或执行后续操作。

## 根因
tool_list_feed 被实现为 async generator,所有出口都使用
yield event.plain_result(...)。在 AstrBot 中,通过 yield event.*_result(...)
产出的内容会被标记为 tool_direct_result,直接发送给用户,不会作为工具返回值
回传给 LLM。

对比同插件早期工具(llm_view_feed、llm_publish_feed)采用普通 async 函数 +
return,结果可以正常回传 LLM。新版工具改用 yield 直发的写法,丢失了这一能力。

## 改动
将 tool_list_feed 从 async generator 改为普通 async 函数:三个出口的
yield event.plain_result(X) 改为 return X,内容不变,仅把投递方式从
"直接发给用户"改为"作为工具结果回传给 LLM"。

- 成功:return format_llm_feed_list(entries),LLM 获得说说列表
- 无权限:return await self._ask_llm_tool_reply(...)
- 异常:return self._error_text(exc)

注意:函数体内不能残留任何 yield,否则函数仍是 generator,return 的值会被忽略。

## 验证
- 本地运行现有测试套件,全部通过。
- 额外通过静态检查确认 qzone_list_feed 不再是 async generator,且具有带值的 return。

相关 Issue: #95
